### PR TITLE
Add autonomous execution loop and CLI flag

### DIFF
--- a/autogpts/autogpt/README.md
+++ b/autogpts/autogpt/README.md
@@ -64,6 +64,8 @@ Options:
   -c, --continuous                Enable Continuous Mode
   -y, --skip-reprompt             Skips the re-prompting messages at the
                                   beginning of the script
+  --autonomous                    Run without requiring user confirmation for
+                                  each action
   -C, --ai-settings FILE          Specifies which ai_settings.yaml file to
                                   use, relative to the AutoGPT root directory.
                                   Will also automatically skip the re-prompt.
@@ -102,6 +104,15 @@ Options:
 ```
 </details>
 
+To enable a fully automated run without any confirmation prompts, start the
+agent with the `--autonomous` flag:
+
+```shell
+$ ./autogpt.sh run --autonomous
+```
+
+This mode will execute commands continuously. Use it cautiously and monitor the
+agent's activity to avoid unintended actions.
 
 <details>
 <summary>

--- a/autogpts/autogpt/autogpt/app/cli.py
+++ b/autogpts/autogpt/autogpt/app/cli.py
@@ -28,6 +28,11 @@ def cli(ctx: click.Context):
     type=int,
     help="Defines the number of times to run in continuous mode",
 )
+@click.option(
+    "--autonomous",
+    is_flag=True,
+    help="Run without requiring user authorization for each action",
+)
 @click.option("--speak", is_flag=True, help="Enable Speak Mode")
 @click.option("--gpt3only", is_flag=True, help="Enable GPT3.5 Only Mode")
 @click.option("--gpt4only", is_flag=True, help="Enable GPT4 Only Mode")
@@ -149,6 +154,7 @@ def cli(ctx: click.Context):
 def run(
     continuous: bool,
     continuous_limit: Optional[int],
+    autonomous: bool,
     speak: bool,
     gpt3only: bool,
     gpt4only: bool,
@@ -176,33 +182,60 @@ def run(
     existing agent.
     """
     # Put imports inside function to avoid importing everything when starting the CLI
-    from autogpt.app.main import run_auto_gpt
+    if autonomous:
+        from autogpt.runner.auto_loop import run_auto_loop
 
-    run_auto_gpt(
-        continuous=continuous,
-        continuous_limit=continuous_limit,
-        ai_settings=ai_settings,
-        prompt_settings=prompt_settings,
-        skip_reprompt=skip_reprompt,
-        speak=speak,
-        debug=debug,
-        log_level=log_level,
-        log_format=log_format,
-        log_file_format=log_file_format,
-        gpt3only=gpt3only,
-        gpt4only=gpt4only,
-        browser_name=browser_name,
-        allow_downloads=allow_downloads,
-        skip_news=skip_news,
-        workspace_directory=workspace_directory,
-        install_plugin_deps=install_plugin_deps,
-        override_ai_name=ai_name,
-        override_ai_role=ai_role,
-        resources=list(resource),
-        constraints=list(constraint),
-        best_practices=list(best_practice),
-        override_directives=override_directives,
-    )
+        run_auto_loop(
+            continuous_limit=continuous_limit,
+            ai_settings=ai_settings,
+            prompt_settings=prompt_settings,
+            speak=speak,
+            debug=debug,
+            log_level=log_level,
+            log_format=log_format,
+            log_file_format=log_file_format,
+            gpt3only=gpt3only,
+            gpt4only=gpt4only,
+            browser_name=browser_name,
+            allow_downloads=allow_downloads,
+            skip_news=skip_news,
+            workspace_directory=workspace_directory,
+            install_plugin_deps=install_plugin_deps,
+            override_ai_name=ai_name,
+            override_ai_role=ai_role,
+            resources=list(resource),
+            constraints=list(constraint),
+            best_practices=list(best_practice),
+            override_directives=override_directives,
+        )
+    else:
+        from autogpt.app.main import run_auto_gpt
+
+        run_auto_gpt(
+            continuous=continuous,
+            continuous_limit=continuous_limit,
+            ai_settings=ai_settings,
+            prompt_settings=prompt_settings,
+            skip_reprompt=skip_reprompt,
+            speak=speak,
+            debug=debug,
+            log_level=log_level,
+            log_format=log_format,
+            log_file_format=log_file_format,
+            gpt3only=gpt3only,
+            gpt4only=gpt4only,
+            browser_name=browser_name,
+            allow_downloads=allow_downloads,
+            skip_news=skip_news,
+            workspace_directory=workspace_directory,
+            install_plugin_deps=install_plugin_deps,
+            override_ai_name=ai_name,
+            override_ai_role=ai_role,
+            resources=list(resource),
+            constraints=list(constraint),
+            best_practices=list(best_practice),
+            override_directives=override_directives,
+        )
 
 
 @cli.command()

--- a/autogpts/autogpt/autogpt/runner/auto_loop.py
+++ b/autogpts/autogpt/autogpt/runner/auto_loop.py
@@ -1,0 +1,25 @@
+"""Utilities for running AutoGPT in unattended mode."""
+from __future__ import annotations
+
+from typing import Any
+
+from autogpt.app.main import run_auto_gpt
+
+
+def run_auto_loop(**kwargs: Any) -> None:
+    """Run AutoGPT continuously without requiring user interaction.
+
+    All keyword arguments are forwarded to :func:`run_auto_gpt`. The function
+    ensures the agent runs in continuous mode with the initial confirmation
+    prompt skipped. It keeps restarting the agent after it finishes until the
+    process is interrupted.
+    """
+    kwargs.setdefault("continuous", True)
+    kwargs.setdefault("skip_reprompt", True)
+
+    try:
+        while True:
+            run_auto_gpt(**kwargs)
+    except KeyboardInterrupt:
+        # Allow graceful shutdown when user interrupts the process.
+        return


### PR DESCRIPTION
## Summary
- add `runner.auto_loop` for unattended continuous execution
- allow `--autonomous` to run without user confirmations
- document autonomous mode usage and safety warnings

## Testing
- `pre-commit run --files README.md autogpt/app/cli.py autogpt/runner/auto_loop.py autogpt/runner/__init__.py` *(fails: ModuleNotFoundError: No module named 'playsound')*
- `pytest tests/test_dummy.py` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a9d8bd8832fba22833e93095b25