### PR TITLE
Add HumanArchitect agent for commit approval governance

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -41,6 +41,23 @@ for commit in pendings:
 Use `add_approval(commit, approver)` to record a new approval and
 `is_approved(commit)` to verify approval status.
 
+## HumanArchitect Agent
+
+The :class:`HumanArchitect` agent builds on ``ApprovalService`` to help a human
+reviewer manage core changes. It can list pending commits and record approvals
+without manually invoking git commands.
+
+```python
+from governance import HumanArchitect
+
+architect = HumanArchitect("Alice")
+for commit in architect.pending_commits():
+    architect.approve_commit(commit)
+```
+
+This keeps final authority in human hands while still integrating with the
+lightweight note‑based approval workflow.
+
 ## Responsibilities
 
 | Role            | Responsibilities                                      |

--- a/governance/__init__.py
+++ b/governance/__init__.py
@@ -1,0 +1,6 @@
+"""Governance utilities and agents."""
+
+from .approvals import ApprovalService
+from .human_architect import HumanArchitect
+
+__all__ = ["ApprovalService", "HumanArchitect"]

--- a/governance/human_architect.py
+++ b/governance/human_architect.py
@@ -1,0 +1,51 @@
+"""Agent responsible for recording commit approvals.
+
+The :class:`HumanArchitect` coordinates with humans to approve or review
+commits. It delegates actual git operations to :class:`ApprovalService`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+
+from .approvals import ApprovalService
+
+
+class HumanArchitect(ABC):
+    """Agent that records commit approvals using :class:`ApprovalService`."""
+
+    def __init__(self, name: str, approval_service: ApprovalService | None = None) -> None:
+        """Create a new ``HumanArchitect``.
+
+        Parameters
+        ----------
+        name:
+            Name of the human architect recording approvals.
+        approval_service:
+            Optional :class:`ApprovalService` instance. If not provided a
+            default instance operating on the current repository is used.
+        """
+
+        self.name = name
+        self.approval_service = approval_service or ApprovalService()
+
+    # ------------------------------------------------------------------
+    # approval workflow
+    # ------------------------------------------------------------------
+    def approve_commit(self, commit_hash: str) -> None:
+        """Record this architect's approval of ``commit_hash``."""
+        self.approval_service.add_approval(commit_hash, self.name)
+
+    def pending_commits(self, base: str = "origin/main", head: str = "HEAD") -> list[str]:
+        """Return commits between ``base`` and ``head`` lacking approval."""
+        return self.approval_service.pending_commits(base=base, head=head)
+
+    # ------------------------------------------------------------------
+    # Agent interface
+    # ------------------------------------------------------------------
+    def perform(self, base: str = "origin/main", head: str = "HEAD") -> str:
+        """Report commits pending approval."""
+        commits = self.pending_commits(base=base, head=head)
+        if commits:
+            return "\n".join(commits)
+        return "No pending commits."

--- a/governance/test_human_architect.py
+++ b/governance/test_human_architect.py
@@ -1,0 +1,44 @@
+import subprocess
+
+from governance import HumanArchitect, ApprovalService
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _git_output(cwd, *args) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def test_approve_and_query_commits(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # initialize repository
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    # first commit
+    file_path = repo / "file.txt"
+    file_path.write_text("one")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "initial")
+
+    # second commit
+    file_path.write_text("two")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "update")
+    commit_hash = _git_output(repo, "rev-parse", "HEAD")
+
+    agent = HumanArchitect("Alice", ApprovalService(repo))
+
+    pending = agent.pending_commits(base="HEAD~1")
+    assert commit_hash in pending
+
+    agent.approve_commit(commit_hash)
+
+    assert commit_hash not in agent.pending_commits(base="HEAD~1")
+    assert "Alice" in agent.approval_service.approvals_for(commit_hash)


### PR DESCRIPTION
## Summary
- add `HumanArchitect` agent that records and queries commit approvals
- expose `HumanArchitect` from `governance` package
- document and test commit approval workflow

## Testing
- `pytest governance/test_human_architect.py tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c917339c832fb5b2222d89bde6a7