### PR TITLE
test: add ability creation integration test

### DIFF
--- a/autogpts/autogpt/tests/core/ability/test_create_new_ability.py
+++ b/autogpts/autogpt/tests/core/ability/test_create_new_ability.py
@@ -1,0 +1,75 @@
+import inspect
+import logging
+import sys
+from pathlib import Path
+
+import inflection
+import pytest
+
+from autogpt.core.ability.builtins import BUILTIN_ABILITIES
+from autogpt.core.ability.builtins.create_new_ability import CreateNewAbility
+from autogpt.core.ability.simple import (
+    AbilityRegistryConfiguration,
+    AbilityRegistrySettings,
+    SimpleAbilityRegistry,
+)
+from autogpt.core.memory.simple import SimpleMemory
+from autogpt.core.workspace.simple import SimpleWorkspace
+
+
+@pytest.mark.asyncio
+async def test_create_and_execute_new_ability(tmp_path):
+    logger = logging.getLogger("test")
+
+    # Set up workspace and memory
+    workspace_settings = SimpleWorkspace.default_settings.copy(deep=True)
+    workspace_settings.configuration.root = str(tmp_path)
+    workspace = SimpleWorkspace(workspace_settings, logger)
+    memory = SimpleMemory(SimpleMemory.default_settings, logger, workspace)
+
+    creator = CreateNewAbility(logger, CreateNewAbility.default_configuration)
+
+    ability_name = "TestAbility"
+    message = "Hello from new ability!"
+    code = (
+        "return AbilityResult(ability_name='TestAbility', ability_args={}, "
+        "success=True, message='" + message + "')"
+    )
+
+    result = await creator(
+        ability_name=ability_name,
+        description="A simple test ability",
+        arguments=[],
+        required_arguments=[],
+        package_requirements=[],
+        code=code,
+    )
+    assert result.success
+
+    ability_class = BUILTIN_ABILITIES[ability_name]
+    ability_key = ability_class.name()
+    registry_settings = AbilityRegistrySettings(
+        name="registry",
+        description="",
+        configuration=AbilityRegistryConfiguration(
+            abilities={ability_key: ability_class.default_configuration}
+        ),
+    )
+    registry = SimpleAbilityRegistry(registry_settings, logger, memory, workspace, {})
+
+    try:
+        exec_result = await registry.perform(ability_key)
+        assert exec_result.message == message
+    finally:
+        # Clean up generated ability
+        builtins_dir = Path(inspect.getfile(CreateNewAbility)).resolve().parent
+        module_name = inflection.underscore(ability_name)
+        ability_file = builtins_dir / f"{module_name}.py"
+        if ability_file.exists():
+            ability_file.unlink()
+        cache_dir = builtins_dir / "__pycache__"
+        if cache_dir.exists():
+            for pyc in cache_dir.glob(f"{module_name}*.pyc"):
+                pyc.unlink()
+        BUILTIN_ABILITIES.pop(ability_name, None)
+        sys.modules.pop(f"autogpt.core.ability.builtins.{module_name}", None)


### PR DESCRIPTION
## Summary
- add test for CreateNewAbility and SimpleAbilityRegistry

## Testing
- `PYTHONPATH=.:autogpts/autogpt pytest autogpts/autogpt/tests/core/ability/test_create_new_ability.py --confcutdir=autogpts/autogpt/tests/core/ability -q`
- `PYTHONPATH=autogpts/autogpt pytest autogpts/autogpt/tests -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_68a7729e8acc832fa6ca804466690656