### PR TITLE
feat: add unsubscribe support for event bus

### DIFF
--- a/events/client.py
+++ b/events/client.py
@@ -20,5 +20,12 @@ class EventClient:
     def publish(self, topic: str, event: Dict[str, Any]) -> None:
         self._bus.publish(topic, event)
 
-    def subscribe(self, topic: str, handler: Callable[[Dict[str, Any]], None]) -> None:
-        self._bus.subscribe(topic, handler)
+    def subscribe(
+        self, topic: str, handler: Callable[[Dict[str, Any]], None]
+    ) -> Callable[[], None]:
+        return self._bus.subscribe(topic, handler)
+
+    def unsubscribe(
+        self, topic: str, handler: Callable[[Dict[str, Any]], None]
+    ) -> None:
+        self._bus.unsubscribe(topic, handler)

--- a/founder_agent/__init__.py
+++ b/founder_agent/__init__.py
@@ -27,11 +27,13 @@ def run_monitoring_loop(
         interval: Seconds between proposal generations.
     """
     analytics = Analytics()
-    for topic in topics:
-        subscribe(topic, analytics.handle_event)
-
-    while True:
-        time.sleep(interval)
-        trends = analytics.get_trends()
-        if trends:
-            generate_proposal(trends)
+    subscriptions = [subscribe(topic, analytics.handle_event) for topic in topics]
+    try:
+        while True:
+            time.sleep(interval)
+            trends = analytics.get_trends()
+            if trends:
+                generate_proposal(trends)
+    finally:
+        for cancel in subscriptions:
+            cancel()

--- a/tests/dummy_packages/events/__init__.py
+++ b/tests/dummy_packages/events/__init__.py
@@ -2,6 +2,14 @@ def create_event_bus(*args, **kwargs):
     class Bus:
         def publish(self, *args, **kwargs):
             pass
+
+        def subscribe(self, *args, **kwargs):
+            def cancel():
+                pass
+            return cancel
+
+        def unsubscribe(self, *args, **kwargs):
+            pass
     return Bus()
 
 def set_event_bus(bus):


### PR DESCRIPTION
## Summary
- allow event handlers to unsubscribe from topics on the in-memory bus
- return cancellable subscriptions for Redis event bus
- clean up modules by cancelling event bus subscriptions when done

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'playsound')*


------
https://chatgpt.com/codex/tasks/task_e_68abcdc93ebc832f8e7a070a5eac4f93