### PR TITLE
Add governance package and commit approval utilities

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,53 @@
+# Governance and Approvals
+
+This repository supports a lightweight governance model for coordinating work
+between automated agents and human collaborators.
+
+## Roles
+
+Roles and their permissions are declared in [`governance/charter/roles.yaml`](../governance/charter/roles.yaml).
+The default charter defines three roles:
+
+- **human_architect** – reviews and approves pull requests.
+- **developer** – proposes code changes and responds to feedback.
+- **ci_agent** – runs tests and reports status.
+
+## Workflow
+
+1. A developer opens a pull request with proposed changes.
+2. Continuous integration agents run automated checks.
+3. The human architect reviews the pending commits and records approvals using
+   the utilities in [`governance/approvals.py`](../governance/approvals.py).
+4. Once all commits are approved, the pull request can be merged.
+
+## Approval Utility
+
+The `ApprovalService` class wraps git commands to track approvals using
+[`git notes`](https://git-scm.com/docs/git-notes). Each approval adds a note in
+`Approved-by: <name>` format to the corresponding commit. A commit is considered
+approved when at least one such note is present.
+
+Example usage:
+
+```python
+from governance.approvals import ApprovalService
+
+svc = ApprovalService()
+pendings = svc.pending_commits()
+for commit in pendings:
+    print(commit, "requires approval")
+```
+
+Use `add_approval(commit, approver)` to record a new approval and
+`is_approved(commit)` to verify approval status.
+
+## Responsibilities
+
+| Role            | Responsibilities                                      |
+|-----------------|--------------------------------------------------------|
+| human_architect | Validate major changes, ensure safety and governance. |
+| developer       | Implement features and incorporate feedback.          |
+| ci_agent        | Execute tests and share results.                      |
+
+All participants should follow the governance charter and ensure that changes
+receive the necessary approvals before merging.

--- a/governance/approvals.py
+++ b/governance/approvals.py
@@ -1,0 +1,72 @@
+"""Utilities for recording and querying commit approvals.
+
+This module uses git notes to track which commits have been approved by a
+`human_architect`.  The notes are stored in the local git repository and can be
+shared like any other ref.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from typing import List, Optional
+
+
+class ApprovalService:
+    """Encapsulates commit approval logic for a git repository."""
+
+    def __init__(self, repo_path: Optional[Path | str] = None) -> None:
+        self.repo_path = Path(repo_path or ".").resolve()
+
+    def _run_git(self, *args: str) -> str:
+        """Run a git command and return its stdout."""
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    # ------------------------------------------------------------------
+    # query helpers
+    # ------------------------------------------------------------------
+    def approvals_for(self, commit: str) -> List[str]:
+        """Return a list of approvers for the given commit hash."""
+        try:
+            notes = self._run_git("notes", "show", commit)
+        except subprocess.CalledProcessError:
+            return []
+        approvers = []
+        for line in notes.splitlines():
+            if line.lower().startswith("approved-by:"):
+                approvers.append(line.split(":", 1)[1].strip())
+        return approvers
+
+    def is_approved(self, commit: str) -> bool:
+        """Return True if the commit has any recorded approvals."""
+        return bool(self.approvals_for(commit))
+
+    # ------------------------------------------------------------------
+    # approval workflow
+    # ------------------------------------------------------------------
+    def add_approval(self, commit: str, approver: str) -> None:
+        """Record an approval for ``commit`` by ``approver``.
+
+        Approvals are stored using ``git notes`` so the underlying commit
+        remains unchanged.
+        """
+        note = f"Approved-by: {approver}"
+        try:
+            # append if a note already exists
+            self._run_git("notes", "append", "-m", note, commit)
+        except subprocess.CalledProcessError:
+            # otherwise create a new note
+            self._run_git("notes", "add", "-m", note, commit)
+
+    def pending_commits(self, base: str = "origin/main", head: str = "HEAD") -> List[str]:
+        """Return commits between ``base`` and ``head`` lacking approval."""
+        revs = self._run_git("rev-list", f"{base}..{head}")
+        commits = revs.splitlines()
+        return [c for c in commits if not self.is_approved(c)]
+

--- a/governance/charter/roles.yaml
+++ b/governance/charter/roles.yaml
@@ -1,0 +1,13 @@
+roles:
+  human_architect:
+    permissions:
+      - approve_pull_requests
+      - define_governance
+  developer:
+    permissions:
+      - propose_changes
+      - respond_to_feedback
+  ci_agent:
+    permissions:
+      - run_tests
+      - report_status


### PR DESCRIPTION
## Summary
- add governance package with YAML charter for role permissions
- implement ApprovalService using git notes to track commit approvals
- document governance workflow and roles

## Testing
- `pytest` *(fails: ImportError: cannot import name 'GetCoreSchemaHandler' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2eb1e5c832f85d85a0798471f03