### PR TITLE
feat: add governance agent layer

### DIFF
--- a/autogpts/autogpt/autogpt/agents/layers/__init__.py
+++ b/autogpts/autogpt/autogpt/agents/layers/__init__.py
@@ -1,0 +1,5 @@
+"""Agent layers for higher-level task routing."""
+
+from .governance import GovernanceAgent
+
+__all__ = ["GovernanceAgent"]

--- a/autogpts/autogpt/autogpt/agents/layers/governance.py
+++ b/autogpts/autogpt/autogpt/agents/layers/governance.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import Field
+
+from autogpt.core.agent.layered import LayeredAgent
+from autogpt.core.configuration import (
+    Configurable,
+    SystemConfiguration,
+    SystemSettings,
+    UserConfigurable,
+)
+
+
+class GovernancePolicy(SystemConfiguration):
+    """Settings that define governance rules for task routing."""
+
+    allowed_task_types: list[str] = UserConfigurable(
+        default_factory=list,
+        description="List of task types permitted by the governance layer.",
+    )
+
+
+class GovernanceAgentSettings(SystemSettings):
+    """System settings for the ``GovernanceAgent``."""
+
+    policy: GovernancePolicy = Field(default_factory=GovernancePolicy)
+
+
+class GovernanceAgent(LayeredAgent, Configurable[GovernanceAgentSettings]):
+    """Top layer agent enforcing governance policy before delegating tasks."""
+
+    default_settings = GovernanceAgentSettings(
+        name="governance_agent",
+        description="Routes tasks according to high level governance policy.",
+    )
+
+    def __init__(
+        self,
+        settings: GovernanceAgentSettings,
+        next_layer: Optional[LayeredAgent] = None,
+    ) -> None:
+        super().__init__(next_layer=next_layer)
+        self.settings = settings
+
+    def route_task(self, task: Any, *args, **kwargs):
+        """Route a task to the next layer if permitted by policy."""
+
+        task_type = getattr(task, "type", getattr(task, "name", str(task)))
+        allowed = self.settings.policy.allowed_task_types
+        if allowed and task_type not in allowed:
+            raise PermissionError(
+                f"Task '{task_type}' is not permitted by the governance policy."
+            )
+
+        if self.next_layer is not None:
+            return self.next_layer.route_task(task, *args, **kwargs)
+
+        return task


### PR DESCRIPTION
## Summary
- add GovernanceAgent with policy-based task routing
- expose GovernanceAgent from `autogpt.agents.layers`

## Testing
- `python -m flake8 autogpts/autogpt/autogpt/agents/layers/governance.py autogpts/autogpt/autogpt/agents/layers/__init__.py`
- `pytest autogpts/autogpt/tests/unit -q` *(fails: ModuleNotFoundError: No module named 'playsound')*


------
https://chatgpt.com/codex/tasks/task_e_68a7fb254114832f901739f284657d67