### PR TITLE
Add task coordination events and agent status reporting

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -35,6 +35,8 @@ from autogpt.models.action_history import (
 from autogpt.models.command import CommandOutput
 from autogpt.models.context_item import ContextItem
 
+from events.coordination import TaskStatus
+
 from .base import BaseAgent, BaseAgentConfiguration, BaseAgentSettings
 from .features.agent_file_manager import AgentFileManagerMixin
 from .features.context import ContextMixin
@@ -123,6 +125,13 @@ class Agent(
 
         self.log_cycle_handler = LogCycleHandler()
         """LogCycleHandler for structured debug logging."""
+
+    def report_status(
+        self, task_id: str, status: TaskStatus, detail: str | None = None
+    ) -> None:
+        """Report current task status via the event bus."""
+
+        super().report_status(task_id, status, detail)
 
     def build_prompt(
         self,

--- a/events/coordination.py
+++ b/events/coordination.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class TaskStatus(str, Enum):
+    """Enumeration of possible task states."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class TaskDispatchEvent:
+    """Event published by the coordinator to assign a task to an agent."""
+
+    task_id: str
+    payload: Dict[str, Any]
+    assigned_to: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class TaskStatusEvent:
+    """Event emitted by an agent to report the status of a task."""
+
+    agent_id: str
+    task_id: str
+    status: TaskStatus
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status.value
+        return data

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,5 +1,6 @@
 from .executor import Executor
 from .task_graph import Task, TaskGraph
 from .scheduler import Scheduler
+from .coordinator import AgentCoordinator
 
-__all__ = ["Executor", "Task", "TaskGraph", "Scheduler"]
+__all__ = ["Executor", "Task", "TaskGraph", "Scheduler", "AgentCoordinator"]

--- a/execution/coordinator.py
+++ b/execution/coordinator.py
@@ -1,0 +1,29 @@
+"""Coordinator handling task distribution and status monitoring."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from events import EventBus
+from events.coordination import TaskDispatchEvent, TaskStatus
+
+
+class AgentCoordinator:
+    """Listen for task status events and (re)dispatch tasks."""
+
+    def __init__(self, event_bus: EventBus) -> None:
+        self._bus = event_bus
+        self._bus.subscribe("agent.status", self._on_status)
+
+    def dispatch_task(
+        self, task_id: str, payload: Dict[str, Any], agent_id: str | None = None
+    ) -> None:
+        event = TaskDispatchEvent(task_id=task_id, payload=payload, assigned_to=agent_id)
+        self._bus.publish("task.dispatch", event.to_dict())
+
+    def _on_status(self, event: Dict[str, Any]) -> None:
+        status = event.get("status")
+        if status == TaskStatus.COMPLETED.value:
+            self._bus.publish("coordinator.task_completed", event)
+        elif status == TaskStatus.FAILED.value:
+            self._bus.publish("coordinator.task_failed", event)


### PR DESCRIPTION
## Summary
- introduce standardized task dispatch and status events
- add AgentCoordinator to route tasks and react to agent updates
- enable agents to report task status through the event bus

## Testing
- `pytest tests/test_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3fbb919c832fbe3f92f6c24ecb07