### PR TITLE
Add feature extraction and baseline model training utilities

### DIFF
--- a/ml/feature_extractor.py
+++ b/ml/feature_extractor.py
@@ -1,0 +1,37 @@
+"""Utilities for converting raw log lines into numerical feature vectors."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+import joblib
+
+
+class FeatureExtractor:
+    """Converts raw log strings into TF-IDF feature vectors.
+
+    The extractor wraps a ``TfidfVectorizer`` so that we can easily serialise the
+    fitted vocabulary and reuse it for future data.
+    """
+
+    def __init__(self) -> None:
+        self.vectorizer = TfidfVectorizer()
+
+    def fit_transform(self, logs: Iterable[str]):
+        """Fit the vectoriser on ``logs`` and return the transformed matrix."""
+        return self.vectorizer.fit_transform(list(logs))
+
+    def transform(self, logs: Iterable[str]):
+        """Transform ``logs`` using the fitted vectoriser."""
+        return self.vectorizer.transform(list(logs))
+
+    def save(self, path: str) -> None:
+        """Serialise the underlying vectoriser to ``path`` using ``joblib``."""
+        joblib.dump(self.vectorizer, path)
+
+    @classmethod
+    def load(cls, path: str) -> "FeatureExtractor":
+        """Load a previously saved extractor from ``path``."""
+        instance = cls()
+        instance.vectorizer = joblib.load(path)
+        return instance

--- a/ml/train_models.py
+++ b/ml/train_models.py
@@ -1,0 +1,74 @@
+"""Train baseline models on log data.
+
+This script expects a CSV file with two columns:
+``text`` containing the raw log message and ``target`` containing the numeric
+value to predict.  It splits the dataset into train, validation and test sets,
+trains a simple model and stores the model together with the fitted
+``FeatureExtractor``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+from .feature_extractor import FeatureExtractor
+
+
+def load_data(path: str):
+    df = pd.read_csv(path)
+    if "text" not in df.columns or "target" not in df.columns:
+        raise ValueError("CSV must contain 'text' and 'target' columns")
+    return df["text"].astype(str).tolist(), df["target"].values
+
+
+def train_model(model_name: str, X_train, y_train):
+    if model_name == "linear":
+        model = LinearRegression()
+    else:
+        model = RandomForestRegressor(random_state=42)
+    model.fit(X_train, y_train)
+    return model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train baseline models on log data")
+    parser.add_argument("data", help="Path to CSV file with columns 'text' and 'target'")
+    parser.add_argument("--model", choices=["linear", "random_forest"], default="linear")
+    parser.add_argument("--version", default="v1", help="Version string for saved artifacts")
+    args = parser.parse_args()
+
+    texts, targets = load_data(args.data)
+
+    extractor = FeatureExtractor()
+    X = extractor.fit_transform(texts)
+
+    X_train, X_temp, y_train, y_temp = train_test_split(X, targets, test_size=0.4, random_state=42)
+    X_val, X_test, y_val, y_test = train_test_split(X_temp, y_temp, test_size=0.5, random_state=42)
+
+    model = train_model(args.model, X_train, y_train)
+
+    val_pred = model.predict(X_val)
+    test_pred = model.predict(X_test)
+    val_mse = mean_squared_error(y_val, val_pred)
+    test_mse = mean_squared_error(y_test, test_pred)
+    print(f"Validation MSE: {val_mse:.4f}")
+    print(f"Test MSE: {test_mse:.4f}")
+
+    artifacts_dir = Path("artifacts") / args.version
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, artifacts_dir / f"{args.model}_model.joblib")
+    extractor.save(str(artifacts_dir / "feature_extractor.joblib"))
+    with open(artifacts_dir / "metrics.txt", "w") as f:
+        f.write(f"Validation MSE: {val_mse}\nTest MSE: {test_mse}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add FeatureExtractor module converting log lines to TF-IDF vectors
- provide train_models script to split data, train regression or random forest, and save artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spacy')*


------
https://chatgpt.com/codex/tasks/task_e_68abb5ab6690832f8a71c96782d8a3c4