### PR TITLE
Add automated model retraining workflow

### DIFF
--- a/.github/workflows/model-retrain.yml
+++ b/.github/workflows/model-retrain.yml
@@ -1,0 +1,21 @@
+name: model-retrain
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  retrain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run retraining workflow
+        run: python -m monitoring.retraining_workflow

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,5 +1,6 @@
 """Monitoring utilities for AutoGPT."""
 
 from .storage import TimeSeriesStorage
+from .dataset_buffer import DatasetBuffer
 
-__all__ = ["TimeSeriesStorage"]
+__all__ = ["TimeSeriesStorage", "DatasetBuffer"]

--- a/monitoring/dataset_buffer.py
+++ b/monitoring/dataset_buffer.py
@@ -1,0 +1,51 @@
+"""SQLite-backed dataset buffer for accumulating logs."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict
+
+
+class DatasetBuffer:
+    """Store log entries in an SQLite database for later processing."""
+
+    def __init__(self, db_path: Path | str = "dataset_buffer.db") -> None:
+        self.db_path = Path(db_path)
+        self._conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                data TEXT
+            )
+            """
+        )
+        self._conn.commit()
+
+    def add_log(self, log: Dict[str, Any]) -> None:
+        """Persist a *log* entry into the buffer."""
+        cur = self._conn.cursor()
+        cur.execute("INSERT INTO logs (data) VALUES (?)", (json.dumps(log),))
+        self._conn.commit()
+
+    def fetch_logs(self) -> list[Dict[str, Any]]:
+        """Return all stored log entries."""
+        cur = self._conn.cursor()
+        cur.execute("SELECT data FROM logs ORDER BY id")
+        rows = cur.fetchall()
+        return [json.loads(r[0]) for r in rows]
+
+    def clear(self) -> None:
+        """Remove all log entries from the buffer."""
+        cur = self._conn.cursor()
+        cur.execute("DELETE FROM logs")
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/monitoring/retraining_workflow.py
+++ b/monitoring/retraining_workflow.py
@@ -1,0 +1,57 @@
+"""Automated data aggregation, model training and deployment workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+from .dataset_buffer import DatasetBuffer
+
+BASELINE_PATH = Path("models/baseline.json")
+
+
+def aggregate_data(buffer: DatasetBuffer) -> list[Dict]:
+    """Collect all logs from *buffer* for training."""
+    return buffer.fetch_logs()
+
+
+def train_model(logs: Iterable[Dict]) -> Dict[str, float]:
+    """Train a model from *logs* and return its metrics.
+
+    This placeholder implementation calculates the success rate where each
+    log contains a boolean ``success`` field.
+    """
+    logs_list = list(logs)
+    total = len(logs_list)
+    successes = sum(1 for log in logs_list if log.get("success"))
+    metric = successes / total if total else 0.0
+    return {"metric": metric}
+
+
+def evaluate_and_deploy(model: Dict[str, float], baseline_path: Path = BASELINE_PATH) -> bool:
+    """Deploy *model* if its metric exceeds the baseline metric.
+
+    Returns ``True`` if the model was deployed.
+    """
+    baseline_metric = 0.0
+    if baseline_path.exists():
+        baseline_metric = json.loads(baseline_path.read_text()).get("metric", 0.0)
+    if model["metric"] > baseline_metric:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        baseline_path.write_text(json.dumps(model))
+        return True
+    return False
+
+
+def main() -> None:
+    buffer = DatasetBuffer()
+    logs = aggregate_data(buffer)
+    model = train_model(logs)
+    improved = evaluate_and_deploy(model)
+    if improved:
+        buffer.clear()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_retraining_workflow.py
+++ b/tests/test_retraining_workflow.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from monitoring.dataset_buffer import DatasetBuffer
+from monitoring.retraining_workflow import (
+    aggregate_data,
+    evaluate_and_deploy,
+    train_model,
+)
+
+
+def test_dataset_buffer(tmp_path):
+    db_path = tmp_path / "buffer.db"
+    buffer = DatasetBuffer(db_path)
+    buffer.add_log({"success": True})
+    buffer.add_log({"success": False})
+    logs = aggregate_data(buffer)
+    assert len(logs) == 2
+    model = train_model(logs)
+    assert model["metric"] == 0.5
+    buffer.close()
+
+
+def test_evaluate_and_deploy(tmp_path):
+    baseline = tmp_path / "baseline.json"
+    # First deployment should succeed because baseline doesn't exist
+    model = {"metric": 0.8}
+    assert evaluate_and_deploy(model, baseline) is True
+    assert json.loads(baseline.read_text())["metric"] == 0.8
+    # Worse model should not be deployed
+    assert evaluate_and_deploy({"metric": 0.5}, baseline) is False
+    assert json.loads(baseline.read_text())["metric"] == 0.8


### PR DESCRIPTION
## Summary
- store logs in SQLite-backed dataset buffer
- add retraining workflow that aggregates logs, trains and deploys improved models
- schedule retraining via GitHub Actions

## Testing
- `python -m pytest tests/test_retraining_workflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abb369bec4832f83c6f811baae9f41