### PR TITLE
feat: add execution agent layer

### DIFF
--- a/autogpts/autogpt/autogpt/agents/layers/__init__.py
+++ b/autogpts/autogpt/autogpt/agents/layers/__init__.py
@@ -3,5 +3,11 @@
 from .governance import GovernanceAgent
 from .evolution import EvolutionAgent
 from .capability import CapabilityAgent
+from .execution import ExecutionAgent
 
-__all__ = ["GovernanceAgent", "EvolutionAgent", "CapabilityAgent"]
+__all__ = [
+    "GovernanceAgent",
+    "EvolutionAgent",
+    "CapabilityAgent",
+    "ExecutionAgent",
+]

--- a/autogpts/autogpt/autogpt/agents/layers/execution.py
+++ b/autogpts/autogpt/autogpt/agents/layers/execution.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from autogpt.core.ability import AbilityRegistry, SimpleAbilityRegistry
+from autogpt.core.ability.schema import AbilityResult
+from autogpt.core.agent.layered import LayeredAgent
+
+
+class ExecutionAgent(LayeredAgent):
+    """Layer responsible for executing abilities from a plan."""
+
+    def __init__(
+        self,
+        ability_registry: AbilityRegistry | SimpleAbilityRegistry,
+        next_layer: Optional[LayeredAgent] = None,
+    ) -> None:
+        super().__init__(next_layer=next_layer)
+        self._ability_registry = ability_registry
+
+    @classmethod
+    def from_workspace(
+        cls, workspace_path: Path, logger: Any
+    ) -> "ExecutionAgent":  # pragma: no cover - simple passthrough
+        raise NotImplementedError("ExecutionAgent does not support workspace loading")
+
+    def __repr__(self) -> str:  # pragma: no cover - simple representation
+        return f"ExecutionAgent(registry={self._ability_registry})"
+
+    async def route_task(
+        self, plan: dict[str, Any], *args: Any, **kwargs: Any
+    ) -> AbilityResult:
+        """Execute the ability described in ``plan`` and return the result."""
+
+        ability_name = plan.get("next_ability")
+        ability_args = plan.get("ability_arguments", {})
+        try:
+            result = await self._ability_registry.perform(ability_name, **ability_args)
+        except Exception as err:
+            if self.next_layer is not None:
+                return await self.next_layer.route_task(err, *args, **kwargs)
+            raise
+
+        if self.next_layer is not None:
+            return await self.next_layer.route_task(result, *args, **kwargs)
+        return result


### PR DESCRIPTION
## Summary
- add ExecutionAgent to run abilities and bubble up results or errors
- expose ExecutionAgent in agents.layers package

## Testing
- `flake8 autogpts/autogpt/autogpt/agents/layers/execution.py autogpts/autogpt/autogpt/agents/layers/__init__.py`
- `pytest autogpts/autogpt/tests/unit -q` *(fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68a81ae0915c832f8d7b175a2f8fc489