### PR TITLE
Add feature extraction and baseline model training

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,5 +1,6 @@
 """Monitoring utilities for AutoGPT."""
 
 from .storage import TimeSeriesStorage
+from .feature_extractor import FeatureExtractor
 
-__all__ = ["TimeSeriesStorage"]
+__all__ = ["TimeSeriesStorage", "FeatureExtractor"]

--- a/monitoring/feature_extractor.py
+++ b/monitoring/feature_extractor.py
@@ -1,0 +1,50 @@
+"""Feature extraction utilities for converting raw log lines into numerical vectors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+class FeatureExtractor:
+    """Convert collections of log strings into numerical feature vectors.
+
+    The extractor internally uses :class:`~sklearn.feature_extraction.text.TfidfVectorizer`
+    to transform raw log text into a sparse matrix of TF-IDF features.
+    """
+
+    def __init__(self, **vectorizer_kwargs) -> None:
+        self.vectorizer = TfidfVectorizer(**vectorizer_kwargs)
+
+    # ------------------------------------------------------------------
+    # fitting and transforming
+    # ------------------------------------------------------------------
+    def fit(self, logs: Iterable[str]) -> "FeatureExtractor":
+        """Learn the vocabulary and IDF weights from *logs*."""
+        self.vectorizer.fit(list(logs))
+        return self
+
+    def transform(self, logs: Iterable[str]):
+        """Transform *logs* into a sparse feature matrix."""
+        return self.vectorizer.transform(list(logs))
+
+    def fit_transform(self, logs: Iterable[str]):
+        """Fit to *logs* then return the transformed matrix."""
+        return self.vectorizer.fit_transform(list(logs))
+
+    # ------------------------------------------------------------------
+    # persistence
+    # ------------------------------------------------------------------
+    def save(self, path: Path | str) -> None:
+        """Serialize the underlying vectorizer to *path*."""
+        joblib.dump(self.vectorizer, Path(path))
+
+    @classmethod
+    def load(cls, path: Path | str) -> "FeatureExtractor":
+        """Load a previously saved extractor from *path*."""
+        inst = cls()
+        inst.vectorizer = joblib.load(Path(path))
+        return inst

--- a/monitoring/train_baselines.py
+++ b/monitoring/train_baselines.py
@@ -1,0 +1,117 @@
+"""Train baseline models on log data.
+
+This script expects a CSV file containing at least two columns:
+``log`` with the raw log text and ``target`` with the numerical target value.
+It splits the data into train/validation/test sets, trains a linear regression
+and a random forest regressor, selects the best model on the validation set,
+and serializes the model together with the feature extractor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Tuple
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+from .feature_extractor import FeatureExtractor
+
+
+# ---------------------------------------------------------------------------
+# data loading
+# ---------------------------------------------------------------------------
+
+def load_dataset(path: Path | str) -> Tuple[list[str], list[float]]:
+    """Return log texts and targets from CSV *path*."""
+    df = pd.read_csv(path)
+    if "log" not in df.columns or "target" not in df.columns:
+        raise ValueError("CSV must contain 'log' and 'target' columns")
+    logs = df["log"].astype(str).tolist()
+    targets = df["target"].tolist()
+    return logs, targets
+
+
+# ---------------------------------------------------------------------------
+# training
+# ---------------------------------------------------------------------------
+
+def train_models(X, y) -> tuple:
+    """Train baseline models and return the best-performing one."""
+    X_train, X_tmp, y_train, y_tmp = train_test_split(X, y, test_size=0.4, random_state=42)
+    X_val, X_test, y_val, y_test = train_test_split(X_tmp, y_tmp, test_size=0.5, random_state=42)
+
+    models = {
+        "linear_regression": LinearRegression(),
+        "random_forest": RandomForestRegressor(random_state=42),
+    }
+
+    scores = {}
+    for name, model in models.items():
+        model.fit(X_train, y_train)
+        preds = model.predict(X_val)
+        scores[name] = mean_squared_error(y_val, preds)
+
+    best_name = min(scores, key=scores.get)
+    best_model = models[best_name]
+    test_score = mean_squared_error(y_test, best_model.predict(X_test))
+
+    return best_name, best_model, scores[best_name], test_score
+
+
+# ---------------------------------------------------------------------------
+# main entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train baseline models on log data")
+    parser.add_argument("csv", help="Path to CSV file containing log and target columns")
+    parser.add_argument(
+        "--output", default="monitoring/models", help="Directory to store serialized artifacts"
+    )
+    args = parser.parse_args()
+
+    logs, targets = load_dataset(args.csv)
+
+    extractor = FeatureExtractor()
+    features = extractor.fit_transform(logs)
+
+    model_name, model, val_mse, test_mse = train_models(features, targets)
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = int(time.time())
+    model_path = output_dir / f"{model_name}_{timestamp}.joblib"
+    vec_path = output_dir / f"feature_extractor_{timestamp}.joblib"
+    meta_path = output_dir / f"metadata_{timestamp}.json"
+
+    joblib.dump(model, model_path)
+    extractor.save(vec_path)
+    with open(meta_path, "w") as f:
+        json.dump(
+            {
+                "model": model_name,
+                "model_path": model_path.name,
+                "vectorizer_path": vec_path.name,
+                "val_mse": val_mse,
+                "test_mse": test_mse,
+                "timestamp": timestamp,
+            },
+            f,
+            indent=2,
+        )
+
+    print(f"Saved model to {model_path}")
+    print(f"Validation MSE: {val_mse:.4f}; Test MSE: {test_mse:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_feature_extractor.py
+++ b/tests/test_feature_extractor.py
@@ -1,0 +1,12 @@
+from monitoring.feature_extractor import FeatureExtractor
+
+
+def test_feature_extractor_transformations():
+    logs = ["error on line 1", "warning: disk full"]
+    extractor = FeatureExtractor()
+    matrix = extractor.fit_transform(logs)
+    assert matrix.shape[0] == 2
+
+    new_logs = ["error on line 2"]
+    new_matrix = extractor.transform(new_logs)
+    assert new_matrix.shape[0] == 1


### PR DESCRIPTION
## Summary
- add `FeatureExtractor` to convert raw logs into TF-IDF vectors
- implement training script to load logs, split dataset, train linear regression and random forest models, and persist artifacts with timestamps
- expose new utilities through `monitoring` package and basic tests

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68abb3627144832fb7e0816a119220c3