### PR TITLE
Add system resource monitoring and management

### DIFF
--- a/execution/manager.py
+++ b/execution/manager.py
@@ -6,11 +6,17 @@ published on the global event bus for observability.
 """
 from __future__ import annotations
 
+import os
+import threading
+import time
 from pathlib import Path
 from typing import Dict
 
+import psutil
+
 from agent_factory import create_agent_from_blueprint
 from events import EventBus
+from monitoring import SystemMetricsCollector
 from org_charter.watchdog import BlueprintWatcher
 from autogpt.config import Config
 from autogpt.core.resource.model_providers import ChatModelProvider
@@ -33,6 +39,15 @@ class AgentLifecycleManager:
         self._file_storage = file_storage
         self._event_bus = event_bus
         self._agents: Dict[str, Agent] = {}
+        self._resources: Dict[str, Dict[str, float]] = {}
+        self._metrics = SystemMetricsCollector(event_bus)
+        self._metrics.start()
+        self._event_bus.subscribe("agent.resource", self._on_resource_event)
+        self._resource_stop = threading.Event()
+        self._resource_thread = threading.Thread(
+            target=self._resource_manager, daemon=True
+        )
+        self._resource_thread.start()
         self._watcher = BlueprintWatcher(self._on_blueprint_change)
         self._watcher.start()
 
@@ -48,10 +63,17 @@ class AgentLifecycleManager:
             previous = self._agents.get(name)
             if previous is not None:
                 _shutdown_agent(previous)
+                self._metrics.unregister(name)
                 action = "restarted"
             else:
                 action = "spawned"
             self._agents[name] = agent
+            self._metrics.register(name, getattr(agent, "pid", os.getpid()))
+            self._resources[name] = {
+                "cpu": 0.0,
+                "memory": 0.0,
+                "last_active": time.time(),
+            }
             self._event_bus.publish(
                 "agent.lifecycle",
                 {"agent": name, "action": action, "path": str(path)},
@@ -73,9 +95,51 @@ class AgentLifecycleManager:
     def stop(self) -> None:
         """Stop watching and shut down all managed agents."""
         self._watcher.stop()
+        self._resource_stop.set()
+        self._resource_thread.join()
+        self._metrics.stop()
         for agent in self._agents.values():
             _shutdown_agent(agent)
         self._agents.clear()
+
+    # ------------------------------------------------------------------
+    def _on_resource_event(self, event: Dict[str, float]) -> None:
+        name = event.get("agent")
+        if name not in self._resources:
+            return
+        data = self._resources[name]
+        data["cpu"] = event.get("cpu", 0.0)
+        data["memory"] = event.get("memory", 0.0)
+        if data["cpu"] > 1.0:
+            data["last_active"] = time.time()
+
+    def _resource_manager(self) -> None:
+        idle_timeout = 30.0
+        pressure_threshold = 80.0
+        while not self._resource_stop.wait(5.0):
+            now = time.time()
+            for name, data in list(self._resources.items()):
+                if now - data.get("last_active", now) > idle_timeout:
+                    agent = self._agents.get(name)
+                    if agent is not None:
+                        _shutdown_agent(agent)
+                        self._metrics.unregister(name)
+                        del self._agents[name]
+                        del self._resources[name]
+                        self._event_bus.publish(
+                            "agent.lifecycle", {"agent": name, "action": "reclaimed"}
+                        )
+            cpu_total = psutil.cpu_percent()
+            mem_total = psutil.virtual_memory().percent
+            if cpu_total > pressure_threshold or mem_total > pressure_threshold:
+                if self._resources:
+                    heavy = max(
+                        self._resources.items(), key=lambda item: item[1].get("cpu", 0.0)
+                    )[0]
+                    self._event_bus.publish(
+                        "agent.resource",
+                        {"agent": heavy, "action": "throttle"},
+                    )
 
 
 def _shutdown_agent(agent: Agent) -> None:

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -2,5 +2,6 @@
 
 from .action_logger import ActionLogger
 from .storage import TimeSeriesStorage
+from .system_metrics import SystemMetricsCollector
 
-__all__ = ["TimeSeriesStorage", "ActionLogger"]
+__all__ = ["TimeSeriesStorage", "ActionLogger", "SystemMetricsCollector"]

--- a/monitoring/system_metrics.py
+++ b/monitoring/system_metrics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict
+
+import psutil
+
+from events import EventBus
+
+
+class SystemMetricsCollector:
+    """Periodically publish CPU and memory usage for registered processes."""
+
+    def __init__(self, event_bus: EventBus, interval: float = 5.0) -> None:
+        self._bus = event_bus
+        self._interval = interval
+        self._agents: Dict[str, int] = {}
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def register(self, name: str, pid: int) -> None:
+        """Start tracking metrics for *pid* under *name*."""
+        self._agents[name] = pid
+
+    def unregister(self, name: str) -> None:
+        self._agents.pop(name, None)
+
+    def start(self) -> None:
+        if self._thread is None:
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    # ------------------------------------------------------------------
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            for name, pid in list(self._agents.items()):
+                try:
+                    proc = psutil.Process(pid)
+                    cpu = proc.cpu_percent(interval=None)
+                    mem = proc.memory_percent()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    cpu = 0.0
+                    mem = 0.0
+                self._bus.publish(
+                    "agent.resource",
+                    {"agent": name, "cpu": cpu, "memory": mem},
+                )
+            time.sleep(self._interval)


### PR DESCRIPTION
## Summary
- collect per-agent CPU and memory usage via psutil and publish on the event bus
- expand AgentLifecycleManager with a resource manager that tracks utilization and reclaims or throttles agents

## Testing
- `pytest tests/test_executor.py tests/test_performance_monitor.py tests/test_storage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abdb6e9ed0832fa9d5cb6d9e7ff3d4