### PR TITLE
Add simple algorithm storage library

### DIFF
--- a/algorithm_library/__init__.py
+++ b/algorithm_library/__init__.py
@@ -1,0 +1,3 @@
+from .library import AlgorithmLibrary
+
+__all__ = ["AlgorithmLibrary"]

--- a/algorithm_library/library.py
+++ b/algorithm_library/library.py
@@ -1,0 +1,29 @@
+"""Simple in-memory algorithm storage."""
+
+from collections.abc import Callable
+from typing import Dict, List
+
+
+class AlgorithmLibrary:
+    """Stores callables representing algorithms keyed by name."""
+
+    def __init__(self) -> None:
+        self._algorithms: Dict[str, Callable] = {}
+
+    def add(self, name: str, algorithm: Callable) -> None:
+        """Add an algorithm under a unique name."""
+        if name in self._algorithms:
+            raise ValueError(f"Algorithm '{name}' already exists")
+        self._algorithms[name] = algorithm
+
+    def get(self, name: str) -> Callable:
+        """Retrieve an algorithm by name."""
+        return self._algorithms[name]
+
+    def list(self) -> List[str]:
+        """List the names of stored algorithms."""
+        return list(self._algorithms.keys())
+
+    def remove(self, name: str) -> None:
+        """Remove a stored algorithm."""
+        del self._algorithms[name]

--- a/tests/test_algorithm_library.py
+++ b/tests/test_algorithm_library.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from algorithm_library import AlgorithmLibrary
+import pytest
+
+
+def test_add_and_get_algorithm():
+    library = AlgorithmLibrary()
+
+    def sample(x):
+        return x + 1
+
+    library.add("increment", sample)
+    retrieved = library.get("increment")
+    assert retrieved(1) == 2
+
+
+def test_list_algorithms():
+    library = AlgorithmLibrary()
+    library.add("a", lambda x: x)
+    library.add("b", lambda x: x * 2)
+    assert set(library.list()) == {"a", "b"}
+
+
+def test_remove_algorithm():
+    library = AlgorithmLibrary()
+    library.add("a", lambda x: x)
+    library.remove("a")
+    assert library.list() == []
+
+
+def test_add_duplicate_algorithm_raises():
+    library = AlgorithmLibrary()
+    library.add("a", lambda x: x)
+    with pytest.raises(ValueError):
+        library.add("a", lambda x: x)


### PR DESCRIPTION
## Summary
- create `AlgorithmLibrary` for storing callables by name
- add tests for adding, retrieving, listing, removing, and duplicate handling

## Testing
- `pytest tests/test_algorithm_library.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab9a59d0f0832fb3fbac12b25a2d90