### PR TITLE
feat: add agent lifecycle states and heartbeat

### DIFF
--- a/autogpts/autogpt/autogpt/agents/base.py
+++ b/autogpts/autogpt/autogpt/agents/base.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Optional
+import time
 
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
 from pydantic import Field, validator
@@ -197,8 +198,20 @@ class BaseAgent(Configurable[BaseAgentSettings], ABC):
 
         # Support multi-inheritance and mixins for subclasses
         super(BaseAgent, self).__init__()
-
         logger.debug(f"Created {__class__} '{self.ai_profile.ai_name}'")
+
+    # ------------------------------------------------------------------
+    # Heartbeat
+    # ------------------------------------------------------------------
+    def heartbeat(self) -> None:
+        """Emit a heartbeat event for this agent."""
+        try:
+            self.event_bus.publish(
+                "agent.heartbeat",
+                {"agent": self.state.agent_id, "time": time.time()},
+            )
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("Failed to publish heartbeat", exc_info=True)
 
     @property
     def llm(self) -> ChatModelInfo:

--- a/execution/manager.py
+++ b/execution/manager.py
@@ -10,7 +10,8 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
+from enum import Enum
 
 import psutil
 
@@ -23,6 +24,14 @@ from autogpt.core.resource.model_providers import ChatModelProvider
 from autogpt.file_storage.base import FileStorage
 from autogpt.agents.agent import Agent
 from .scheduler import Scheduler
+
+
+class AgentState(Enum):
+    INITIALIZING = "initializing"
+    RUNNING = "running"
+    IDLE = "idle"
+    SLEEPING = "sleeping"
+    TERMINATED = "terminated"
 
 
 class AgentLifecycleManager:
@@ -41,11 +50,19 @@ class AgentLifecycleManager:
         self._file_storage = file_storage
         self._event_bus = event_bus
         self._scheduler = scheduler
+        if self._scheduler:
+            self._scheduler.set_task_callback(self.notify_tasks)
         self._agents: Dict[str, Agent] = {}
         self._resources: Dict[str, Dict[str, float]] = {}
+        self._states: Dict[str, AgentState] = {}
+        self._heartbeats: Dict[str, float] = {}
+        self._paths: Dict[str, Path] = {}
+        self._task_count = 0
+        self._heartbeat_timeout = 30.0
         self._metrics = SystemMetricsCollector(event_bus)
         self._metrics.start()
         self._event_bus.subscribe("agent.resource", self._on_resource_event)
+        self._event_bus.subscribe("agent.heartbeat", self._on_heartbeat)
         self._resource_stop = threading.Event()
         self._resource_thread = threading.Thread(
             target=self._resource_manager, daemon=True
@@ -55,10 +72,34 @@ class AgentLifecycleManager:
         self._watcher.start()
 
     # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def _set_state(self, name: str, state: AgentState) -> None:
+        if self._states.get(name) == state:
+            return
+        self._states[name] = state
+        self._event_bus.publish(
+            "agent.state", {"agent": name, "state": state.value, "time": time.time()}
+        )
+
+    def _on_heartbeat(self, event: Dict[str, Any]) -> None:
+        name = event.get("agent")
+        if not name:
+            return
+        self._heartbeats[name] = event.get("time", time.time())
+        if self._states.get(name) in {AgentState.SLEEPING, AgentState.IDLE}:
+            self._set_state(name, AgentState.RUNNING)
+
+    def notify_tasks(self, count: int) -> None:
+        """Update the current number of pending tasks."""
+        self._task_count = count
+
+    # ------------------------------------------------------------------
     # Blueprint change handling
     # ------------------------------------------------------------------
     def _on_blueprint_change(self, path: Path) -> None:
         name = path.stem.split("_v")[0]
+        self._paths[name] = path
         try:
             agent = create_agent_from_blueprint(
                 path, self._config, self._llm_provider, self._file_storage
@@ -67,6 +108,7 @@ class AgentLifecycleManager:
             if previous is not None:
                 _shutdown_agent(previous)
                 self._metrics.unregister(name)
+                self._set_state(name, AgentState.TERMINATED)
                 action = "restarted"
             else:
                 action = "spawned"
@@ -77,6 +119,9 @@ class AgentLifecycleManager:
                 "memory": 0.0,
                 "last_active": time.time(),
             }
+            self._heartbeats[name] = time.time()
+            self._set_state(name, AgentState.INITIALIZING)
+            self._set_state(name, AgentState.RUNNING)
             if self._scheduler:
                 self._scheduler.add_agent(name)
             self._event_bus.publish(
@@ -107,7 +152,10 @@ class AgentLifecycleManager:
             _shutdown_agent(agent)
             if self._scheduler:
                 self._scheduler.remove_agent(name)
+            self._metrics.unregister(name)
+            self._set_state(name, AgentState.TERMINATED)
         self._agents.clear()
+        self._resources.clear()
 
     # ------------------------------------------------------------------
     def _on_resource_event(self, event: Dict[str, float]) -> None:
@@ -121,25 +169,39 @@ class AgentLifecycleManager:
             self._scheduler.update_agent(name, data["cpu"], data["memory"])
         if data["cpu"] > 1.0:
             data["last_active"] = time.time()
+            self._set_state(name, AgentState.RUNNING)
 
     def _resource_manager(self) -> None:
         idle_timeout = 30.0
         pressure_threshold = 80.0
         while not self._resource_stop.wait(5.0):
             now = time.time()
-            for name, data in list(self._resources.items()):
-                if now - data.get("last_active", now) > idle_timeout:
-                    agent = self._agents.get(name)
+
+            # Check heartbeat timeouts
+            for name in list(self._agents.keys()):
+                hb = self._heartbeats.get(name, 0.0)
+                if now - hb > self._heartbeat_timeout:
+                    agent = self._agents.pop(name, None)
                     if agent is not None:
                         _shutdown_agent(agent)
                         self._metrics.unregister(name)
-                        del self._agents[name]
-                        del self._resources[name]
                         if self._scheduler:
                             self._scheduler.remove_agent(name)
-                        self._event_bus.publish(
-                            "agent.lifecycle", {"agent": name, "action": "reclaimed"}
-                        )
+                    self._resources.pop(name, None)
+                    self._set_state(name, AgentState.SLEEPING)
+
+            # Check for idleness
+            for name, data in list(self._resources.items()):
+                if now - data.get("last_active", now) > idle_timeout:
+                    if self._states.get(name) == AgentState.RUNNING:
+                        self._set_state(name, AgentState.IDLE)
+
+            # Scale agents based on pending tasks
+            if self._task_count > len(self._agents):
+                self._wake_sleeping_agents(self._task_count - len(self._agents))
+            elif self._task_count < len(self._agents):
+                self._release_idle_agents(len(self._agents) - self._task_count)
+
             cpu_total = psutil.cpu_percent()
             mem_total = psutil.virtual_memory().percent
             if cpu_total > pressure_threshold or mem_total > pressure_threshold:
@@ -151,6 +213,42 @@ class AgentLifecycleManager:
                         "agent.resource",
                         {"agent": heavy, "action": "throttle"},
                     )
+
+    def _wake_sleeping_agents(self, count: int) -> None:
+        sleepers = [n for n, s in self._states.items() if s == AgentState.SLEEPING]
+        for name in sleepers[:count]:
+            path = self._paths.get(name)
+            if not path:
+                continue
+            try:
+                agent = create_agent_from_blueprint(
+                    path, self._config, self._llm_provider, self._file_storage
+                )
+                self._agents[name] = agent
+                self._metrics.register(name, getattr(agent, "pid", os.getpid()))
+                self._resources[name] = {
+                    "cpu": 0.0,
+                    "memory": 0.0,
+                    "last_active": time.time(),
+                }
+                self._heartbeats[name] = time.time()
+                if self._scheduler:
+                    self._scheduler.add_agent(name)
+                self._set_state(name, AgentState.RUNNING)
+            except Exception:
+                self._set_state(name, AgentState.TERMINATED)
+
+    def _release_idle_agents(self, count: int) -> None:
+        idle = [n for n, s in self._states.items() if s == AgentState.IDLE]
+        for name in idle[:count]:
+            agent = self._agents.pop(name, None)
+            if agent is not None:
+                _shutdown_agent(agent)
+                self._metrics.unregister(name)
+                if self._scheduler:
+                    self._scheduler.remove_agent(name)
+            self._resources.pop(name, None)
+            self._set_state(name, AgentState.SLEEPING)
 
 
 def _shutdown_agent(agent: Agent) -> None:


### PR DESCRIPTION
## Summary
- introduce explicit AgentState machine with initialization, running, idle, sleeping, and terminated phases
- add heartbeat interface and timeout handling for agents
- integrate scheduler task callbacks to wake or release agents based on workload

## Testing
- `pytest` *(fails: numpy.dtype size changed, may indicate binary incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0fc56ec8832f9d1976c9c83b03be