### PR TITLE
Add metrics collector and performance monitoring API

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -3,5 +3,15 @@
 from .action_logger import ActionLogger
 from .storage import TimeSeriesStorage
 from .system_metrics import SystemMetricsCollector
+from .metrics_collector import MetricsCollector
+from .performance_monitor import PerformanceMonitor, email_alert, dashboard_alert
 
-__all__ = ["TimeSeriesStorage", "ActionLogger", "SystemMetricsCollector"]
+__all__ = [
+    "TimeSeriesStorage",
+    "ActionLogger",
+    "SystemMetricsCollector",
+    "MetricsCollector",
+    "PerformanceMonitor",
+    "email_alert",
+    "dashboard_alert",
+]

--- a/monitoring/api.py
+++ b/monitoring/api.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Simple API for exposing stored monitoring metrics."""
+
+from fastapi import FastAPI
+
+from .storage import TimeSeriesStorage
+
+
+def create_app(storage: TimeSeriesStorage | None = None) -> FastAPI:
+    storage = storage or TimeSeriesStorage()
+    app = FastAPI()
+
+    @app.get("/metrics/{topic}")
+    def get_events(topic: str, limit: int = 100):
+        """Return recent events for *topic*."""
+        return storage.events(topic, limit=limit)
+
+    @app.get("/metrics/summary")
+    def summary():
+        """Return aggregated performance metrics."""
+        return {
+            "success_rate": storage.success_rate(),
+            "bottlenecks": storage.bottlenecks(),
+            "blueprint_versions": storage.blueprint_versions(),
+        }
+
+    return app

--- a/monitoring/metrics_collector.py
+++ b/monitoring/metrics_collector.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Collect agent lifecycle and resource metrics into SQLite."""
+
+from pathlib import Path
+from typing import Callable, List
+
+from events import EventBus
+
+from .storage import TimeSeriesStorage
+
+
+class MetricsCollector:
+    """Subscribe to agent events on the event bus and persist them."""
+
+    def __init__(self, bus: EventBus, db_path: Path | str = "monitoring.db") -> None:
+        self.storage = TimeSeriesStorage(db_path)
+        self._bus = bus
+        self._subscriptions: List[Callable[[], None]] = []
+        self._subscriptions.append(
+            self._bus.subscribe("agent.lifecycle", self._store_lifecycle)
+        )
+        self._subscriptions.append(
+            self._bus.subscribe("agent.resource", self._store_resource)
+        )
+
+    # ------------------------------------------------------------------
+    def _store_lifecycle(self, event: dict) -> None:
+        self.storage.store("agent.lifecycle", event)
+
+    def _store_resource(self, event: dict) -> None:
+        self.storage.store("agent.resource", event)
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        for cancel in self._subscriptions:
+            cancel()
+        self.storage.close()

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,0 +1,18 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from pathlib import Path
+
+from events import InMemoryEventBus
+from monitoring.metrics_collector import MetricsCollector
+
+
+def test_metrics_collector_stores_events(tmp_path: Path) -> None:
+    bus = InMemoryEventBus()
+    db_path = tmp_path / "metrics.db"
+    collector = MetricsCollector(bus, db_path)
+    bus.publish("agent.lifecycle", {"agent": "test", "action": "spawned"})
+    bus.publish("agent.resource", {"agent": "test", "cpu": 10.0, "memory": 20.0})
+    events = collector.storage.events("agent.resource")
+    assert events[0]["cpu"] == 10.0
+    collector.close()


### PR DESCRIPTION
## Summary
- Collect agent lifecycle and resource metrics via new `MetricsCollector`
- Extend `PerformanceMonitor` with CPU/memory usage, throughput metrics and alerts
- Provide FastAPI endpoints to inspect stored metrics

## Testing
- `pytest tests/test_metrics_collector.py::test_metrics_collector_stores_events tests/test_performance_monitor.py::test_performance_monitor_resource_alert -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac09c44014832f84614c9828a85f6a