### PR TITLE
feat: add async task queue with conflict resolution

### DIFF
--- a/evolution/genesis_team/__init__.py
+++ b/evolution/genesis_team/__init__.py
@@ -5,6 +5,7 @@ from .archaeologist import Archaeologist
 from .tdd_dev import TDDDeveloper
 from .qa import QA
 from .manager import GenesisTeamManager
+from .conflict import ConflictResolver
 
 __all__ = [
     "Sentinel",
@@ -12,4 +13,5 @@ __all__ = [
     "TDDDeveloper",
     "QA",
     "GenesisTeamManager",
+    "ConflictResolver",
 ]

--- a/evolution/genesis_team/conflict.py
+++ b/evolution/genesis_team/conflict.py
@@ -1,0 +1,45 @@
+"""Conflict detection and resolution for Genesis team."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class ConflictResolver:
+    """Detects conflicts in agent outputs and coordinates resolution."""
+
+    history: List[str] = field(default_factory=list)
+
+    def detect(self, output: str) -> bool:
+        """Return True if the output contains signs of conflict."""
+
+        lowered = output.lower()
+        keywords = ["conflict", "version mismatch", "overlap", "error"]
+        return any(keyword in lowered for keyword in keywords)
+
+    def resolve(self, agent_name: str, logs: Dict[str, str]) -> str:
+        """Resolve detected conflicts by rolling back or merging.
+
+        Parameters
+        ----------
+        agent_name
+            Name of the agent whose output was most recently produced.
+        logs
+            Mapping of agent names to their output logs.
+
+        Returns
+        -------
+        str
+            Decision summary, either a merge or rollback description.
+        """
+
+        output = logs[agent_name]
+        if self.detect(output):
+            logs[agent_name] = f"ROLLED BACK: {output}"
+            decision = f"{agent_name}: rollback"
+        else:
+            decision = f"{agent_name}: merge"
+        self.history.append(decision)
+        return decision

--- a/evolution/genesis_team/manager.py
+++ b/evolution/genesis_team/manager.py
@@ -2,44 +2,100 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List
 
 from .sentinel import Sentinel
 from .archaeologist import Archaeologist
 from .tdd_dev import TDDDeveloper
 from .qa import QA
+from .conflict import ConflictResolver
+
+
+@dataclass
+class _AgentInfo:
+    """Container holding agent execution metadata."""
+
+    agent: object
+    capability: int = 1
+    load: int = 0
 
 
 @dataclass
 class GenesisTeamManager:
     """Orchestrates the Genesis team agents.
 
-    The manager instantiates each agent and provides a :meth:`run` method
-    which executes them sequentially, collecting their outputs. The order of
-    execution is Sentinel -> Archaeologist -> TDDDeveloper -> QA. Agent
-    instances can be provided for testing purposes; otherwise defaults are
-    created.
+    The manager instantiates each agent and provides an asynchronous
+    :meth:`run` method which schedules agents on a capability-aware task
+    queue. Agents are executed concurrently and, after each completes, a
+    conflict resolution step is triggered to merge or roll back results.
+    Decision summaries are stored in :attr:`decision_log`.
     """
 
     sentinel: Sentinel = field(default_factory=Sentinel)
     archaeologist: Archaeologist = field(default_factory=Archaeologist)
     tdd_dev: TDDDeveloper = field(default_factory=TDDDeveloper)
     qa: QA = field(default_factory=QA)
+    max_workers: int = 4
+    decision_log: List[str] = field(default_factory=list)
+    conflict: ConflictResolver = field(default_factory=ConflictResolver)
 
-    def run(self) -> Dict[str, str]:
-        """Execute all agents and return their logs.
+    def __post_init__(self) -> None:
+        self._agents: Dict[str, _AgentInfo] = {
+            "sentinel": _AgentInfo(
+                self.sentinel,
+                getattr(self.sentinel, "capability", 1),
+                getattr(self.sentinel, "load", 0),
+            ),
+            "archaeologist": _AgentInfo(
+                self.archaeologist,
+                getattr(self.archaeologist, "capability", 1),
+                getattr(self.archaeologist, "load", 0),
+            ),
+            "tdd_developer": _AgentInfo(
+                self.tdd_dev,
+                getattr(self.tdd_dev, "capability", 1),
+                getattr(self.tdd_dev, "load", 0),
+            ),
+            "qa": _AgentInfo(
+                self.qa,
+                getattr(self.qa, "capability", 1),
+                getattr(self.qa, "load", 0),
+            ),
+        }
 
-        Returns
-        -------
-        Dict[str, str]
-            A dictionary mapping agent names to their output. The insertion
-            order reflects the execution order.
-        """
+    def _priority(self, info: _AgentInfo) -> float:
+        """Compute scheduling priority based on capability and load."""
+
+        return info.load / info.capability
+
+    async def run(self) -> Dict[str, str]:
+        """Execute all agents concurrently and return their logs."""
 
         logs: Dict[str, str] = {}
-        logs["sentinel"] = self.sentinel.perform()
-        logs["archaeologist"] = self.archaeologist.perform()
-        logs["tdd_developer"] = self.tdd_dev.perform()
-        logs["qa"] = self.qa.perform()
+        queue: asyncio.PriorityQueue = asyncio.PriorityQueue()
+        for name, info in self._agents.items():
+            queue.put_nowait((self._priority(info), name, info))
+
+        async def worker() -> None:
+            while True:
+                priority, agent_name, info = await queue.get()
+                if agent_name is None:
+                    queue.task_done()
+                    break
+                result = await asyncio.to_thread(info.agent.perform)
+                logs[agent_name] = result
+                decision = self.conflict.resolve(agent_name, logs)
+                self.decision_log.append(decision)
+                queue.task_done()
+
+        workers = [
+            asyncio.create_task(worker())
+            for _ in range(min(self.max_workers, len(self._agents)))
+        ]
+        await queue.join()
+        for _ in workers:
+            await queue.put((float("inf"), None, None))
+        await asyncio.gather(*workers)
         return logs

--- a/tests/genesis_team/test_manager.py
+++ b/tests/genesis_team/test_manager.py
@@ -1,0 +1,55 @@
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution import Agent
+from evolution.genesis_team.manager import GenesisTeamManager
+
+
+class DummyAgent(Agent):
+    def __init__(self, output: str = "done", delay: float = 0.1):
+        self.output = output
+        self.delay = delay
+
+    def perform(self) -> str:  # type: ignore[override]
+        time.sleep(self.delay)
+        return self.output
+
+
+def test_async_concurrency():
+    """Manager should execute agents concurrently to reduce runtime."""
+
+    delay = 0.3
+    agents = [DummyAgent(delay=delay) for _ in range(4)]
+    manager = GenesisTeamManager(
+        sentinel=agents[0],
+        archaeologist=agents[1],
+        tdd_dev=agents[2],
+        qa=agents[3],
+        max_workers=4,
+    )
+    start = time.perf_counter()
+    asyncio.run(manager.run())
+    duration = time.perf_counter() - start
+    assert duration < delay * len(agents)  # would be serial runtime
+
+
+def test_conflict_resolution():
+    """ConflictResolver should roll back when conflicts detected."""
+
+    sentinel = DummyAgent(output="version conflict detected")
+    archaeologist = DummyAgent()
+    tdd_dev = DummyAgent()
+    qa = DummyAgent()
+    manager = GenesisTeamManager(
+        sentinel=sentinel,
+        archaeologist=archaeologist,
+        tdd_dev=tdd_dev,
+        qa=qa,
+        max_workers=1,
+    )
+    asyncio.run(manager.run())
+    assert any("rollback" in d for d in manager.decision_log)


### PR DESCRIPTION
## Summary
- build capability-aware task queue in `GenesisTeamManager` and make `run` async for concurrent execution
- introduce `ConflictResolver` module to detect log conflicts and record merge/rollback decisions
- exercise manager concurrency and conflict handling with new unit tests

## Testing
- `pytest tests/genesis_team/test_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9565cc98832f9322a3bbee4881d7