### PR TITLE
Add metrics recorder for optimization runs

### DIFF
--- a/algorithms/aco.py
+++ b/algorithms/aco.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
+import time
 import numpy as np
 
 from .termination import StopCondition
@@ -17,7 +18,7 @@ def optimize(
     patience: Optional[int] = None,
     ant_count: int = 20,
     q: float = 0.1,
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, float, int, float]:
     rng = np.random.default_rng(seed)
 
     mean = np.array([(b[0] + b[1]) / 2 for b in problem.bounds])
@@ -42,4 +43,5 @@ def optimize(
         std *= 0.95  # slowly reduce exploration
         stopper.update(improved)
 
-    return best, best_val
+    elapsed = time.time() - stopper.start_time
+    return best, best_val, stopper.iteration, elapsed

--- a/algorithms/ga.py
+++ b/algorithms/ga.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
+import time
 import numpy as np
 
 from .termination import StopCondition
@@ -17,7 +18,7 @@ def optimize(
     patience: Optional[int] = None,
     pop_size: int = 20,
     mutation_rate: float = 0.1,
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, float, int, float]:
     """Optimize ``problem`` using a very small GA."""
     rng = np.random.default_rng(seed)
 
@@ -62,4 +63,5 @@ def optimize(
             improved = True
         stopper.update(improved)
 
-    return best, best_val
+    elapsed = time.time() - stopper.start_time
+    return best, best_val, stopper.iteration, elapsed

--- a/algorithms/pso.py
+++ b/algorithms/pso.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
+import time
 import numpy as np
 
 from .termination import StopCondition
@@ -19,7 +20,7 @@ def optimize(
     inertia: float = 0.7,
     cognitive: float = 1.4,
     social: float = 1.4,
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, float, int, float]:
     rng = np.random.default_rng(seed)
 
     lower = np.array([b[0] for b in problem.bounds])
@@ -57,4 +58,5 @@ def optimize(
             improved = True
         stopper.update(improved)
 
-    return global_best, global_best_val
+    elapsed = time.time() - stopper.start_time
+    return global_best, global_best_val, stopper.iteration, elapsed

--- a/algorithms/random_search.py
+++ b/algorithms/random_search.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
+import time
 import numpy as np
 
 from .termination import StopCondition
@@ -15,7 +16,7 @@ def optimize(
     max_iters: int = 1000,
     max_time: Optional[float] = None,
     patience: Optional[int] = None,
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, float, int, float]:
     rng = np.random.default_rng(seed)
     lower = np.array([b[0] for b in problem.bounds])
     upper = np.array([b[1] for b in problem.bounds])
@@ -31,4 +32,5 @@ def optimize(
             best = x
             improved = True
         stopper.update(improved)
-    return best, best_val
+    elapsed = time.time() - stopper.start_time
+    return best, best_val, stopper.iteration, elapsed

--- a/metrics/recorder.py
+++ b/metrics/recorder.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Utilities for recording optimization metrics and exporting them."""
+
+from dataclasses import dataclass, asdict
+import json
+import csv
+from typing import List, Optional
+
+
+@dataclass
+class RunMetrics:
+    """Container for metrics from a single optimization run."""
+
+    algorithm: str
+    problem: str
+    seed: int
+    best_val: float
+    relative_error: float
+    iterations: int
+    time: float
+    iter_limit_reached: bool
+    time_limit_reached: bool
+
+
+class MetricsRecorder:
+    """Accumulates run metrics and saves them to JSON or CSV."""
+
+    def __init__(self) -> None:
+        self.records: List[RunMetrics] = []
+
+    def record(
+        self,
+        algorithm: str,
+        problem: str,
+        seed: int,
+        best_val: float,
+        optimum_val: float,
+        iterations: int,
+        elapsed_time: float,
+        max_iters: Optional[int] = None,
+        max_time: Optional[float] = None,
+    ) -> None:
+        """Record metrics for a single run.
+
+        ``max_iters`` and ``max_time`` are used to determine whether the run hit
+        the iteration or time budget.
+        """
+        if optimum_val == 0:
+            relative_error = abs(best_val - optimum_val)
+        else:
+            relative_error = abs(best_val - optimum_val) / abs(optimum_val)
+
+        iter_limit_reached = max_iters is not None and iterations >= max_iters
+        time_limit_reached = max_time is not None and elapsed_time >= max_time
+
+        self.records.append(
+            RunMetrics(
+                algorithm=algorithm,
+                problem=problem,
+                seed=seed,
+                best_val=float(best_val),
+                relative_error=float(relative_error),
+                iterations=int(iterations),
+                time=float(elapsed_time),
+                iter_limit_reached=iter_limit_reached,
+                time_limit_reached=time_limit_reached,
+            )
+        )
+
+    def save(self, path: str) -> None:
+        """Save all recorded metrics to ``path`` as JSON or CSV."""
+        if path.lower().endswith(".json"):
+            with open(path, "w") as f:
+                json.dump([asdict(r) for r in self.records], f, indent=2)
+        elif path.lower().endswith(".csv"):
+            fieldnames = list(RunMetrics.__annotations__.keys())
+            with open(path, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                for r in self.records:
+                    writer.writerow(asdict(r))
+        else:
+            raise ValueError("Unsupported file format: expected .json or .csv")
+
+    def to_list(self) -> List[dict]:
+        """Return recorded metrics as list of dictionaries."""
+        return [asdict(r) for r in self.records]


### PR DESCRIPTION
## Summary
- track best objective value, relative error, iterations and time for optimization runs
- export metrics to JSON or CSV after experiments
- return iteration counts and runtime from all algorithms

## Testing
- `pytest` *(fails: ImportError: cannot import name 'GetCoreSchemaHandler' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68abc571e0d0832fac6825a982cc078e