### PR TITLE
Track per-agent task counts in scheduler

### DIFF
--- a/execution/executor.py
+++ b/execution/executor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
 from typing import Any, Dict, List
 
 from capability.skill_library import SkillLibrary
@@ -12,7 +11,9 @@ from .scheduler import Scheduler
 class Executor:
     """Very small executor that decomposes a goal into skill tasks."""
 
-    def __init__(self, skill_library: SkillLibrary, scheduler: Scheduler | None = None) -> None:
+    def __init__(
+        self, skill_library: SkillLibrary, scheduler: Scheduler | None = None
+    ) -> None:
         self.skill_library = skill_library
         self.scheduler = scheduler or Scheduler()
         if not self.scheduler._agents:
@@ -49,7 +50,7 @@ class Executor:
         graph = self.decompose_goal(goal)
         return self.scheduler.submit(graph, self._call_skill)
 
-    def _call_skill(self, name: str) -> Any:
+    def _call_skill(self, agent: str, name: str) -> Any:
         code, _ = self.skill_library.get_skill(name)
         namespace: Dict[str, Any] = {}
         exec(code, namespace)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from execution import Scheduler  # noqa: E402
+from execution.task_graph import TaskGraph  # noqa: E402
+
+
+def test_per_agent_task_counts() -> None:
+    scheduler = Scheduler()
+    scheduler.add_agent("a1")
+    scheduler.add_agent("a2")
+
+    graph = TaskGraph()
+    graph.add_task("t1", "task 1", skill="s")
+    graph.add_task("t2", "task 2", skill="s")
+
+    def worker(agent: str, skill: str):
+        return agent
+
+    scheduler.submit(graph, worker)
+
+    counts = scheduler.task_counts
+    assert counts["a1"] + counts["a2"] == 2


### PR DESCRIPTION
## Summary
- Pass selected agent name to worker and record per-agent task counts
- Expose task count data for fairness checks
- Add regression test for Scheduler task count tracking

## Testing
- `flake8 execution/executor.py execution/scheduler.py tests/test_scheduler.py`
- `pytest tests/test_executor.py tests/test_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac438a8a90832f9df19e996e9f1b65