### PR TITLE
Add governance charter models and loader

### DIFF
--- a/autogpts/autogpt/.gitignore
+++ b/autogpts/autogpt/.gitignore
@@ -17,6 +17,10 @@ log-ingestion.txt
 mem.sqlite3
 venvAutoGPT
 data/*
+!data/charter/
+!data/charter/*.json
+!data/charter/*.yaml
+!data/charter/*.yml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/autogpts/autogpt/autogpt/governance/__init__.py
+++ b/autogpts/autogpt/autogpt/governance/__init__.py
@@ -1,0 +1,11 @@
+"""Governance models and utilities for AutoGPT."""
+
+from .charter import Charter, Permission, Role, CharterValidationError, load_charter
+
+__all__ = [
+    "Charter",
+    "Permission",
+    "Role",
+    "CharterValidationError",
+    "load_charter",
+]

--- a/autogpts/autogpt/autogpt/governance/charter.py
+++ b/autogpts/autogpt/autogpt/governance/charter.py
@@ -1,0 +1,98 @@
+"""Governance charter models and loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel, ValidationError, validator
+
+
+class CharterError(Exception):
+    """Base exception for charter related errors."""
+
+
+class CharterValidationError(CharterError):
+    """Raised when a charter definition fails validation."""
+
+
+class Permission(BaseModel):
+    """A specific action an agent is permitted to perform."""
+
+    name: str
+    description: Optional[str] = None
+
+
+class Role(BaseModel):
+    """An agent role comprised of permissions and allowed tasks."""
+
+    name: str
+    description: Optional[str] = None
+    permissions: List[Permission] = []
+    allowed_tasks: List[str] = []
+
+    @validator("permissions")
+    def unique_permissions(cls, perms: List[Permission]) -> List[Permission]:  # noqa: N805
+        names = [p.name for p in perms]
+        if len(names) != len(set(names)):
+            raise ValueError("permission names must be unique")
+        return perms
+
+
+class Charter(BaseModel):
+    """Top-level governance charter definition."""
+
+    name: str
+    roles: List[Role]
+    core_directives: List[str] = []
+
+    @validator("roles")
+    def unique_roles(cls, roles: List[Role]) -> List[Role]:  # noqa: N805
+        names = [r.name for r in roles]
+        if len(names) != len(set(names)):
+            raise ValueError("role names must be unique")
+        return roles
+
+
+def load_charter(name: str, directory: Optional[Path] = None) -> Charter:
+    """Load a charter definition by name.
+
+    Parameters
+    ----------
+    name
+        Base name of the charter file (without extension).
+    directory
+        Directory to search for charter files. Defaults to the built-in
+        ``data/charter`` directory.
+    """
+
+    if directory is None:
+        directory = Path(__file__).resolve().parent.parent / "data" / "charter"
+
+    for ext in (".json", ".yaml", ".yml"):
+        file_path = directory / f"{name}{ext}"
+        if file_path.exists():
+            break
+    else:
+        raise FileNotFoundError(
+            f"Charter file '{name}' not found in {directory}."
+        )
+
+    try:
+        if file_path.suffix == ".json":
+            data = json.loads(file_path.read_text())
+        else:
+            data = yaml.safe_load(file_path.read_text())
+    except Exception as exc:  # pragma: no cover - unexpected parse errors
+        raise CharterValidationError(
+            f"Failed to parse charter file '{file_path}': {exc}"
+        ) from exc
+
+    try:
+        return Charter.parse_obj(data)
+    except ValidationError as exc:
+        raise CharterValidationError(
+            f"Invalid charter data in '{file_path}': {exc}"
+        ) from exc

--- a/autogpts/autogpt/data/charter/example.yaml
+++ b/autogpts/autogpt/data/charter/example.yaml
@@ -1,0 +1,15 @@
+name: Example Charter
+core_directives:
+  - Serve the user
+  - Stay safe
+roles:
+  - name: assistant
+    description: Basic assistant role
+    permissions:
+      - name: read
+        description: Read data sources
+      - name: write
+        description: Write outputs
+    allowed_tasks:
+      - answer questions
+      - draft texts

--- a/autogpts/autogpt/tests/unit/test_charter.py
+++ b/autogpts/autogpt/tests/unit/test_charter.py
@@ -1,0 +1,46 @@
+"""Tests for the governance charter loader."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+import json
+
+from autogpt.governance.charter import (
+    Charter,
+    CharterValidationError,
+    load_charter,
+)
+
+
+def test_load_charter_from_yaml(tmp_path: Path) -> None:
+    data = {
+        "name": "Test Charter",
+        "core_directives": ["Be kind"],
+        "roles": [
+            {
+                "name": "assistant",
+                "permissions": [{"name": "write"}],
+                "allowed_tasks": ["respond"],
+            }
+        ],
+    }
+    path = tmp_path / "test.yaml"
+    path.write_text(yaml.safe_dump(data))
+
+    charter = load_charter("test", directory=tmp_path)
+    assert isinstance(charter, Charter)
+    assert charter.roles[0].permissions[0].name == "write"
+
+
+def test_invalid_charter_raises(tmp_path: Path) -> None:
+    """Duplicate role names should trigger validation errors."""
+    data = {
+        "name": "Bad Charter",
+        "roles": [{"name": "dup"}, {"name": "dup"}],
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(data))
+
+    with pytest.raises(CharterValidationError):
+        load_charter("bad", directory=tmp_path)

--- a/docs/governance/charter.md
+++ b/docs/governance/charter.md
@@ -1,0 +1,45 @@
+# Governance Charter
+
+AutoGPT agents can be configured with a **governance charter** that defines
+which roles exist, what each role may do, and the core directives that guide
+all behavior. Charters are stored as JSON or YAML files in
+`autogpts/autogpt/data/charter/` and loaded at runtime.
+
+## Format
+
+```yaml
+name: Example Charter
+core_directives:
+  - Serve the user
+  - Stay safe
+roles:
+  - name: assistant
+    description: Basic assistant role
+    permissions:
+      - name: read
+        description: Read data sources
+      - name: write
+        description: Write outputs
+    allowed_tasks:
+      - answer questions
+      - draft texts
+```
+
+### Fields
+
+- **name**: A human readable name for the charter.
+- **core_directives**: High level guidelines that apply to all roles.
+- **roles**: List of roles available in the system.
+  - **name**: Unique identifier for the role.
+  - **description**: Optional details about the role.
+  - **permissions**: Specific permissions granted to the role. Permission
+    names must be unique within a role.
+  - **allowed_tasks**: Free form descriptions of tasks the role may perform.
+
+## Validation
+
+The loader validates charters using [Pydantic](https://docs.pydantic.dev).
+Malformed files or duplicate role/permission names raise a
+`CharterValidationError` with details about the problem.
+
+Use `load_charter(name)` to read and validate a charter by filename.


### PR DESCRIPTION
## Summary
- add Pydantic models and loader for governance charters
- unignore charter data files and document charter format
- cover charter parsing and validation with unit tests

## Testing
- `pytest autogpts/autogpt/tests/unit/test_charter.py -q` *(fails: ImportError: cannot import name 'Discriminator' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a8718ddc4c832f908e69682e56105b