### PR TITLE
Add concurrent skill retrieval and distributed search scaffold

### DIFF
--- a/benchmark/skill_retrieval_benchmark.py
+++ b/benchmark/skill_retrieval_benchmark.py
@@ -1,0 +1,71 @@
+"""Micro-benchmark for sequential vs threaded skill retrieval."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List
+import sys
+
+# Ensure repository root on path for direct execution
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from capability.librarian import Librarian
+
+
+class DummyIndex:
+    def __init__(self, ids: List[str]):
+        self.ids = ids
+
+    def query(self, embedding, n_results, vector_type="text"):
+        return {"ids": [self.ids[:n_results]]}
+
+
+def _create_skills(base: Path, n: int) -> List[str]:
+    skills_dir = base / "skills"
+    skills_dir.mkdir()
+    names = []
+    # Make skill files moderately large to better showcase I/O parallelism
+    payload = "x" * 10000
+    for i in range(n):
+        name = f"skill{i}"
+        (skills_dir / f"{name}.py").write_text(
+            f"def {name}():\n    return {i}\n# {payload}\n", encoding="utf-8"
+        )
+        (skills_dir / f"{name}.json").write_text("{}", encoding="utf-8")
+        names.append(name)
+    return names
+
+
+def benchmark(n: int = 100) -> dict[str, float]:
+    with TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        names = _create_skills(repo, n)
+        lib = Librarian(str(repo))
+        lib.index = DummyIndex(names)
+        # Simulate I/O latency to highlight parallel speedup
+        original_get_skill = lib.get_skill
+
+        def delayed(name: str):
+            time.sleep(0.005)
+            return original_get_skill(name)
+
+        lib.get_skill = delayed
+        embedding = [0.0]
+
+        start = time.perf_counter()
+        lib.search(embedding, n_results=n, return_content=True, max_workers=1)
+        sequential = time.perf_counter() - start
+
+        start = time.perf_counter()
+        lib.search(embedding, n_results=n, return_content=True)
+        parallel = time.perf_counter() - start
+
+        return {"sequential": sequential, "parallel": parallel}
+
+
+if __name__ == "__main__":
+    results = benchmark()
+    print(
+        f"sequential: {results['sequential']:.4f}s, parallel: {results['parallel']:.4f}s"
+    )

--- a/capability/distributed_search.py
+++ b/capability/distributed_search.py
@@ -1,0 +1,48 @@
+"""Scaffolding for distributed skill search using Spark or MapReduce."""
+from __future__ import annotations
+
+from typing import List
+
+
+def spark_search(vector_index_path: str, query_embedding: List[float], n_results: int = 3):
+    """Example scaffold for running a distributed search on a Spark cluster.
+
+    Parameters
+    ----------
+    vector_index_path: str
+        Path to a persisted vector index dataset accessible to the cluster.
+    query_embedding: List[float]
+        Embedding to query with.
+    n_results: int
+        Number of results to return.
+
+    Notes
+    -----
+    This function is a placeholder demonstrating how Spark could be used to
+    perform the similarity search in parallel across a cluster. A full
+    implementation would load the vector index as a DataFrame and compute
+    cosine similarities using Spark SQL or UDFs.
+    """
+    try:
+        from pyspark.sql import SparkSession
+    except Exception as e:  # pragma: no cover - pyspark optional
+        raise RuntimeError("pyspark is required for spark_search") from e
+
+    spark = SparkSession.builder.appName("SkillSearch").getOrCreate()
+    try:
+        # TODO: Load vectors and compute similarity.
+        pass
+    finally:
+        spark.stop()
+
+
+def map_reduce_search(data_path: str, query_embedding: List[float], n_results: int = 3):
+    """Placeholder for a MapReduce-style distributed search.
+
+    This function outlines how a map and reduce phase could be structured to
+    distribute the workload across a cluster. The map phase would compute
+    similarities for partitions of the dataset, and the reduce phase would
+    aggregate the top results.
+    """
+    # TODO: Implement using a framework like Hadoop streaming or mrjob.
+    raise NotImplementedError("map_reduce_search is a scaffold and not implemented")


### PR DESCRIPTION
## Summary
- add `ThreadPoolExecutor` to fetch skill contents concurrently in `Librarian.search`
- scaffold Spark and MapReduce search helpers for cluster execution
- add benchmark comparing sequential vs threaded skill loading

## Testing
- `python benchmark/skill_retrieval_benchmark.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_68abb076b114832f9abd5fe87ac749b4