### PR TITLE
feat: add generate_code command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Commands:
 
 只需克隆仓库，使用 `./run setup` 安装依赖即可开始！
 
+### 🤖 自动代码生成
+
+AutoGPT 包含 `generate_code` 指令，可根据你的提示生成代码并将结果写入代理的工作区。
+
+```json
+{"command": {"name": "generate_code", "args": {"prompt": "编写一个打印 \"Hello, world!\" 的 Python 程序"}}}
+```
+
+生成的代码会保存为工作区中的新文件（文件名包含时间戳）。
+**限制**：该代码由 LLM 自动生成，未经过审查或执行，可能包含错误或安全隐患，运行前请务必检查。
+
 ## 🤔 有问题？遇到困难？有建议？
 
 ### 获取帮助 - [Discord 💬](https://discord.gg/autogpt)

--- a/autogpts/autogpt/autogpt/commands/__init__.py
+++ b/autogpts/autogpt/autogpt/commands/__init__.py
@@ -6,4 +6,5 @@ COMMAND_CATEGORIES = [
     "autogpt.commands.web_selenium",
     "autogpt.commands.system",
     "autogpt.commands.image_gen",
+    "autogpt.commands.code_generation",
 ]

--- a/autogpts/autogpt/autogpt/commands/code_generation.py
+++ b/autogpts/autogpt/autogpt/commands/code_generation.py
@@ -1,0 +1,46 @@
+"""Commands to generate code using an LLM."""
+
+import logging
+from datetime import datetime
+
+from autogpt.agents.agent import Agent
+from autogpt.command_decorator import command
+from autogpt.core.resource.model_providers import ChatMessage
+from autogpt.core.utils.json_schema import JSONSchema
+
+COMMAND_CATEGORY = "code_generation"
+COMMAND_CATEGORY_TITLE = "Code Generation"
+
+logger = logging.getLogger(__name__)
+
+
+@command(
+    "generate_code",
+    "Generate code from a prompt and save it to a file in the workspace",
+    {
+        "prompt": JSONSchema(
+            type=JSONSchema.Type.STRING,
+            description="Instructions for the code to generate",
+            required=True,
+        ),
+    },
+)
+async def generate_code(prompt: str, agent: Agent) -> str:
+    """Generate code using the configured LLM and write it to the workspace.
+
+    Args:
+        prompt: Instructions for the code to generate.
+
+    Returns:
+        str: The relative path to the file containing the generated code.
+    """
+    response = await agent.llm_provider.create_chat_completion(
+        model_prompt=[ChatMessage.user(prompt)],
+        functions=[],
+        model_name=agent.llm.name,
+    )
+    code = response.response.content or ""
+    filename = f"generated_code_{datetime.now().strftime('%Y%m%d_%H%M%S')}.py"
+    await agent.workspace.write_file(filename, code)
+    logger.info("Generated code written to %s", filename)
+    return filename


### PR DESCRIPTION
## Summary
- add `generate_code` command to create code via LLM and save to workspace
- document automatic code generation usage and limitations

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab789f29a0832f934dc171a44982f6