### PR TITLE
feat: add runtime instrumentation and analytics scripts

### DIFF
--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -41,6 +41,7 @@ from autogpt.core.runner.client_lib.utils import coroutine
 from autogpt.file_storage import FileStorageBackendName, get_storage
 from autogpt.logs.config import configure_chat_plugins, configure_logging
 from autogpt.logs.helpers import print_attribute, speak
+from autogpt.logs.instrumentation import log_call
 from autogpt.models.action_history import ActionInterruptedByHuman
 from autogpt.plugins import scan_plugins
 from scripts.install_plugin_deps import install_plugin_dependencies
@@ -58,6 +59,7 @@ from .utils import (
 )
 
 
+@log_call
 @coroutine
 async def run_auto_gpt(
     continuous: bool = False,

--- a/autogpts/autogpt/autogpt/logs/instrumentation.py
+++ b/autogpts/autogpt/autogpt/logs/instrumentation.py
@@ -1,0 +1,63 @@
+"""Logging utilities for runtime instrumentation."""
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import logging
+import time
+from typing import Any, Callable, TypeVar, cast
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def log_call(func: F) -> F:
+    """Log inputs, outputs and execution time for ``func``.
+
+    The log record is emitted at INFO level with the ``runtime_metrics`` tag to
+    make it easy to parse by analytics tooling. Both synchronous and
+    asynchronous callables are supported.
+    """
+
+    if asyncio.iscoroutinefunction(func):
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any):
+            logger = logging.getLogger(func.__module__)
+            start = time.perf_counter()
+            logger.debug("Calling %s with %s %s", func.__qualname__, args, kwargs)
+            try:
+                result = await func(*args, **kwargs)
+                return result
+            finally:
+                duration = time.perf_counter() - start
+                payload = {
+                    "function": func.__qualname__,
+                    "args": args,
+                    "kwargs": kwargs,
+                    "duration": duration,
+                    "result": result if "result" in locals() else None,
+                }
+                logger.info("runtime_metrics %s", json.dumps(payload, default=str))
+
+        return cast(F, async_wrapper)
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any):
+        logger = logging.getLogger(func.__module__)
+        start = time.perf_counter()
+        logger.debug("Calling %s with %s %s", func.__qualname__, args, kwargs)
+        try:
+            result = func(*args, **kwargs)
+            return result
+        finally:
+            duration = time.perf_counter() - start
+            payload = {
+                "function": func.__qualname__,
+                "args": args,
+                "kwargs": kwargs,
+                "duration": duration,
+                "result": result if "result" in locals() else None,
+            }
+            logger.info("runtime_metrics %s", json.dumps(payload, default=str))
+
+    return cast(F, sync_wrapper)

--- a/scripts/analyze_runtime.py
+++ b/scripts/analyze_runtime.py
@@ -1,0 +1,47 @@
+"""Analyze instrumentation logs to derive parameter suggestions."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import mean
+
+
+def load_metrics(path: Path) -> list[dict]:
+    metrics: list[dict] = []
+    if not path.exists():
+        return metrics
+    for line in path.read_text().splitlines():
+        if "runtime_metrics" not in line:
+            continue
+        data = line.split("runtime_metrics", 1)[1].strip()
+        try:
+            metrics.append(json.loads(data))
+        except json.JSONDecodeError:
+            continue
+    return metrics
+
+
+def suggest_parameters(metrics: list[dict]) -> dict:
+    if not metrics:
+        return {}
+    durations = [m.get("duration", 0) for m in metrics]
+    avg = mean(durations)
+    return {
+        "average_duration": avg,
+        "suggested_parameters": {"execution_timeout": round(avg * 1.5, 2)},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze runtime log")
+    parser.add_argument("--log", default="autogpt.log", help="Path to log file")
+    args = parser.parse_args()
+    metrics = load_metrics(Path(args.log))
+    results = suggest_parameters(metrics)
+    Path("analytics_output.json").write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_parameters.py
+++ b/scripts/deploy_parameters.py
@@ -1,0 +1,56 @@
+"""Apply parameter suggestions and monitor for regression."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import yaml
+
+
+def apply_parameters(config_path: Path, params: dict) -> dict:
+    config: dict = {}
+    if config_path.exists():
+        config = yaml.safe_load(config_path.read_text()) or {}
+    config.update(params)
+    config_path.write_text(yaml.safe_dump(config))
+    return config
+
+
+def run_tests(command: str) -> tuple[int, float, str]:
+    start = time.perf_counter()
+    proc = subprocess.run(command, shell=True, capture_output=True, text=True)
+    duration = time.perf_counter() - start
+    output = proc.stdout + proc.stderr
+    return proc.returncode, duration, output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Deploy parameters and run regression tests"
+    )
+    parser.add_argument(
+        "--analytics", default="analytics_output.json", help="Analytics JSON file"
+    )
+    parser.add_argument(
+        "--config", default="prompt_settings.yaml", help="Config file to update"
+    )
+    parser.add_argument(
+        "--test", default="pytest -q", help="Command used for regression tests"
+    )
+    args = parser.parse_args()
+
+    data = json.loads(Path(args.analytics).read_text())
+    params = data.get("suggested_parameters", {})
+    apply_parameters(Path(args.config), params)
+
+    code, duration, output = run_tests(args.test)
+    report = {"returncode": code, "duration": duration, "output": output}
+    Path("deployment_report.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log function inputs, outputs, and duration via a reusable decorator
- add analytics script to parse runtime metrics and suggest parameter tweaks
- create deployment helper to apply suggestions and run regression tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'forge')*

------
https://chatgpt.com/codex/tasks/task_e_68abb9680ab8832fbb2d68fc2f3c6701