### PR TITLE
Enable learning feedback to update command availability

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -277,8 +277,13 @@ class Agent(
             self.llm_provider, self.legacy_config
         )
 
-        # Allow the agent to learn from its recent experience
-        self._experience_learner.learn_from_experience()
+        # Allow the agent to learn from its recent experience and adjust
+        # command availability based on the learned success rates
+        updated_weights = self._experience_learner.learn_from_experience()
+        for name, weight in updated_weights.items():
+            if cmd := self.command_registry.get_command(name):
+                # Simple heuristic: disable commands with low success rate
+                cmd.available = weight >= 0.5
 
         return result
 

--- a/autogpts/autogpt/autogpt/core/learning/__init__.py
+++ b/autogpts/autogpt/autogpt/core/learning/__init__.py
@@ -24,14 +24,20 @@ class ExperienceLearner:
         self._model_path = Path(__file__).with_name("experience_model.json")
         self._model, self._trained_records = self._load_model()
 
-    def learn_from_experience(self) -> None:
-        """Read past interactions from memory and update the model."""
+    def learn_from_experience(self) -> dict[str, float]:
+        """Read past interactions from memory and update the model.
+
+        Returns:
+            dict[str, float]: Mapping of command names to their learned
+                success weights. Returns the current model state even when no
+                update is performed so callers can always rely on the result.
+        """
         if not self._config.enabled:
-            return
+            return self._model
 
         records = list(self._memory) if self._memory is not None else []
         if not records or len(records) <= self._trained_records:
-            return
+            return self._model
 
         new_records = records[self._trained_records :]
 
@@ -60,6 +66,8 @@ class ExperienceLearner:
 
         self._trained_records = len(records)
         self._save_model()
+
+        return self._model
 
     def _load_model(self) -> tuple[dict[str, float], int]:
         if self._model_path.exists():

--- a/prompt_settings.yaml
+++ b/prompt_settings.yaml
@@ -1,0 +1,17 @@
+constraints: [
+  'Exclusively use the commands listed below.',
+  'You can only act proactively, and are unable to start background jobs or set up webhooks for yourself. Take this into account when planning your actions.',
+  'You are unable to interact with physical objects. If this is absolutely necessary to fulfill a task or objective or to complete a step, you must ask the user to do it for you. If the user refuses this, and there is no other way to achieve your goals, you must terminate to avoid wasting time and energy.'
+]
+resources: [
+  'Internet access for searches and information gathering.',
+  'The ability to read and write files.',
+  'You are a Large Language Model, trained on millions of pages of text, including a lot of factual knowledge. Make use of this factual knowledge to avoid unnecessary gathering of information.'
+]
+best_practices: [
+  'Continuously review and analyze your actions to ensure you are performing to the best of your abilities.',
+  'Constructively self-criticize your big-picture behavior constantly.',
+  'Reflect on past decisions and strategies to refine your approach.',
+  'Every command has a cost, so be smart and efficient. Aim to complete tasks in the least number of steps.',
+  'Only make use of your information gathering abilities to find information that you don''t yet have knowledge of.'
+]

--- a/tests/dummy_packages/docx/__init__.py
+++ b/tests/dummy_packages/docx/__init__.py
@@ -1,0 +1,1 @@
+# dummy docx package for tests

--- a/tests/dummy_packages/events/__init__.py
+++ b/tests/dummy_packages/events/__init__.py
@@ -1,0 +1,8 @@
+def create_event_bus(*args, **kwargs):
+    class Bus:
+        def publish(self, *args, **kwargs):
+            pass
+    return Bus()
+
+def set_event_bus(bus):
+    pass

--- a/tests/dummy_packages/events/client.py
+++ b/tests/dummy_packages/events/client.py
@@ -1,0 +1,5 @@
+class EventClient:
+    def __init__(self, bus):
+        self.bus = bus
+    def publish(self, *args, **kwargs):
+        pass

--- a/tests/dummy_packages/openapi_python_client/__init__.py
+++ b/tests/dummy_packages/openapi_python_client/__init__.py
@@ -1,0 +1,2 @@
+class Config:
+    pass

--- a/tests/dummy_packages/openapi_python_client/config.py
+++ b/tests/dummy_packages/openapi_python_client/config.py
@@ -1,0 +1,2 @@
+class Config:
+    pass

--- a/tests/dummy_packages/pylatexenc/__init__.py
+++ b/tests/dummy_packages/pylatexenc/__init__.py
@@ -1,0 +1,1 @@
+# dummy pylatexenc package for tests

--- a/tests/dummy_packages/pylatexenc/latex2text/__init__.py
+++ b/tests/dummy_packages/pylatexenc/latex2text/__init__.py
@@ -1,0 +1,3 @@
+class LatexNodes2Text:
+    def latex_to_text(self, s):
+        return s

--- a/tests/dummy_packages/pypdf/__init__.py
+++ b/tests/dummy_packages/pypdf/__init__.py
@@ -1,0 +1,1 @@
+# dummy pypdf package for tests

--- a/tests/dummy_packages/spacy/__init__.py
+++ b/tests/dummy_packages/spacy/__init__.py
@@ -1,0 +1,1 @@
+# dummy spacy package for tests

--- a/tests/test_experience_learning.py
+++ b/tests/test_experience_learning.py
@@ -1,0 +1,92 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from autogpt.agents.agent import Agent, AgentConfiguration, AgentSettings
+from autogpt.config import AIProfile, Config
+from autogpt.models.command import Command
+from autogpt.models.command_registry import CommandRegistry
+from autogpt.file_storage.local import LocalFileStorage, FileStorageConfiguration
+from autogpt.models.action_history import Action
+
+
+class DummyProvider:
+    def count_tokens(self, text: str, model_name: str) -> int:
+        return len(text)
+
+    def get_token_limit(self, model_name: str) -> int:
+        return 1000
+
+    def get_tokenizer(self, model_name: str):
+        class _Tok:
+            def encode(self, text):
+                return list(text)
+
+            def decode(self, tokens):
+                return "".join(tokens)
+
+        return _Tok()
+
+    async def create_chat_completion(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_learning_disables_failing_command(tmp_path):
+    cfg = Config()
+    cfg.fast_llm = "gpt-3.5-turbo"
+    cfg.smart_llm = "gpt-3.5-turbo"
+
+    storage = LocalFileStorage(
+        FileStorageConfiguration(root=tmp_path, restrict_to_root=False)
+    )
+    storage.initialize()
+
+    command_registry = CommandRegistry()
+
+    ai_profile = AIProfile(ai_name="Test", ai_role="Test", ai_goals=[])
+    agent_settings = AgentSettings(
+        name="Agent",
+        description="",
+        agent_id="test-agent",
+        ai_profile=ai_profile,
+        config=AgentConfiguration(
+            fast_llm=cfg.fast_llm,
+            smart_llm=cfg.smart_llm,
+            allow_fs_access=True,
+            plugins=[],
+        ),
+        prompt_config=Agent.default_settings.prompt_config.copy(deep=True),
+        history=Agent.default_settings.history.copy(deep=True),
+    )
+
+    agent = Agent(
+        settings=agent_settings,
+        llm_provider=DummyProvider(),
+        command_registry=command_registry,
+        file_storage=storage,
+        legacy_config=cfg,
+    )
+    agent.config.learning.enabled = True
+    agent.config.learning.learning_rate = 1.0
+
+    # avoid network calls during compression
+    object.__setattr__(agent.event_history, "handle_compression", AsyncMock())
+
+    def fail_command(*, agent):
+        raise RuntimeError("fail")
+
+    cmd = Command(
+        name="fail",
+        description="failing command",
+        method=fail_command,
+        parameters=[],
+    )
+    agent.command_registry.register(cmd)
+
+    assert any(c.name == "fail" for c in agent.command_registry.list_available_commands(agent))
+
+    agent.event_history.register_action(Action(name="fail", args={}, reasoning=""))
+    await agent.execute("fail")
+
+    assert all(c.name != "fail" for c in agent.command_registry.list_available_commands(agent))


### PR DESCRIPTION
## Summary
- return updated success weights from `ExperienceLearner.learn_from_experience`
- use learned weights to toggle command availability inside `Agent.execute`
- add regression test confirming failing commands become unavailable after learning

## Testing
- `PYTHONPATH=autogpts/autogpt:tests/dummy_packages pytest tests/test_experience_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab80c1d10c832fbc37aeaaa41bf3ac