### PR TITLE
Vectorize ResourceRL with optional GPU and benchmarking

### DIFF
--- a/benchmark/resource_rl_benchmark.py
+++ b/benchmark/resource_rl_benchmark.py
@@ -1,0 +1,52 @@
+"""Benchmark CPU vs GPU training and evaluation for ResourceRL."""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+import numpy as np
+import torch
+
+from evolution.resource_rl import ResourceRL, Transition
+
+
+def _generate_transitions(n: int = 1000) -> list[Transition]:
+    """Create synthetic transitions for benchmarking."""
+
+    rng = np.random.default_rng(0)
+    states = rng.uniform(0, 100, size=(n, 2)).astype(np.float32)
+    agent = ResourceRL()
+    transitions: list[Transition] = []
+    for state in states:
+        for action in range(3):
+            reward = agent._rule_reward(state, action)
+            transitions.append(Transition(state, action, reward))
+    return transitions
+
+
+def _benchmark(device: str) -> None:
+    agent = ResourceRL(device=device)
+    transitions = _generate_transitions()
+
+    start = time.perf_counter()
+    agent.train(transitions, epochs=10)
+    train_time = time.perf_counter() - start
+
+    sample_states: Iterable[tuple[float, float]] = (
+        (float(i % 100), float((i * 2) % 100)) for i in range(1000)
+    )
+    start = time.perf_counter()
+    agent.evaluate(sample_states)
+    eval_time = time.perf_counter() - start
+
+    print(f"{device} train time: {train_time:.3f}s, eval time: {eval_time:.3f}s")
+
+
+if __name__ == "__main__":
+    _benchmark("cpu")
+    if torch.cuda.is_available():
+        _benchmark("cuda")
+    else:
+        print("CUDA/ROCm GPU not available; skipping GPU benchmark.")
+

--- a/docs/resource_rl_benchmark.md
+++ b/docs/resource_rl_benchmark.md
@@ -1,0 +1,22 @@
+# ResourceRL CPU/GPU Benchmark
+
+This benchmark compares training and evaluation performance of the
+``ResourceRL`` agent on CPU versus GPU.
+
+## Hardware requirements
+
+- **CPU:** Any modern processor.
+- **Optional GPU:** NVIDIA GPU with CUDA or AMD GPU with ROCm. PyTorch must be
+  installed with the appropriate backend and at least 1 GB of memory is
+  recommended.
+
+## Running the benchmark
+
+```bash
+python benchmark/resource_rl_benchmark.py
+```
+
+The script executes the workload on the CPU and, when available, on a
+CUDA/ROCm-capable GPU.  It reports the runtime for both paths, allowing you to
+compare the speedup achieved with hardware acceleration.
+


### PR DESCRIPTION
## Summary
- vectorize ResourceRL training and evaluation with NumPy
- add optional CUDA/ROCm execution via PyTorch device selection with CPU fallback
- provide benchmark script and documentation for CPU vs GPU performance

## Testing
- `python3 -m py_compile evolution/resource_rl.py benchmark/resource_rl_benchmark.py`
- `.venv/bin/pytest tests/test_resource_model.py`
- `PYTHONPATH=. .venv/bin/python benchmark/resource_rl_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb1ee1b24832fb8fc3cda9c8ad5f7