### PR TITLE
feat(memory): add redis vector memory provider

### DIFF
--- a/autogpts/autogpt/.env.template
+++ b/autogpts/autogpt/.env.template
@@ -24,6 +24,18 @@ OPENAI_API_KEY=your-openai-api-key
 ## Options: local, gcs, s3
 # FILE_STORAGE_BACKEND=local
 
+### Memory ###
+
+## MEMORY_BACKEND - Memory backend to use for storing vector data
+## Options: json_file, redis, no_memory
+# MEMORY_BACKEND=json_file
+
+## Redis configuration (used when MEMORY_BACKEND=redis)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=
+# WIPE_REDIS_ON_START=True
+
 ## STORAGE_BUCKET - GCS/S3 Bucket to store contents in
 # STORAGE_BUCKET=autogpt
 

--- a/autogpts/autogpt/autogpt/memory/vector/__init__.py
+++ b/autogpts/autogpt/autogpt/memory/vector/__init__.py
@@ -9,12 +9,12 @@ from .providers.no_memory import NoMemory
 # Add a backend to this list if the import attempt is successful
 supported_memory = ["json_file", "no_memory"]
 
-# try:
-#     from .providers.redis import RedisMemory
+try:
+    from .providers.redis import RedisMemory
 
-#     supported_memory.append("redis")
-# except ImportError:
-#     RedisMemory = None
+    supported_memory.append("redis")
+except ImportError:  # pragma: no cover - handled gracefully if dependency missing
+    RedisMemory = None
 
 # try:
 #     from .providers.pinecone import PineconeMemory
@@ -79,17 +79,11 @@ def get_memory(config: Config) -> VectorMemory:
             #         memory.clear()
 
         case "redis":
-            raise NotImplementedError(
-                "The Redis memory backend has been rendered incompatible by work on "
-                "the memory system, and has been removed temporarily."
-            )
-            # if not RedisMemory:
-            #     logger.warning(
-            #         "Error: Redis is not installed. Please install redis-py to"
-            #         " use Redis as a memory backend."
-            #     )
-            # else:
-            #     memory = RedisMemory(config)
+            if not RedisMemory:
+                raise ValueError(
+                    "Error: Redis is not installed. Please install redis-py to use Redis as a memory backend."
+                )
+            memory = RedisMemory(config)
 
         case "weaviate":
             raise NotImplementedError(
@@ -149,7 +143,7 @@ __all__ = [
     "JSONFileMemory",
     "NoMemory",
     "VectorMemory",
-    # "RedisMemory",
+    "RedisMemory",
     # "PineconeMemory",
     # "MilvusMemory",
     # "WeaviateMemory",

--- a/autogpts/autogpt/autogpt/memory/vector/providers/redis.py
+++ b/autogpts/autogpt/autogpt/memory/vector/providers/redis.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+
+import orjson
+import redis
+
+from autogpt.config import Config
+
+from ..memory_item import MemoryItem
+from .base import VectorMemoryProvider
+
+logger = logging.getLogger(__name__)
+
+
+class RedisMemory(VectorMemoryProvider):
+    """Memory backend that stores memories in a Redis list."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize a Redis memory provider.
+
+        Args:
+            config: application configuration instance
+        """
+        self.key = config.memory_index
+        self.client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password or None,
+            db=0,
+        )
+        if config.wipe_redis_on_start:
+            self.clear()
+        logger.debug(
+            f"Initialized {__class__.__name__} with key '{self.key}' at {config.redis_host}:{config.redis_port}"
+        )
+
+    def __iter__(self) -> Iterator[MemoryItem]:
+        items = self.client.lrange(self.key, 0, -1)
+        for item in items:
+            try:
+                yield MemoryItem.parse_raw(item)
+            except Exception as e:
+                logger.warning(f"Could not parse MemoryItem from redis: {e}")
+
+    def __contains__(self, x: MemoryItem) -> bool:
+        serialized = orjson.dumps(x.dict())
+        return self.client.lpos(self.key, serialized) is not None
+
+    def __len__(self) -> int:
+        return self.client.llen(self.key) or 0
+
+    def add(self, item: MemoryItem):
+        serialized = orjson.dumps(item.dict())
+        self.client.rpush(self.key, serialized)
+        logger.debug(f"Adding item to memory: {item.dump()}")
+        return len(self)
+
+    def discard(self, item: MemoryItem):
+        serialized = orjson.dumps(item.dict())
+        self.client.lrem(self.key, 0, serialized)
+
+    def clear(self):
+        self.client.delete(self.key)

--- a/docs/content/AutoGPT/configuration/options.md
+++ b/docs/content/AutoGPT/configuration/options.md
@@ -28,7 +28,7 @@ Configuration is controlled through the `Config` object. You can set configurati
 - `HUGGINGFACE_IMAGE_MODEL`: HuggingFace model to use for image generation. Default: CompVis/stable-diffusion-v1-4
 - `IMAGE_PROVIDER`: Image provider. Options are `dalle`, `huggingface`, and `sdwebui`. Default: dalle
 - `IMAGE_SIZE`: Default size of image to generate. Default: 256
-- `MEMORY_BACKEND`: Memory back-end to use. Currently `json_file` is the only supported and enabled backend. Default: json_file
+- `MEMORY_BACKEND`: Memory back-end to use. Options are `json_file`, `redis`, and `no_memory`. Default: json_file
 - `MEMORY_INDEX`: Value used in the Memory backend for scoping, naming, or indexing. Default: auto-gpt
 - `OPENAI_API_KEY`: *REQUIRED*- Your [OpenAI API Key](https://platform.openai.com/account/api-keys).
 - `OPENAI_ORGANIZATION`: Organization ID in OpenAI. Optional.


### PR DESCRIPTION
## Summary
- add RedisMemory provider implementing VectorMemoryProvider interface
- expose redis backend as supported memory option
- document new memory backend configuration in env template and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pre-commit run --files autogpts/autogpt/autogpt/memory/vector/providers/redis.py autogpts/autogpt/autogpt/memory/vector/__init__.py autogpts/autogpt/.env.template docs/content/AutoGPT/configuration/options.md` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eceb0ae0832fb57b27c29fe381a4