### PR TITLE
refactor: inject event bus dependencies

### DIFF
--- a/agent_factory.py
+++ b/agent_factory.py
@@ -23,6 +23,7 @@ from autogpt.config.ai_directives import AIDirectives
 from autogpt.core.resource.model_providers import ChatModelProvider
 from autogpt.file_storage.base import FileStorage
 from autogpt.models.command_registry import CommandRegistry
+from events import EventBus
 
 from capability.librarian import Librarian
 from org_charter import io as charter_io
@@ -81,6 +82,7 @@ def create_agent_from_blueprint(
     config: Config,
     llm_provider: ChatModelProvider,
     file_storage: FileStorage,
+    bus: EventBus,
 ) -> Agent:
     """Instantiate an :class:`Agent` from a blueprint file.
 
@@ -94,6 +96,8 @@ def create_agent_from_blueprint(
         Model provider used for prompting.
     file_storage:
         File storage backend for the agent.
+    bus:
+        Event bus instance to inject into the agent.
     """
     path = Path(blueprint_path)
     blueprint = _parse_blueprint(path)
@@ -114,6 +118,7 @@ def create_agent_from_blueprint(
         app_config=config,
         file_storage=file_storage,
         llm_provider=llm_provider,
+        event_bus=bus,
     )
 
     # Restrict commands to authorised tools

--- a/autogpts/autogpt/autogpt/agent_factory/configurators.py
+++ b/autogpts/autogpt/autogpt/agent_factory/configurators.py
@@ -8,6 +8,7 @@ from autogpt.file_storage.base import FileStorage
 from autogpt.logs.config import configure_chat_plugins
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.plugins import scan_plugins
+from events import EventBus
 
 
 def create_agent(
@@ -18,6 +19,7 @@ def create_agent(
     file_storage: FileStorage,
     llm_provider: ChatModelProvider,
     directives: Optional[AIDirectives] = None,
+    event_bus: EventBus,
 ) -> Agent:
     if not task:
         raise ValueError("No task specified for new agent")
@@ -32,6 +34,7 @@ def create_agent(
         app_config=app_config,
         file_storage=file_storage,
         llm_provider=llm_provider,
+        event_bus=event_bus,
     )
 
     return agent
@@ -42,12 +45,14 @@ def configure_agent_with_state(
     app_config: Config,
     file_storage: FileStorage,
     llm_provider: ChatModelProvider,
+    event_bus: EventBus,
 ) -> Agent:
     return _configure_agent(
         state=state,
         app_config=app_config,
         file_storage=file_storage,
         llm_provider=llm_provider,
+        event_bus=event_bus,
     )
 
 
@@ -55,6 +60,7 @@ def _configure_agent(
     app_config: Config,
     llm_provider: ChatModelProvider,
     file_storage: FileStorage,
+    event_bus: EventBus,
     agent_id: str = "",
     task: str = "",
     ai_profile: Optional[AIProfile] = None,
@@ -92,6 +98,7 @@ def _configure_agent(
         command_registry=command_registry,
         file_storage=file_storage,
         legacy_config=app_config,
+        event_bus=event_bus,
     )
 
 

--- a/autogpts/autogpt/autogpt/agent_factory/generators.py
+++ b/autogpts/autogpt/autogpt/agent_factory/generators.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from autogpt.config.ai_directives import AIDirectives
 from autogpt.file_storage.base import FileStorage
+from events import EventBus
 
 from .configurators import _configure_agent
 from .profile_generator import generate_agent_profile_for_task
@@ -20,6 +21,7 @@ async def generate_agent_for_task(
     app_config: Config,
     file_storage: FileStorage,
     llm_provider: ChatModelProvider,
+    event_bus: EventBus,
 ) -> Agent:
     base_directives = AIDirectives.from_file(app_config.prompt_settings_file)
     ai_profile, task_directives = await generate_agent_profile_for_task(
@@ -35,4 +37,5 @@ async def generate_agent_for_task(
         app_config=app_config,
         file_storage=file_storage,
         llm_provider=llm_provider,
+        event_bus=event_bus,
     )

--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -38,6 +38,7 @@ from autogpt.models.context_item import ContextItem
 from .base import BaseAgent, BaseAgentConfiguration, BaseAgentSettings
 from .features.agent_file_manager import AgentFileManagerMixin
 from .features.context import ContextMixin
+from events import EventBus
 from .features.watchdog import WatchdogMixin
 from .prompt_strategies.one_shot import (
     OneShotAgentPromptConfiguration,
@@ -99,6 +100,7 @@ class Agent(
         command_registry: CommandRegistry,
         file_storage: FileStorage,
         legacy_config: Config,
+        event_bus: EventBus,
     ):
         prompt_strategy = OneShotAgentPromptStrategy(
             configuration=settings.prompt_config,
@@ -111,6 +113,7 @@ class Agent(
             command_registry=command_registry,
             file_storage=file_storage,
             legacy_config=legacy_config,
+            event_bus=event_bus,
         )
         self._experience_learner = ExperienceLearner(
             memory=self.event_history,

--- a/autogpts/autogpt/autogpt/agents/base.py
+++ b/autogpts/autogpt/autogpt/agents/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
 from pydantic import Field, validator
-from events import create_event_bus, set_event_bus
+from events import EventBus
 from events.client import EventClient
 
 if TYPE_CHECKING:
@@ -166,6 +166,7 @@ class BaseAgent(Configurable[BaseAgentSettings], ABC):
         command_registry: CommandRegistry,
         file_storage: FileStorage,
         legacy_config: Config,
+        event_bus: EventBus,
     ):
         self.state = settings
         self.config = settings.config
@@ -173,14 +174,7 @@ class BaseAgent(Configurable[BaseAgentSettings], ABC):
         self.directives = settings.directives
         self.event_history = settings.history
 
-        bus = create_event_bus(
-            legacy_config.event_bus_backend,
-            host=legacy_config.event_bus_redis_host,
-            port=legacy_config.event_bus_redis_port,
-            password=legacy_config.event_bus_redis_password or None,
-        )
-        set_event_bus(bus)
-        self.event_client = EventClient(bus)
+        self.event_client = EventClient(event_bus)
 
         self.legacy_config = legacy_config
         """LEGACY: Monolithic application configuration."""

--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -45,6 +45,7 @@ from autogpt.logs.instrumentation import log_call
 from autogpt.models.action_history import ActionInterruptedByHuman
 from autogpt.plugins import scan_plugins
 from scripts.install_plugin_deps import install_plugin_dependencies
+from events import create_event_bus
 
 from .configurator import apply_overrides_to_config
 from .setup import apply_overrides_to_ai_settings, interactively_revise_ai_settings
@@ -95,6 +96,13 @@ async def run_auto_gpt(
         config.file_storage_backend, root_path="data", restrict_to_root=restrict_to_root
     )
     file_storage.initialize()
+
+    bus = create_event_bus(
+        config.event_bus_backend,
+        host=config.event_bus_redis_host,
+        port=config.event_bus_redis_port,
+        password=config.event_bus_redis_password or None,
+    )
 
     # Set up logging module
     if speak:
@@ -224,6 +232,7 @@ async def run_auto_gpt(
             app_config=config,
             file_storage=file_storage,
             llm_provider=llm_provider,
+            event_bus=bus,
         )
         apply_overrides_to_ai_settings(
             ai_profile=agent.state.ai_profile,
@@ -328,6 +337,7 @@ async def run_auto_gpt(
             app_config=config,
             file_storage=file_storage,
             llm_provider=llm_provider,
+            event_bus=bus,
         )
 
         if not agent.config.allow_fs_access:
@@ -381,6 +391,13 @@ async def run_auto_gpt_server(
     )
     file_storage.initialize()
 
+    bus = create_event_bus(
+        config.event_bus_backend,
+        host=config.event_bus_redis_host,
+        port=config.event_bus_redis_port,
+        password=config.event_bus_redis_password or None,
+    )
+
     # Set up logging module
     configure_logging(
         debug=debug,
@@ -421,6 +438,7 @@ async def run_auto_gpt_server(
         database=database,
         file_storage=file_storage,
         llm_provider=llm_provider,
+        event_bus=bus,
     )
     await server.start(port=port)
 

--- a/autogpts/factory.py
+++ b/autogpts/factory.py
@@ -9,6 +9,7 @@ from autogpt.core.resource.model_providers import ChatModelProvider
 from autogpt.file_storage.base import FileStorage
 
 from agent_factory import create_agent_from_blueprint
+from events import EventBus
 
 
 def spawn_agent(
@@ -17,6 +18,7 @@ def spawn_agent(
     config: Config,
     llm_provider: ChatModelProvider,
     file_storage: FileStorage,
+    bus: EventBus,
 ):
     """Create a new AutoGPT agent from a blueprint.
 
@@ -30,12 +32,15 @@ def spawn_agent(
         LLM provider used for the agent's thinking.
     file_storage: FileStorage
         Storage backend for the agent's file operations.
+    bus: EventBus
+        Event bus instance to inject into the agent.
     """
     return create_agent_from_blueprint(
         blueprint_path,
         config=config,
         llm_provider=llm_provider,
         file_storage=file_storage,
+        bus=bus,
     )
 
 

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -12,16 +12,7 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List
 
-__all__ = [
-    "EventBus",
-    "InMemoryEventBus",
-    "event_bus",
-    "create_event_bus",
-    "get_event_bus",
-    "set_event_bus",
-    "publish",
-    "subscribe",
-]
+__all__ = ["EventBus", "InMemoryEventBus", "create_event_bus", "publish", "subscribe"]
 
 
 class EventBus(ABC):
@@ -60,22 +51,6 @@ class InMemoryEventBus(EventBus):
             self._subscribers.setdefault(topic, []).append(handler)
 
 
-event_bus: EventBus = InMemoryEventBus()
-
-
-def set_event_bus(bus: EventBus) -> None:
-    """Set the global event bus instance."""
-
-    global event_bus
-    event_bus = bus
-
-
-def get_event_bus() -> EventBus:
-    """Return the currently configured global event bus."""
-
-    return event_bus
-
-
 def create_event_bus(backend: str, **kwargs: Any) -> EventBus:
     """Create an event bus for *backend*.
 
@@ -93,14 +68,16 @@ def create_event_bus(backend: str, **kwargs: Any) -> EventBus:
     return InMemoryEventBus()
 
 
-def publish(topic: str, event: Dict[str, Any]) -> None:
-    """Publish *event* on *topic* using the configured event bus."""
+def publish(bus: EventBus, topic: str, event: Dict[str, Any]) -> None:
+    """Publish *event* on *topic* using *bus*."""
 
-    event_bus.publish(topic, event)
+    bus.publish(topic, event)
 
 
-def subscribe(topic: str, handler: Callable[[Dict[str, Any]], None]) -> None:
-    """Subscribe *handler* to events published on *topic*."""
+def subscribe(
+    bus: EventBus, topic: str, handler: Callable[[Dict[str, Any]], None]
+) -> None:
+    """Subscribe *handler* to events published on *topic* using *bus*."""
 
-    event_bus.subscribe(topic, handler)
+    bus.subscribe(topic, handler)
 

--- a/events/client.py
+++ b/events/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict
 
-from . import EventBus, get_event_bus
+from . import EventBus
 
 
 class EventClient:
@@ -14,8 +14,8 @@ class EventClient:
     event bus implementation.
     """
 
-    def __init__(self, bus: EventBus | None = None) -> None:
-        self._bus = bus or get_event_bus()
+    def __init__(self, bus: EventBus) -> None:
+        self._bus = bus
 
     def publish(self, topic: str, event: Dict[str, Any]) -> None:
         self._bus.publish(topic, event)

--- a/execution/manager.py
+++ b/execution/manager.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict
 
 from agent_factory import create_agent_from_blueprint
-from events import publish
+from events import EventBus
 from org_charter.watchdog import BlueprintWatcher
 from autogpt.config import Config
 from autogpt.core.resource.model_providers import ChatModelProvider
@@ -26,10 +26,12 @@ class AgentLifecycleManager:
         config: Config,
         llm_provider: ChatModelProvider,
         file_storage: FileStorage,
+        bus: EventBus,
     ) -> None:
         self._config = config
         self._llm_provider = llm_provider
         self._file_storage = file_storage
+        self._bus = bus
         self._agents: Dict[str, Agent] = {}
         self._watcher = BlueprintWatcher(self._on_blueprint_change)
         self._watcher.start()
@@ -41,7 +43,7 @@ class AgentLifecycleManager:
         name = path.stem.split("_v")[0]
         try:
             agent = create_agent_from_blueprint(
-                path, self._config, self._llm_provider, self._file_storage
+                path, self._config, self._llm_provider, self._file_storage, self._bus
             )
             previous = self._agents.get(name)
             if previous is not None:
@@ -50,12 +52,12 @@ class AgentLifecycleManager:
             else:
                 action = "spawned"
             self._agents[name] = agent
-            publish(
+            self._bus.publish(
                 "agent.lifecycle",
                 {"agent": name, "action": action, "path": str(path)},
             )
         except Exception as exc:  # pragma: no cover - logging path
-            publish(
+            self._bus.publish(
                 "agent.lifecycle",
                 {
                     "agent": name,

--- a/founder_agent/__init__.py
+++ b/founder_agent/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import time
 from typing import Sequence
 
-from events import subscribe
+from events import EventBus
 
 from .analytics import Analytics
 from .proposal_generator import generate_proposal
@@ -18,7 +18,7 @@ DEFAULT_TOPICS: Sequence[str] = ("system.metrics",)
 
 
 def run_monitoring_loop(
-    topics: Sequence[str] = DEFAULT_TOPICS, interval: float = 60.0
+    bus: EventBus, topics: Sequence[str] = DEFAULT_TOPICS, interval: float = 60.0
 ) -> None:
     """Subscribe to metric *topics* and periodically emit proposals.
 
@@ -28,7 +28,7 @@ def run_monitoring_loop(
     """
     analytics = Analytics()
     for topic in topics:
-        subscribe(topic, analytics.handle_event)
+        bus.subscribe(topic, analytics.handle_event)
 
     while True:
         time.sleep(interval)

--- a/monitoring/storage.py
+++ b/monitoring/storage.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
-from events import subscribe
+from events import EventBus
 
 
 class TimeSeriesStorage:
@@ -44,10 +44,10 @@ class TimeSeriesStorage:
         )
         self._conn.commit()
 
-    def subscribe_to(self, topics: Iterable[str]) -> None:
-        """Subscribe to *topics* on the global event bus and persist events."""
+    def subscribe_to(self, bus: EventBus, topics: Iterable[str]) -> None:
+        """Subscribe to *topics* on *bus* and persist events."""
         for topic in topics:
-            subscribe(topic, lambda e, t=topic: self.store(t, e))
+            bus.subscribe(topic, lambda e, t=topic: self.store(t, e))
 
     # ------------------------------------------------------------------
     # event retrieval

--- a/tests/dummy_packages/events/__init__.py
+++ b/tests/dummy_packages/events/__init__.py
@@ -1,8 +1,15 @@
-def create_event_bus(*args, **kwargs):
-    class Bus:
-        def publish(self, *args, **kwargs):
-            pass
-    return Bus()
+class EventBus:
+    def publish(self, *args, **kwargs):
+        pass
 
-def set_event_bus(bus):
-    pass
+    def subscribe(self, *args, **kwargs):
+        pass
+
+def create_event_bus(*args, **kwargs):
+    return EventBus()
+
+def publish(bus, *args, **kwargs):
+    bus.publish(*args, **kwargs)
+
+def subscribe(bus, *args, **kwargs):
+    bus.subscribe(*args, **kwargs)

--- a/tests/dummy_packages/events/client.py
+++ b/tests/dummy_packages/events/client.py
@@ -3,3 +3,5 @@ class EventClient:
         self.bus = bus
     def publish(self, *args, **kwargs):
         pass
+    def subscribe(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
## Summary
- create EventBus instances via factory and pass explicitly
- require explicit bus for publish/subscribe and EventClient
- inject EventBus into agents and lifecycle manager

## Testing
- `pytest` *(fails: ImportError: cannot import name 'ModelField' from 'pydantic.fields')*


------
https://chatgpt.com/codex/tasks/task_e_68abcddf3e40832f97a853d847b3e9ed