### PR TITLE
refactor: inject event bus via factory

### DIFF
--- a/autogpts/autogpt/autogpt/agents/base.py
+++ b/autogpts/autogpt/autogpt/agents/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
 from pydantic import Field, validator
-from events import create_event_bus, set_event_bus
+from events import EventBus, create_event_bus
 from events.client import EventClient
 
 if TYPE_CHECKING:
@@ -166,6 +166,7 @@ class BaseAgent(Configurable[BaseAgentSettings], ABC):
         command_registry: CommandRegistry,
         file_storage: FileStorage,
         legacy_config: Config,
+        event_bus: EventBus | None = None,
     ):
         self.state = settings
         self.config = settings.config
@@ -173,14 +174,14 @@ class BaseAgent(Configurable[BaseAgentSettings], ABC):
         self.directives = settings.directives
         self.event_history = settings.history
 
-        bus = create_event_bus(
+        bus = event_bus or create_event_bus(
             legacy_config.event_bus_backend,
             host=legacy_config.event_bus_redis_host,
             port=legacy_config.event_bus_redis_port,
             password=legacy_config.event_bus_redis_password or None,
         )
-        set_event_bus(bus)
         self.event_client = EventClient(bus)
+        self.event_bus = bus
 
         self.legacy_config = legacy_config
         """LEGACY: Monolithic application configuration."""

--- a/autogpts/autogpt/tests/conftest.py
+++ b/autogpts/autogpt/tests/conftest.py
@@ -9,6 +9,9 @@ import pytest
 import yaml
 from pytest_mock import MockerFixture
 
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
 from autogpt.agents.agent import Agent, AgentConfiguration, AgentSettings
 from autogpt.app.main import _configure_openai_provider
 from autogpt.config import AIProfile, Config, ConfigBuilder

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -15,10 +15,7 @@ from typing import Any, Callable, Dict, List
 __all__ = [
     "EventBus",
     "InMemoryEventBus",
-    "event_bus",
     "create_event_bus",
-    "get_event_bus",
-    "set_event_bus",
     "publish",
     "subscribe",
     "unsubscribe",
@@ -80,22 +77,6 @@ class InMemoryEventBus(EventBus):
                     del self._subscribers[topic]
 
 
-event_bus: EventBus = InMemoryEventBus()
-
-
-def set_event_bus(bus: EventBus) -> None:
-    """Set the global event bus instance."""
-
-    global event_bus
-    event_bus = bus
-
-
-def get_event_bus() -> EventBus:
-    """Return the currently configured global event bus."""
-
-    return event_bus
-
-
 def create_event_bus(backend: str, **kwargs: Any) -> EventBus:
     """Create an event bus for *backend*.
 
@@ -113,20 +94,22 @@ def create_event_bus(backend: str, **kwargs: Any) -> EventBus:
     return InMemoryEventBus()
 
 
-def publish(topic: str, event: Dict[str, Any]) -> None:
-    """Publish *event* on *topic* using the configured event bus."""
+def publish(bus: EventBus, topic: str, event: Dict[str, Any]) -> None:
+    """Publish *event* on *topic* using *bus*."""
 
-    event_bus.publish(topic, event)
-
-
-def subscribe(topic: str, handler: Callable[[Dict[str, Any]], None]) -> Callable[[], None]:
-    """Subscribe *handler* to events published on *topic*."""
-
-    return event_bus.subscribe(topic, handler)
+    bus.publish(topic, event)
 
 
-def unsubscribe(topic: str, handler: Callable[[Dict[str, Any]], None]) -> None:
-    """Remove *handler* subscription from *topic*."""
+def subscribe(
+    bus: EventBus, topic: str, handler: Callable[[Dict[str, Any]], None]
+) -> Callable[[], None]:
+    """Subscribe *handler* to events published on *topic* using *bus*."""
 
-    event_bus.unsubscribe(topic, handler)
+    return bus.subscribe(topic, handler)
+
+
+def unsubscribe(bus: EventBus, topic: str, handler: Callable[[Dict[str, Any]], None]) -> None:
+    """Remove *handler* subscription from *topic* using *bus*."""
+
+    bus.unsubscribe(topic, handler)
 

--- a/events/client.py
+++ b/events/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict
 
-from . import EventBus, get_event_bus
+from . import EventBus
 
 
 class EventClient:
@@ -14,8 +14,8 @@ class EventClient:
     event bus implementation.
     """
 
-    def __init__(self, bus: EventBus | None = None) -> None:
-        self._bus = bus or get_event_bus()
+    def __init__(self, bus: EventBus) -> None:
+        self._bus = bus
 
     def publish(self, topic: str, event: Dict[str, Any]) -> None:
         self._bus.publish(topic, event)

--- a/founder_agent/__init__.py
+++ b/founder_agent/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import time
 from typing import Sequence
 
-from events import subscribe
+from events import EventBus
 
 from .analytics import Analytics
 from .proposal_generator import generate_proposal
@@ -18,7 +18,9 @@ DEFAULT_TOPICS: Sequence[str] = ("system.metrics",)
 
 
 def run_monitoring_loop(
-    topics: Sequence[str] = DEFAULT_TOPICS, interval: float = 60.0
+    event_bus: EventBus,
+    topics: Sequence[str] = DEFAULT_TOPICS,
+    interval: float = 60.0,
 ) -> None:
     """Subscribe to metric *topics* and periodically emit proposals.
 
@@ -27,7 +29,9 @@ def run_monitoring_loop(
         interval: Seconds between proposal generations.
     """
     analytics = Analytics()
-    subscriptions = [subscribe(topic, analytics.handle_event) for topic in topics]
+    subscriptions = [
+        event_bus.subscribe(topic, analytics.handle_event) for topic in topics
+    ]
     try:
         while True:
             time.sleep(interval)

--- a/monitoring/storage.py
+++ b/monitoring/storage.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List
 
-from events import subscribe
+from events import EventBus
 
 
 class TimeSeriesStorage:
@@ -48,10 +48,10 @@ class TimeSeriesStorage:
         )
         self._conn.commit()
 
-    def subscribe_to(self, topics: Iterable[str]) -> None:
-        """Subscribe to *topics* on the global event bus and persist events."""
+    def subscribe_to(self, bus: EventBus, topics: Iterable[str]) -> None:
+        """Subscribe to *topics* on *bus* and persist events."""
         for topic in topics:
-            cancel = subscribe(topic, lambda e, t=topic: self.store(t, e))
+            cancel = bus.subscribe(topic, lambda e, t=topic: self.store(t, e))
             self._subscriptions.append(cancel)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- create EventBus instances via factory and pass explicitly
- refactor components to publish/subscribe via injected bus
- add sys.path config for tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'forge')*


------
https://chatgpt.com/codex/tasks/task_e_68abd0481cbc832faa4881a6ba1c42e9