### PR TITLE
Add global exception hooks and unified error handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@
 6. 不要提交有问题的内容。
 7. 避免不必要的更改，尤其是仅基于你个人喜好的更改。这是维护者的工作 ;-)
 
+## 异常处理约定
+
+为保持一致的错误日志输出，所有新增模块应当从 `AutoGPTError` 继承自定义异常，并通过统一的异常处理接口记录未捕获异常。可使用 `core.utils.exception_handling.setup_global_exception_hook` 在入口处注册全局钩子，并利用提供的异步与线程包装器确保后台任务的异常也能被记录。
+
 [开发频道]: https://discord.com/channels/1092243196446249134/1095817829405704305
 
 如果你希望更深入地参与项目（不仅仅是提交 PR），请阅读 wiki 中的 [catalyzing](https://github.com/Significant-Gravitas/Nexus/wiki/Catalyzing) 页面。

--- a/autogpts/autogpt/autogpt/agents/utils/exceptions.py
+++ b/autogpts/autogpt/autogpt/agents/utils/exceptions.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 from typing import Optional
 
+from autogpt.core.exceptions import AutoGPTError
 
-class AgentException(Exception):
+
+class AgentException(AutoGPTError):
     """Base class for specific exceptions relevant in the execution of Agents"""
 
     message: str
-
     hint: Optional[str] = None
     """A hint which can be passed to the LLM to reduce reoccurrence of this error"""
 

--- a/autogpts/autogpt/autogpt/app/cli.py
+++ b/autogpts/autogpt/autogpt/app/cli.py
@@ -6,6 +6,10 @@ from typing import Optional
 import click
 
 from autogpt.logs.config import LogFormatName
+from autogpt.core.utils.exception_handling import setup_global_exception_hook
+
+# Ensure unhandled exceptions are logged consistently
+setup_global_exception_hook()
 
 from .telemetry import setup_telemetry
 

--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -16,6 +16,11 @@ from typing import TYPE_CHECKING, Optional
 from colorama import Fore, Style
 from forge.sdk.db import AgentDB
 
+from autogpt.core.utils.exception_handling import setup_global_exception_hook
+
+# Register handlers for uncaught exceptions early in the application's lifecycle
+setup_global_exception_hook()
+
 if TYPE_CHECKING:
     from autogpt.agents.agent import Agent
 

--- a/autogpts/autogpt/autogpt/core/exceptions.py
+++ b/autogpts/autogpt/autogpt/core/exceptions.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+class AutoGPTError(Exception):
+    """Base exception for all AutoGPT related errors."""
+
+    def __init__(self, message: str, *, hint: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.hint = hint

--- a/autogpts/autogpt/autogpt/core/utils/exception_handling.py
+++ b/autogpts/autogpt/autogpt/core/utils/exception_handling.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import sys
+import threading
+from typing import Any, Awaitable, Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+Coro = TypeVar("Coro", bound=Awaitable[Any])
+
+
+def setup_global_exception_hook() -> None:
+    """Register global hooks to log uncaught exceptions."""
+
+    def handle_exception(exc_type, exc_value, exc_traceback):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+        logging.getLogger().error(
+            "Unhandled exception", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+
+    sys.excepthook = handle_exception
+
+    def thread_exception_hook(args: threading.ExceptHookArgs) -> None:
+        logging.getLogger().error(
+            "Unhandled exception in thread %s",
+            args.thread.name,
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    threading.excepthook = thread_exception_hook
+
+    try:
+        loop = asyncio.get_event_loop()
+
+        def asyncio_exception_handler(loop, context):
+            exc = context.get("exception")
+            if exc:
+                logging.getLogger().error(
+                    "Unhandled asyncio exception",
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+            else:
+                logging.getLogger().error(
+                    f"Unhandled asyncio exception: {context.get('message')}"
+                )
+
+        loop.set_exception_handler(asyncio_exception_handler)
+    except RuntimeError:
+        # No event loop in this thread
+        pass
+
+
+def log_exceptions_in_async(coro: Coro) -> asyncio.Task:
+    """Wrap a coroutine in a Task that logs exceptions."""
+
+    task = asyncio.create_task(coro)
+
+    def _done_callback(t: asyncio.Task) -> None:
+        try:
+            t.result()
+        except Exception:
+            logger.exception("Unhandled exception in async task")
+
+    task.add_done_callback(_done_callback)
+    return task
+
+
+def run_in_thread_with_logging(target: F, *args, daemon: bool = False, **kwargs) -> threading.Thread:
+    """Run a function in a thread and log any exception."""
+
+    def _runner() -> None:
+        try:
+            target(*args, **kwargs)
+        except Exception:
+            logger.exception("Unhandled exception in background thread")
+
+    thread = threading.Thread(target=_runner, daemon=daemon, name=getattr(target, "__name__", "thread"))
+    thread.start()
+    return thread

--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,12 @@ except ImportError:
     os.system("pip3 install PyGithub")
     import click
 
+from autogpts.autogpt.autogpt.core.utils.exception_handling import (
+    setup_global_exception_hook,
+)
+
+setup_global_exception_hook()
+
 
 @click.group()
 def cli():


### PR DESCRIPTION
## Summary
- introduce `AutoGPTError` base class and utilities for logging uncaught exceptions
- register global exception hooks in app entrypoints and extend agent errors
- document requirement for new modules to inherit `AutoGPTError`

## Testing
- `pytest tests/test_storage.py -q`
- `pytest tests/test_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abd4224ab8832f8d15d4d2e04f8374