### PR TITLE
Add simple executor and task graph with CLI integration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -206,6 +206,20 @@ d88P     888  "Y88888  "Y888 "Y88P"   "Y8888P88 888           888
         )
 
 
+@cli.command()
+@click.argument("goal")
+def execute(goal):
+    """Start the simple executor agent with a GOAL."""
+    from pathlib import Path
+    from capability.skill_library import SkillLibrary
+    from execution import Executor
+
+    lib = SkillLibrary(Path.cwd())
+    executor = Executor(lib)
+    results = executor.execute(goal)
+    click.echo(results)
+
+
 @cli.group()
 def agent():
     """Commands to create, start and stop agents"""

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,0 +1,4 @@
+from .executor import Executor
+from .task_graph import Task, TaskGraph
+
+__all__ = ["Executor", "Task", "TaskGraph"]

--- a/execution/executor.py
+++ b/execution/executor.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+from capability.skill_library import SkillLibrary
+from .task_graph import TaskGraph
+
+
+class Executor:
+    """Very small executor that decomposes a goal into skill tasks."""
+
+    def __init__(self, skill_library: SkillLibrary) -> None:
+        self.skill_library = skill_library
+
+    # Goal decomposition
+    def decompose_goal(self, goal: str) -> TaskGraph:
+        """Split a goal string into sequential skill tasks.
+
+        The goal is split on the words 'then' or 'and'. Each resulting token is
+        treated as a skill name if it matches a skill in the library. Subsequent
+        tasks depend on the previous task, forming a simple chain.
+        """
+
+        graph = TaskGraph()
+        tokens = [t.strip() for t in re.split(r"then|and", goal) if t.strip()]
+        previous: str | None = None
+        available = set(self.skill_library.list_skills())
+        for token in tokens:
+            if token in available:
+                deps: List[str] = [previous] if previous else []
+                graph.add_task(
+                    token,
+                    description=f"Execute {token}",
+                    skill=token,
+                    dependencies=deps,
+                )
+                previous = token
+        return graph
+
+    # Task scheduling and execution
+    def execute(self, goal: str) -> Dict[str, Any]:
+        graph = self.decompose_goal(goal)
+        results: Dict[str, Any] = {}
+        for task_id in graph.execution_order():
+            task = graph.tasks[task_id]
+            if task.skill:
+                results[task_id] = self._call_skill(task.skill)
+        return results
+
+    def _call_skill(self, name: str) -> Any:
+        code, _ = self.skill_library.get_skill(name)
+        namespace: Dict[str, Any] = {}
+        exec(code, namespace)
+        func = namespace.get(name)
+        if callable(func):
+            return func()
+        raise ValueError(f"Skill {name} did not define a callable {name}()")

--- a/execution/task_graph.py
+++ b/execution/task_graph.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Task:
+    """Represents a unit of work and its dependencies."""
+
+    description: str
+    skill: str | None = None
+    dependencies: List[str] = field(default_factory=list)
+
+
+class TaskGraph:
+    """Simple task graph supporting dependency resolution."""
+
+    def __init__(self) -> None:
+        self.tasks: Dict[str, Task] = {}
+
+    def add_task(
+        self,
+        task_id: str,
+        description: str,
+        *,
+        skill: str | None = None,
+        dependencies: List[str] | None = None,
+    ) -> None:
+        self.tasks[task_id] = Task(description, skill, dependencies or [])
+
+    def execution_order(self) -> List[str]:
+        """Return a list of task ids in executable order."""
+        visited: set[str] = set()
+        temp_mark: set[str] = set()
+        order: List[str] = []
+
+        def visit(node: str) -> None:
+            if node in visited:
+                return
+            if node in temp_mark:
+                raise ValueError("Cycle detected in task graph")
+            temp_mark.add(node)
+            for dep in self.tasks[node].dependencies:
+                visit(dep)
+            temp_mark.remove(node)
+            visited.add(node)
+            order.append(node)
+
+        for node in list(self.tasks.keys()):
+            visit(node)
+        return order

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,30 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from pathlib import Path
+import subprocess
+
+from capability.skill_library import SkillLibrary
+from execution import Executor
+
+
+def init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+
+
+def test_executor_flow(tmp_path: Path) -> None:
+    repo = tmp_path
+    init_repo(repo)
+    lib = SkillLibrary(repo)
+
+    lib.add_skill("hello", "def hello():\n    return 'hi'\n", {"lang": "python"})
+    lib.add_skill("goodbye", "def goodbye():\n    return 'bye'\n", {"lang": "python"})
+
+    executor = Executor(lib)
+    results = executor.execute("hello then goodbye")
+
+    assert list(results.keys()) == ["hello", "goodbye"]
+    assert results["hello"] == "hi"
+    assert results["goodbye"] == "bye"


### PR DESCRIPTION
## Summary
- add basic `TaskGraph` and `Executor` for decomposing goals into skill tasks
- expose new `execute` CLI command to run executor with a user-supplied goal
- include tests demonstrating end-to-end goal execution

## Testing
- `pytest` *(fails: ImportError: cannot import name 'GetCoreSchemaHandler' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba0df33c832fbf7199e1077473e6