### PR TITLE
Pass agent identifier through scheduler and track per-agent counts

### DIFF
--- a/execution/executor.py
+++ b/execution/executor.py
@@ -49,7 +49,14 @@ class Executor:
         graph = self.decompose_goal(goal)
         return self.scheduler.submit(graph, self._call_skill)
 
-    def _call_skill(self, name: str) -> Any:
+    def _call_skill(self, agent: str, name: str) -> Any:
+        """Execute ``name`` skill for ``agent``.
+
+        The basic executor only supports a local ``SkillLibrary`` and therefore
+        ignores the ``agent`` argument, but the parameter allows alternative
+        implementations to route tasks to remote agents or specialized
+        resources.
+        """
         code, _ = self.skill_library.get_skill(name)
         namespace: Dict[str, Any] = {}
         exec(code, namespace)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 from execution.scheduler import Scheduler
+from execution.task_graph import TaskGraph
 
 
 def test_pick_least_busy_distributes_tasks():
@@ -37,3 +38,22 @@ def test_task_weight_affects_selection():
     scheduler._agents["B"]["tasks"] = 0
 
     assert scheduler._pick_least_busy() == "B"
+
+
+def test_submit_tracks_per_agent_task_counts():
+    scheduler = Scheduler()
+    scheduler.add_agent("A")
+    scheduler.add_agent("B")
+
+    graph = TaskGraph()
+    for i in range(4):
+        graph.add_task(f"t{i}", description="task", skill=f"s{i}")
+
+    def worker(agent: str, skill: str) -> str:
+        return agent
+
+    results = scheduler.submit(graph, worker)
+    assert set(results.keys()) == {f"t{i}" for i in range(4)}
+    counts = scheduler.task_counts()
+    assert counts["A"] + counts["B"] == 4
+    assert counts["A"] > 0 and counts["B"] > 0


### PR DESCRIPTION
## Summary
- allow `Scheduler.submit` to pass the chosen agent name to the worker callable
- record completed task counts per agent and expose `task_counts`
- update executor worker signature and add scheduler test

## Testing
- `pytest tests/test_scheduler.py`
- `pytest tests/test_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4559d7dc832f874cd8d096ce7e6b