### PR TITLE
Integrate charter-based governance checks

### DIFF
--- a/autogpts/autogpt/autogpt/agents/layers/governance.py
+++ b/autogpts/autogpt/autogpt/agents/layers/governance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Optional
 
 from pydantic import Field
@@ -11,15 +12,26 @@ from autogpt.core.configuration import (
     SystemSettings,
     UserConfigurable,
 )
+from autogpt.governance import Charter, load_charter
 
 
 class GovernancePolicy(SystemConfiguration):
     """Settings that define governance rules for task routing."""
 
+    charter_name: str = UserConfigurable(
+        default="example",
+        description="Name of the charter file to load for governance rules.",
+    )
+    role: str = UserConfigurable(
+        default="assistant",
+        description="Role of the requesting agent within the charter.",
+    )
     allowed_task_types: list[str] = UserConfigurable(
         default_factory=list,
         description="List of task types permitted by the governance layer.",
     )
+    charter_path: Optional[Path] = None
+    charter: Optional[Charter] = None
 
 
 class GovernanceAgentSettings(SystemSettings):
@@ -43,11 +55,32 @@ class GovernanceAgent(LayeredAgent, Configurable[GovernanceAgentSettings]):
     ) -> None:
         super().__init__(next_layer=next_layer)
         self.settings = settings
+        self.charter = load_charter(
+            self.settings.policy.charter_name,
+            directory=self.settings.policy.charter_path,
+        )
+        self.settings.policy.charter = self.charter
 
-    def route_task(self, task: Any, *args, **kwargs):
-        """Route a task to the next layer if permitted by policy."""
+    def route_task(self, task: Any, role: Optional[str] = None, *args, **kwargs):
+        """Route a task to the next layer if permitted by policy and charter."""
+
+        role_name = role or self.settings.policy.role
+        charter_role = next(
+            (r for r in self.charter.roles if r.name == role_name), None
+        )
+        if charter_role is None:
+            raise PermissionError(
+                f"Role '{role_name}' is not defined in charter '{self.charter.name}'."
+            )
 
         task_type = getattr(task, "type", getattr(task, "name", str(task)))
+
+        if charter_role.allowed_tasks and task_type not in charter_role.allowed_tasks:
+            raise PermissionError(
+                f"Role '{role_name}' is not permitted to perform task '{task_type}' "
+                f"per charter '{self.charter.name}'."
+            )
+
         allowed = self.settings.policy.allowed_task_types
         if allowed and task_type not in allowed:
             raise PermissionError(

--- a/autogpts/autogpt/tests/unit/test_governance_agent.py
+++ b/autogpts/autogpt/tests/unit/test_governance_agent.py
@@ -1,0 +1,91 @@
+import importlib.util
+import types
+from pathlib import Path
+import sys
+from typing import Optional
+
+import pytest
+
+# Stub out heavy dependencies before importing the governance module
+agent_pkg = types.ModuleType("autogpt.core.agent")
+layered_pkg = types.ModuleType("autogpt.core.agent.layered")
+
+
+class _DummyLayeredAgent:
+    def __init__(self, *args, next_layer=None, **kwargs):
+        self.next_layer = next_layer
+
+    def route_task(self, task, *args, **kwargs):
+        if self.next_layer is not None:
+            return self.next_layer.route_task(task, *args, **kwargs)
+        raise NotImplementedError
+
+
+layered_pkg.LayeredAgent = _DummyLayeredAgent
+agent_pkg.LayeredAgent = _DummyLayeredAgent
+agent_pkg.Agent = object
+agent_pkg.AgentSettings = object
+agent_pkg.SimpleAgent = object
+sys.modules["autogpt.core.agent"] = agent_pkg
+sys.modules["autogpt.core.agent.layered"] = layered_pkg
+
+# Import governance module directly to avoid heavy package dependencies
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "autogpt"
+    / "agents"
+    / "layers"
+    / "governance.py"
+)
+spec = importlib.util.spec_from_file_location("governance", _MODULE_PATH)
+governance = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(governance)  # type: ignore[call-arg]
+governance.GovernancePolicy.update_forward_refs(
+    Path=Path, Charter=governance.Charter, Optional=Optional
+)
+governance.GovernanceAgentSettings.update_forward_refs(
+    GovernancePolicy=governance.GovernancePolicy
+)
+
+GovernanceAgent = governance.GovernanceAgent
+GovernanceAgentSettings = governance.GovernanceAgentSettings
+GovernancePolicy = governance.GovernancePolicy
+
+
+def make_agent(role: str = "assistant") -> GovernanceAgent:
+    settings = GovernanceAgentSettings(
+        name="gov",
+        description="gov",
+        policy=GovernancePolicy(
+            charter_name="example",
+            role=role,
+            charter_path=Path(__file__).resolve().parents[2] / "data" / "charter",
+        ),
+    )
+    return GovernanceAgent(settings=settings)
+
+
+def test_loads_charter() -> None:
+    agent = make_agent()
+    assert agent.charter.name == "Example Charter"
+
+
+def test_allows_task_for_role() -> None:
+    agent = make_agent()
+    result = agent.route_task("answer questions")
+    assert result == "answer questions"
+
+
+def test_blocks_disallowed_task() -> None:
+    agent = make_agent()
+    with pytest.raises(PermissionError) as exc:
+        agent.route_task("forbidden")
+    assert "not permitted" in str(exc.value)
+
+
+def test_blocks_unknown_role() -> None:
+    agent = make_agent(role="stranger")
+    with pytest.raises(PermissionError) as exc:
+        agent.route_task("answer questions")
+    assert "not defined" in str(exc.value)


### PR DESCRIPTION
## Summary
- load governance charter on GovernanceAgent startup
- enforce charter roles and allowed tasks with informative errors
- add unit tests for charter-based task routing

## Testing
- `pytest --noconftest autogpts/autogpt/tests/unit/test_charter.py autogpts/autogpt/tests/unit/test_governance_agent.py`
- `flake8 autogpts/autogpt/autogpt/agents/layers/governance.py autogpts/autogpt/tests/unit/test_governance_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68a87da2b9a8832fbcd57e82f734daf8