### PR TITLE
feat: enable experience-based command prioritization

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -278,7 +278,10 @@ class Agent(
         )
 
         # Allow the agent to learn from its recent experience
-        self._experience_learner.learn_from_experience()
+        weights = self._experience_learner.learn_from_experience()
+        for name, weight in weights.items():
+            if command := self.command_registry.get_command(name):
+                command.priority = weight
 
         return result
 

--- a/autogpts/autogpt/autogpt/models/command.py
+++ b/autogpts/autogpt/autogpt/models/command.py
@@ -33,6 +33,7 @@ class Command:
         disabled_reason: Optional[str] = None,
         aliases: list[str] = [],
         available: bool | Callable[[BaseAgent], bool] = True,
+        priority: float = 0.0,
     ):
         self.name = name
         self.description = description
@@ -42,6 +43,7 @@ class Command:
         self.disabled_reason = disabled_reason
         self.aliases = aliases
         self.available = available
+        self.priority = priority
 
     @property
     def is_async(self) -> bool:

--- a/autogpts/autogpt/autogpt/models/command_registry.py
+++ b/autogpts/autogpt/autogpt/models/command_registry.py
@@ -108,7 +108,9 @@ class CommandRegistry:
             Command: The next available command.
         """
 
-        for cmd in self.commands.values():
+        for cmd in sorted(
+            self.commands.values(), key=lambda c: getattr(c, "priority", 0), reverse=True
+        ):
             available = cmd.available
             if callable(cmd.available):
                 available = cmd.available(agent)

--- a/tests/test_experience_learning.py
+++ b/tests/test_experience_learning.py
@@ -1,0 +1,58 @@
+import sys, os, types
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "autogpts", "autogpt")))
+_openapi_client = types.ModuleType("openapi_python_client")
+_openapi_config = types.ModuleType("config")
+setattr(_openapi_config, "Config", type("Config", (), {}))
+_openapi_client.config = _openapi_config
+sys.modules["openapi_python_client"] = _openapi_client
+sys.modules["openapi_python_client.config"] = _openapi_config
+sys.modules.setdefault("docx", types.ModuleType("docx"))
+sys.modules.setdefault("pypdf", types.ModuleType("pypdf"))
+_pylatexenc = types.ModuleType("pylatexenc")
+_latex2text = types.ModuleType("latex2text")
+setattr(_latex2text, "LatexNodes2Text", type("LatexNodes2Text", (), {}))
+_pylatexenc.latex2text = _latex2text
+sys.modules["pylatexenc"] = _pylatexenc
+sys.modules["pylatexenc.latex2text"] = _latex2text
+
+from autogpt.core.configuration.learning import LearningConfiguration
+from autogpt.core.learning import ExperienceLearner
+from autogpt.models.action_history import (
+    EpisodicActionHistory,
+    Action,
+    ActionSuccessResult,
+)
+from autogpt.models.command import Command
+from autogpt.models.command_registry import CommandRegistry
+
+
+def test_learning_updates_command_priority():
+    history = EpisodicActionHistory()
+    history.register_action(Action(name="b", args={}, reasoning=""))
+    history.register_result(ActionSuccessResult(outputs="ok"))
+
+    learner = ExperienceLearner(
+        memory=history, config=LearningConfiguration(enabled=True)
+    )
+    weights = learner.learn_from_experience()
+    assert weights["b"] == 1.0
+
+    registry = CommandRegistry()
+
+    def cmd_a(*, agent=None):
+        return "A"
+
+    def cmd_b(*, agent=None):
+        return "B"
+
+    registry.register(Command("a", "cmd a", cmd_a, []))
+    registry.register(Command("b", "cmd b", cmd_b, []))
+
+    before = [c.name for c in registry.list_available_commands(agent=None)]
+    assert before == ["a", "b"]
+
+    for name, weight in weights.items():
+        registry.get_command(name).priority = weight
+
+    after = [c.name for c in registry.list_available_commands(agent=None)]
+    assert after[0] == "b"


### PR DESCRIPTION
## Summary
- teach `ExperienceLearner` to compute success-based weights for past commands
- update agents to adjust command priorities using learned weights
- sort registry commands by priority and test learning-driven reordering

## Testing
- `pytest tests/test_experience_learning.py`
- `pytest tests/test_executor.py tests/test_reasoning_planner.py tests/test_skill_library.py tests/test_genesis_team_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7eaa4364832fa42f202b6756acb7