### PR TITLE
Add optimization benchmarks and unified algorithm interfaces

### DIFF
--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -1,0 +1,12 @@
+"""Collection of optimization algorithms with a unified interface."""
+
+from . import ga, pso, aco, random_search
+
+ALGORITHMS = {
+    "ga": ga.optimize,
+    "pso": pso.optimize,
+    "aco": aco.optimize,
+    "random": random_search.optimize,
+}
+
+__all__ = ["ALGORITHMS", "ga", "pso", "aco", "random_search"]

--- a/algorithms/aco.py
+++ b/algorithms/aco.py
@@ -1,0 +1,37 @@
+"""A very small Ant Colony Optimization style optimizer."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+import numpy as np
+
+from benchmarks.problems import Problem
+
+
+def optimize(
+    problem: Problem,
+    seed: Optional[int] = None,
+    max_iters: int = 100,
+    ant_count: int = 20,
+    q: float = 0.1,
+) -> Tuple[np.ndarray, float]:
+    rng = np.random.default_rng(seed)
+
+    mean = np.array([(b[0] + b[1]) / 2 for b in problem.bounds])
+    std = np.array([(b[1] - b[0]) / 2 for b in problem.bounds])
+
+    best = None
+    best_val = float("inf")
+
+    for _ in range(max_iters):
+        ants = rng.normal(mean, std, size=(ant_count, problem.dim))
+        ants = problem.clip(ants)
+        values = np.array([problem.evaluate(a) for a in ants])
+        idx = np.argmin(values)
+        if values[idx] < best_val:
+            best_val = values[idx]
+            best = ants[idx]
+        # update pheromone (mean) towards best ant
+        mean = (1 - q) * mean + q * best
+        std *= 0.95  # slowly reduce exploration
+
+    return best, best_val

--- a/algorithms/ga.py
+++ b/algorithms/ga.py
@@ -1,0 +1,59 @@
+"""A tiny Genetic Algorithm implementation with a unified interface."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+import numpy as np
+import random
+
+from benchmarks.problems import Problem
+
+
+def optimize(
+    problem: Problem,
+    seed: Optional[int] = None,
+    max_iters: int = 100,
+    pop_size: int = 20,
+    mutation_rate: float = 0.1,
+) -> Tuple[np.ndarray, float]:
+    """Optimize ``problem`` using a very small GA."""
+    rng = np.random.default_rng(seed)
+    random.seed(seed)
+
+    lower = np.array([b[0] for b in problem.bounds])
+    upper = np.array([b[1] for b in problem.bounds])
+
+    pop = rng.uniform(lower, upper, size=(pop_size, problem.dim))
+    fitness = np.array([problem.evaluate(ind) for ind in pop])
+
+    best_idx = np.argmin(fitness)
+    best, best_val = pop[best_idx], fitness[best_idx]
+
+    for _ in range(max_iters):
+        # Select the best half
+        idx = np.argsort(fitness)
+        parents = pop[idx][: pop_size // 2]
+
+        # Simple arithmetic crossover to create children
+        children = []
+        for i in range(0, len(parents), 2):
+            p1 = parents[i]
+            p2 = parents[(i + 1) % len(parents)]
+            children.append((p1 + p2) / 2.0)
+        children = np.array(children)
+
+        pop = np.vstack([parents, children])
+        if pop.shape[0] < pop_size:  # maintain population size
+            extra = parents[: pop_size - pop.shape[0]]
+            pop = np.vstack([pop, extra])
+
+        # Gaussian mutation and clipping to bounds
+        pop += rng.normal(0.0, mutation_rate, pop.shape)
+        pop = problem.clip(pop)
+
+        fitness = np.array([problem.evaluate(ind) for ind in pop])
+        idx = np.argmin(fitness)
+        if fitness[idx] < best_val:
+            best_val = fitness[idx]
+            best = pop[idx]
+
+    return best, best_val

--- a/algorithms/pso.py
+++ b/algorithms/pso.py
@@ -1,0 +1,52 @@
+"""Particle Swarm Optimization with unified interface."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+import numpy as np
+
+from benchmarks.problems import Problem
+
+
+def optimize(
+    problem: Problem,
+    seed: Optional[int] = None,
+    max_iters: int = 100,
+    swarm_size: int = 30,
+    inertia: float = 0.7,
+    cognitive: float = 1.4,
+    social: float = 1.4,
+) -> Tuple[np.ndarray, float]:
+    rng = np.random.default_rng(seed)
+
+    lower = np.array([b[0] for b in problem.bounds])
+    upper = np.array([b[1] for b in problem.bounds])
+
+    pos = rng.uniform(lower, upper, size=(swarm_size, problem.dim))
+    vel = rng.normal(0, 1, size=(swarm_size, problem.dim))
+    personal_best = pos.copy()
+    personal_best_val = np.array([problem.evaluate(p) for p in pos])
+
+    best_idx = np.argmin(personal_best_val)
+    global_best = personal_best[best_idx].copy()
+    global_best_val = personal_best_val[best_idx]
+
+    for _ in range(max_iters):
+        r1, r2 = rng.random(size=(2, swarm_size, problem.dim))
+        vel = (
+            inertia * vel
+            + cognitive * r1 * (personal_best - pos)
+            + social * r2 * (global_best - pos)
+        )
+        pos = problem.clip(pos + vel)
+        values = np.array([problem.evaluate(p) for p in pos])
+
+        improved = values < personal_best_val
+        personal_best[improved] = pos[improved]
+        personal_best_val[improved] = values[improved]
+
+        idx = np.argmin(personal_best_val)
+        if personal_best_val[idx] < global_best_val:
+            global_best_val = personal_best_val[idx]
+            global_best = personal_best[idx].copy()
+
+    return global_best, global_best_val

--- a/algorithms/random_search.py
+++ b/algorithms/random_search.py
@@ -1,0 +1,26 @@
+"""Baseline random search optimizer."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+import numpy as np
+
+from benchmarks.problems import Problem
+
+
+def optimize(
+    problem: Problem,
+    seed: Optional[int] = None,
+    max_iters: int = 1000,
+) -> Tuple[np.ndarray, float]:
+    rng = np.random.default_rng(seed)
+    lower = np.array([b[0] for b in problem.bounds])
+    upper = np.array([b[1] for b in problem.bounds])
+    best = None
+    best_val = float("inf")
+    for _ in range(max_iters):
+        x = rng.uniform(lower, upper)
+        val = problem.evaluate(x)
+        if val < best_val:
+            best_val = val
+            best = x
+    return best, best_val

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,11 @@
+"""Common benchmark problems for optimization algorithms."""
+
+from .problems import Problem, Sphere, Rastrigin, ConstrainedQuadratic
+
+PROBLEMS = {
+    "sphere": Sphere,
+    "rastrigin": Rastrigin,
+    "constrained": ConstrainedQuadratic,
+}
+
+__all__ = ["Problem", "Sphere", "Rastrigin", "ConstrainedQuadratic", "PROBLEMS"]

--- a/benchmarks/problems.py
+++ b/benchmarks/problems.py
@@ -1,0 +1,85 @@
+"""Common benchmark optimization problems with known optima."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+import math
+import numpy as np
+
+
+@dataclass
+class Problem:
+    """Base class for optimization problems."""
+
+    dim: int
+    bounds: Sequence[Tuple[float, float]]
+    optimum: Sequence[float]
+    optimum_value: float
+    name: str
+
+    def evaluate(self, x: Sequence[float]) -> float:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def clip(self, x: np.ndarray) -> np.ndarray:
+        """Clip array ``x`` to the problem bounds."""
+        lower = np.array([b[0] for b in self.bounds])
+        upper = np.array([b[1] for b in self.bounds])
+        return np.minimum(np.maximum(x, lower), upper)
+
+
+class Sphere(Problem):
+    """Sphere function ``f(x) = sum(x_i^2)`` with optimum at ``x=0``."""
+
+    def __init__(self, dim: int = 2, bound: float = 5.12):
+        bounds = [(-bound, bound)] * dim
+        super().__init__(
+            dim=dim,
+            bounds=bounds,
+            optimum=[0.0] * dim,
+            optimum_value=0.0,
+            name="sphere",
+        )
+
+    def evaluate(self, x: Sequence[float]) -> float:
+        return float(np.sum(np.square(x)))
+
+
+class Rastrigin(Problem):
+    """Rastrigin function with global minimum at ``x=0``."""
+
+    def __init__(self, dim: int = 2, bound: float = 5.12):
+        bounds = [(-bound, bound)] * dim
+        super().__init__(
+            dim=dim,
+            bounds=bounds,
+            optimum=[0.0] * dim,
+            optimum_value=0.0,
+            name="rastrigin",
+        )
+
+    def evaluate(self, x: Sequence[float]) -> float:
+        x = np.asarray(x)
+        return float(10 * self.dim + np.sum(x * x - 10 * np.cos(2 * math.pi * x)))
+
+
+class ConstrainedQuadratic(Problem):
+    """Minimise ``x^2 + y^2`` subject to ``x + y = 1``."""
+
+    def __init__(self):
+        bounds = [(0.0, 1.0)] * 2
+        super().__init__(
+            dim=2,
+            bounds=bounds,
+            optimum=[0.5, 0.5],
+            optimum_value=0.5,
+            name="constrained_quadratic",
+        )
+
+    def is_feasible(self, x: Sequence[float]) -> bool:
+        return abs(sum(x) - 1.0) < 1e-6
+
+    def evaluate(self, x: Sequence[float]) -> float:
+        if not self.is_feasible(x):
+            return float("inf")
+        x = np.asarray(x)
+        return float(np.sum(np.square(x)))

--- a/runner/experiment.py
+++ b/runner/experiment.py
@@ -1,0 +1,45 @@
+"""Utility to run algorithms on benchmark problems with multiple seeds."""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any, List
+
+from algorithms import ALGORITHMS
+from benchmarks import PROBLEMS
+
+
+def run_experiments(
+    algorithm: str,
+    problem: str,
+    seeds: Iterable[int],
+    max_iters: int = 100,
+    **kwargs: Any,
+) -> List[Dict[str, Any]]:
+    """Run ``algorithm`` on ``problem`` for each seed."""
+    algo_fn = ALGORITHMS[algorithm]
+    problem_cls = PROBLEMS[problem]
+    prob = problem_cls()
+
+    results: List[Dict[str, Any]] = []
+    for seed in seeds:
+        best_x, best_val = algo_fn(prob, seed=seed, max_iters=max_iters, **kwargs)
+        results.append(
+            {"seed": seed, "best_x": best_x.tolist(), "best_val": float(best_val)}
+        )
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Run optimization experiments")
+    parser.add_argument("algorithm", choices=ALGORITHMS.keys())
+    parser.add_argument("problem", choices=PROBLEMS.keys())
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--max-iters", type=int, default=100)
+    args = parser.parse_args()
+
+    output = run_experiments(
+        args.algorithm, args.problem, args.seeds, max_iters=args.max_iters
+    )
+    print(json.dumps(output, indent=2))


### PR DESCRIPTION
## Summary
- add benchmark problems (Sphere, Rastrigin, constrained quadratic) with known optima
- introduce GA, PSO, ACO and random search implementations exposing a unified `optimize` API
- add experiment runner to execute algorithms across multiple seeds

## Testing
- `python -m flake8 benchmarks algorithms runner`
- `pytest benchmarks algorithms runner -q`
- `PYTHONPATH=. python runner/experiment.py ga sphere --seeds 0 1 --max-iters 5`


------
https://chatgpt.com/codex/tasks/task_e_68abc1fd9c0c832f8c880754b613ebca