### PR TITLE
Add self-assessment ability and periodic reasoning checks

### DIFF
--- a/autogpts/autogpt/autogpt/core/planning/templates.py
+++ b/autogpts/autogpt/autogpt/core/planning/templates.py
@@ -82,3 +82,12 @@ PLAN_PROMPT_MAIN = (
 ###########################
 # Parameterized templates #
 ###########################
+
+#############################
+# Reasoning critique prompt #
+#############################
+
+CRITIQUE_REASONING_PROMPT = (
+    "Review the reasoning steps for logical consistency, "
+    "highlighting any contradictions or gaps and suggesting improvements."
+)


### PR DESCRIPTION
## Summary
- introduce `self_assess` ability to scan recent memory for logical contradictions
- add reasoning critique template for planning
- run self-assess after configurable number of tasks and log the result

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'GetCoreSchemaHandler' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5fbd2ac8832f981069e7d60fd86f