### PR TITLE
feat: add agent coordination framework

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Any
 
 import sentry_sdk
 from pydantic import Field
@@ -123,6 +123,14 @@ class Agent(
 
         self.log_cycle_handler = LogCycleHandler()
         """LogCycleHandler for structured debug logging."""
+
+    # ------------------------------------------------------------------
+    def report_status(
+        self, status: str, progress: float | None = None, **info: Any
+    ) -> None:
+        """Proxy to :meth:`BaseAgent.report_status`."""
+
+        super().report_status(status, progress=progress, **info)
 
     def build_prompt(
         self,

--- a/events/coordination.py
+++ b/events/coordination.py
@@ -1,0 +1,31 @@
+"""Standard event definitions for agent coordination."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+# Topics used for coordination events
+TASK_PUBLISH_TOPIC = "coordination.task.publish"
+STATUS_SYNC_TOPIC = "coordination.agent.status"
+TASK_COMPLETE_TOPIC = "coordination.task.complete"
+TASK_FAILED_TOPIC = "coordination.task.failed"
+
+
+@dataclass
+class TaskEvent:
+    """Event emitted when a new task is published for agents."""
+
+    task_id: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    target: Optional[str] = None
+
+
+@dataclass
+class StatusEvent:
+    """Event used by agents to report their current status."""
+
+    agent: str
+    status: str
+    progress: Optional[float] = None
+    info: Dict[str, Any] = field(default_factory=dict)

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,5 +1,6 @@
 from .executor import Executor
 from .task_graph import Task, TaskGraph
 from .scheduler import Scheduler
+from .coordinator import AgentCoordinator
 
-__all__ = ["Executor", "Task", "TaskGraph", "Scheduler"]
+__all__ = ["Executor", "Task", "TaskGraph", "Scheduler", "AgentCoordinator"]

--- a/execution/coordinator.py
+++ b/execution/coordinator.py
@@ -1,0 +1,48 @@
+"""Agent coordination utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from events import EventBus
+from events.coordination import (
+    STATUS_SYNC_TOPIC,
+    TASK_COMPLETE_TOPIC,
+    TASK_FAILED_TOPIC,
+    TASK_PUBLISH_TOPIC,
+    StatusEvent,
+    TaskEvent,
+)
+
+
+class AgentCoordinator:
+    """Listen for task events and coordinate work between agents."""
+
+    def __init__(self, event_bus: EventBus) -> None:
+        self._bus = event_bus
+        self._statuses: Dict[str, Dict[str, Any]] = {}
+        self._bus.subscribe(TASK_COMPLETE_TOPIC, self._on_task_complete)
+        self._bus.subscribe(TASK_FAILED_TOPIC, self._on_task_failed)
+        self._bus.subscribe(STATUS_SYNC_TOPIC, self._on_status)
+
+    # ------------------------------------------------------------------
+    def _on_task_complete(self, event: Dict[str, Any]) -> None:
+        """Handle task completion by redistributing work."""
+        self._bus.publish("coordination.reassign", event)
+
+    def _on_task_failed(self, event: Dict[str, Any]) -> None:
+        """Handle task failure by redistributing work."""
+        self._bus.publish("coordination.reassign", event)
+
+    def _on_status(self, event: Dict[str, Any]) -> None:
+        """Track latest status reported by agents."""
+        agent = event.get("agent")
+        if agent:
+            self._statuses[agent] = event
+
+    # ------------------------------------------------------------------
+    def publish_task(self, task: TaskEvent) -> None:
+        self._bus.publish(TASK_PUBLISH_TOPIC, task.__dict__)
+
+    def get_status(self, agent: str) -> Dict[str, Any] | None:
+        return self._statuses.get(agent)


### PR DESCRIPTION
## Summary
- define task and status coordination events
- introduce AgentCoordinator to redistribute tasks
- allow agents to report runtime status on event bus

## Testing
- `pytest tests/test_executor.py -q`
- `pytest tests/test_resource_model.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68ac09d277a4832fb7d5038125acf8c0