### PR TITLE
feat: add layered agent abstraction

### DIFF
--- a/autogpts/autogpt/autogpt/core/agent/__init__.py
+++ b/autogpts/autogpt/autogpt/core/agent/__init__.py
@@ -1,9 +1,11 @@
 """The Agent is an autonomouos entity guided by a LLM provider."""
 from autogpt.core.agent.base import Agent
+from autogpt.core.agent.layered import LayeredAgent
 from autogpt.core.agent.simple import AgentSettings, SimpleAgent
 
 __all__ = [
     "Agent",
+    "LayeredAgent",
     "AgentSettings",
     "SimpleAgent",
 ]

--- a/autogpts/autogpt/autogpt/core/agent/layered.py
+++ b/autogpts/autogpt/autogpt/core/agent/layered.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from autogpt.core.agent.base import Agent
+
+
+class LayeredAgent(Agent):
+    """An agent capable of forwarding tasks to a subsequent layer."""
+
+    next_layer: Optional["LayeredAgent"]
+
+    def __init__(self, *args, next_layer: Optional["LayeredAgent"] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.next_layer = next_layer
+
+    def route_task(self, task: Any, *args, **kwargs):
+        """Route a task to the next layer by default."""
+        if self.next_layer is not None:
+            return self.next_layer.route_task(task, *args, **kwargs)
+        raise NotImplementedError("No next layer to route task to.")


### PR DESCRIPTION
## Summary
- add `LayeredAgent` abstract class for chaining agent layers
- expose `LayeredAgent` via core.agent package
- allow `SimpleAgent` to act as bottom layer with task routing

## Testing
- `flake8 autogpts/autogpt/autogpt/core/agent/layered.py autogpts/autogpt/autogpt/core/agent/simple.py autogpts/autogpt/autogpt/core/agent/__init__.py`
- `pytest autogpts/autogpt/tests -q` *(fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')*


------
https://chatgpt.com/codex/tasks/task_e_68a7f90a3c68832fb8f7853743587628