### PR TITLE
Implement dynamic ability creation

### DIFF
--- a/autogpts/autogpt/autogpt/core/ability/builtins/__init__.py
+++ b/autogpts/autogpt/autogpt/core/ability/builtins/__init__.py
@@ -3,6 +3,7 @@ from autogpt.core.ability.builtins.query_language_model import QueryLanguageMode
 
 BUILTIN_ABILITIES = {
     QueryLanguageModel.name(): QueryLanguageModel,
+    CreateNewAbility.name(): CreateNewAbility,
 }
 
 __all__ = [


### PR DESCRIPTION
## Summary
- implement CreateNewAbility to generate modules, install dependencies, and register them for immediate use
- expose CreateNewAbility in built-in ability registry

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')*


------
https://chatgpt.com/codex/tasks/task_e_68a76f347e84832f9b421dc78c142ab7