### PR TITLE
feat: enforce human architect approval for core architecture changes

### DIFF
--- a/autogpts/autogpt/data/charter/human_architect.yaml
+++ b/autogpts/autogpt/data/charter/human_architect.yaml
@@ -1,0 +1,11 @@
+name: Human Architecture Charter
+core_directives:
+  - Safeguard the core architecture
+roles:
+  - name: assistant
+    description: Standard assistant role
+  - name: human_architect
+    description: Human supervisor responsible for core architecture decisions
+    permissions:
+      - name: approve_core_change
+        description: Approve modifications to core system architecture

--- a/docs/governance/charter.md
+++ b/docs/governance/charter.md
@@ -36,6 +36,28 @@ roles:
     names must be unique within a role.
   - **allowed_tasks**: Free form descriptions of tasks the role may perform.
 
+## Human Architect Approval
+
+Some tasks may be flagged as *core architecture changes*. These tasks carry
+significant risk and must be approved before execution. A charter can define a
+`human_architect` role with the `approve_core_change` permission. When a task is
+marked with a `core_change` flag (or has type `core_change`), the governance
+layer requires approval from this role before routing the task to lower-level
+agents.
+
+To grant this authority, include a role similar to:
+
+```yaml
+roles:
+  - name: human_architect
+    description: Human supervisor responsible for core architecture decisions
+    permissions:
+      - name: approve_core_change
+        description: Approve modifications to core system architecture
+```
+
+If such approval is not present, the governance agent rejects the task.
+
 ## Validation
 
 The loader validates charters using [Pydantic](https://docs.pydantic.dev).


### PR DESCRIPTION
## Summary
- add `human_architect` charter with `approve_core_change` permission
- require human architect approval for core architecture change tasks in governance layer
- document new approval process and cover it with unit tests

## Testing
- `pytest autogpts/autogpt/tests/unit/test_governance_agent.py -q` *(fails: ModuleNotFoundError: No module named 'spacy')*


------
https://chatgpt.com/codex/tasks/task_e_68a88da908d4832f8a59c2456b7bc191