### PR TITLE
Add automated model retraining pipeline

### DIFF
--- a/docs/retraining_pipeline.md
+++ b/docs/retraining_pipeline.md
@@ -1,0 +1,21 @@
+# Retraining Pipeline
+
+The `ml/retraining_pipeline.py` module automates model updates using new log
+entries.
+
+1. **Accumulate logs** – new logs are stored in `data/new_logs.csv` and are
+   appended to the aggregated dataset `data/dataset.csv`.
+2. **Retrain and evaluate** – the dataset is used to train a fresh model via
+   `ml/train_models.py`. The resulting metrics are compared against the current
+   baseline located in `artifacts/current/`.
+3. **Deploy on improvement** – if the new model achieves a lower test MSE, it
+   replaces the existing model in `artifacts/current/`.
+
+To execute the pipeline periodically, use the provided `retrain_cron.sh` script
+in a cron job or workflow:
+
+```cron
+0 0 * * * /path/to/retrain_cron.sh >> /path/to/retrain.log 2>&1
+```
+
+This runs the pipeline every day at midnight.

--- a/ml/retraining_pipeline.py
+++ b/ml/retraining_pipeline.py
@@ -1,0 +1,104 @@
+"""Automated model retraining pipeline.
+
+This module accumulates new log data, retrains the model, evaluates it
+against the current baseline, and deploys the new model if it performs
+better.  It is intended to be triggered periodically (for example by a
+cron job).
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+import subprocess
+
+import pandas as pd
+
+DATA_DIR = Path("data")
+DATASET = DATA_DIR / "dataset.csv"
+NEW_LOGS = DATA_DIR / "new_logs.csv"
+ARTIFACTS = Path("artifacts")
+CURRENT = ARTIFACTS / "current"
+
+
+def accumulate_logs() -> None:
+    """Append new logs to the main dataset and clear the buffer file.
+
+    New logs are expected in ``data/new_logs.csv`` with columns ``text`` and
+    ``target``.  They are appended to ``data/dataset.csv`` which serves as the
+    aggregated dataset for training.  The buffer file is removed afterwards.
+    """
+    if not NEW_LOGS.exists():
+        return
+
+    DATA_DIR.mkdir(exist_ok=True)
+    if DATASET.exists():
+        df = pd.read_csv(DATASET)
+    else:
+        df = pd.DataFrame(columns=["text", "target"])
+    new_df = pd.read_csv(NEW_LOGS)
+    df = pd.concat([df, new_df], ignore_index=True)
+    df.to_csv(DATASET, index=False)
+    NEW_LOGS.unlink()
+
+
+def parse_test_mse(metrics_file: Path) -> float:
+    with open(metrics_file, "r") as f:
+        for line in f:
+            if line.startswith("Test MSE:"):
+                return float(line.split(":", 1)[1].strip())
+    raise ValueError("Test MSE not found in metrics file")
+
+
+def train_and_evaluate(version: str) -> Path:
+    """Train a model using the aggregated dataset and return metrics path."""
+    subprocess.run(
+        [
+            sys.executable,
+            "ml/train_models.py",
+            str(DATASET),
+            "--model",
+            "linear",
+            "--version",
+            version,
+        ],
+        check=True,
+    )
+    return ARTIFACTS / version / "metrics.txt"
+
+
+def deploy_if_better(version: str, metrics_file: Path) -> None:
+    """Deploy the trained model if it outperforms the current baseline."""
+    new_metric = parse_test_mse(metrics_file)
+
+    baseline_metric = float("inf")
+    baseline_file = CURRENT / "metrics.txt"
+    if baseline_file.exists():
+        baseline_metric = parse_test_mse(baseline_file)
+
+    if new_metric < baseline_metric:
+        if CURRENT.exists():
+            shutil.rmtree(CURRENT)
+        shutil.copytree(ARTIFACTS / version, CURRENT)
+        print(
+            f"Deployed new model version {version} (Test MSE {new_metric:.4f})"
+        )
+    else:
+        print(
+            f"Model not deployed: {new_metric:.4f} >= {baseline_metric:.4f}"
+        )
+
+
+def main() -> None:
+    accumulate_logs()
+    if not DATASET.exists():
+        print("No dataset available for training")
+        return
+    version = datetime.utcnow().strftime("v%Y%m%d%H%M%S")
+    metrics_file = train_and_evaluate(version)
+    deploy_if_better(version, metrics_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/retrain_cron.sh
+++ b/retrain_cron.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the retraining pipeline. Suitable for cron usage.
+# Example crontab entry (runs daily at midnight):
+# 0 0 * * * /path/to/retrain_cron.sh >> /path/to/retrain.log 2>&1
+set -e
+cd "$(dirname "$0")"
+python -m ml.retraining_pipeline


### PR DESCRIPTION
## Summary
- add retraining pipeline that aggregates new logs, trains and evaluates models, and deploys on improvement
- provide cron-ready shell script and documentation for scheduled retraining

## Testing
- `python -m pytest` *(fails: Defining 'pytest_plugins' in a non-top-level conftest is no longer supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abb6cd04a0832fb628166cd706b459