### PR TITLE
feat: support multimodal retrieval and RAG

### DIFF
--- a/capability/librarian.py
+++ b/capability/librarian.py
@@ -28,18 +28,40 @@ class Librarian:
         code: str,
         metadata: Dict,
         embedding: List[float] | None = None,
+        vector_type: str = "text",
     ) -> None:
         """Store a skill and optionally index its embedding."""
         self.library.add_skill(name, code, metadata)
         if self.index and embedding is not None:
-            self.index.add(name, embedding, metadata)
+            self.index.add(name, embedding, metadata, vector_type=vector_type)
 
-    def search(self, embedding: List[float], n_results: int = 1) -> List[str]:
-        """Search skills by embedding."""
+    def search(
+        self,
+        embedding: List[float],
+        n_results: int = 1,
+        vector_type: str = "text",
+        return_content: bool = False,
+    ) -> List[str]:
+        """Search skills by embedding.
+
+        Parameters
+        ----------
+        embedding: List[float]
+            The embedding to query with.
+        n_results: int
+            Number of results to retrieve.
+        vector_type: str
+            Which vector space to query in.
+        return_content: bool
+            When ``True`` return the document contents instead of IDs.
+        """
         if not self.index:
             raise RuntimeError("Vector index not available")
-        result = self.index.query(embedding, n_results)
-        return result.get("ids", [[]])[0]
+        result = self.index.query(embedding, n_results, vector_type=vector_type)
+        ids = result.get("ids", [[]])[0]
+        if return_content:
+            return [self.get_skill(name)[0] for name in ids]
+        return ids
 
     def get_skill(self, name: str):
         return self.library.get_skill(name)

--- a/rag_retriever.py
+++ b/rag_retriever.py
@@ -1,0 +1,46 @@
+"""Simple Retrieval Augmented Generation helper."""
+from __future__ import annotations
+
+from typing import Callable, List
+
+from capability.librarian import Librarian
+
+
+class RAGRetriever:
+    """Perform retrieval augmented generation using the skill library."""
+
+    def __init__(self, librarian: Librarian) -> None:
+        self.librarian = librarian
+
+    def generate(
+        self,
+        prompt: str,
+        query_embedding: List[float],
+        llm_callable: Callable[[str], str],
+        n_results: int = 3,
+        vector_type: str = "text",
+    ) -> str:
+        """Generate LLM output with retrieved context.
+
+        Parameters
+        ----------
+        prompt: str
+            The user prompt/question.
+        query_embedding: List[float]
+            Embedding of the query used for similarity search.
+        llm_callable: Callable[[str], str]
+            Function that takes the final prompt and returns generated text.
+        n_results: int
+            Number of documents to retrieve.
+        vector_type: str
+            Vector space to query (e.g. ``"text"`` or ``"image"``).
+        """
+        docs = self.librarian.search(
+            query_embedding,
+            n_results=n_results,
+            vector_type=vector_type,
+            return_content=True,
+        )
+        context = "\n".join(docs)
+        final_prompt = f"{context}\n\n{prompt}" if context else prompt
+        return llm_callable(final_prompt)


### PR DESCRIPTION
## Summary
- extend VectorIndex for multiple vector types and image embeddings
- expose vector type and content retrieval in Librarian
- add RAGRetriever to combine search results with LLM prompts

## Testing
- `pytest` (fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')


------
https://chatgpt.com/codex/tasks/task_e_68ab9768f5c4832fbcbd51deaac292b7