### PR TITLE
Add pluggable conflict detection with structured comparison

### DIFF
--- a/evolution/genesis_team/__init__.py
+++ b/evolution/genesis_team/__init__.py
@@ -5,7 +5,11 @@ from .archaeologist import Archaeologist
 from .tdd_dev import TDDDeveloper
 from .qa import QA
 from .manager import GenesisTeamManager
-from .conflict import ConflictResolver
+from .conflict import (
+    ConflictResolver,
+    KeywordConflictStrategy,
+    StructuredDataConflictStrategy,
+)
 
 __all__ = [
     "Sentinel",
@@ -14,4 +18,6 @@ __all__ = [
     "QA",
     "GenesisTeamManager",
     "ConflictResolver",
+    "KeywordConflictStrategy",
+    "StructuredDataConflictStrategy",
 ]

--- a/evolution/genesis_team/conflict.py
+++ b/evolution/genesis_team/conflict.py
@@ -2,8 +2,71 @@
 
 from __future__ import annotations
 
+import json
+import difflib
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, Iterable, List
+
+
+class ConflictDetectionStrategy(ABC):
+    """Interface for conflict detection strategies."""
+
+    @abstractmethod
+    def detect(self, agent_name: str, logs: Dict[str, str]) -> bool:
+        """Return True if a conflict is present for the given agent."""
+
+
+class KeywordConflictStrategy(ConflictDetectionStrategy):
+    """Detect conflicts based on presence of configured keywords."""
+
+    def __init__(self, keywords: Iterable[str] | None = None) -> None:
+        self.keywords = [
+            keyword.lower()
+            for keyword in (keywords or ["conflict", "version mismatch", "overlap", "error"])
+        ]
+
+    def detect(self, agent_name: str, logs: Dict[str, str]) -> bool:
+        output = logs.get(agent_name, "").lower()
+        return any(keyword in output for keyword in self.keywords)
+
+
+class StructuredDataConflictStrategy(ConflictDetectionStrategy):
+    """Parse JSON outputs and detect overlapping edits or version mismatches."""
+
+    def detect(self, agent_name: str, logs: Dict[str, str]) -> bool:  # noqa: D401 - see base class
+        try:
+            current = json.loads(logs[agent_name])
+        except (KeyError, json.JSONDecodeError):
+            return False
+
+        file_name = current.get("file")
+        version = current.get("version")
+        content = current.get("content", "")
+
+        for name, raw in logs.items():
+            if name == agent_name:
+                continue
+            try:
+                other = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if other.get("file") != file_name:
+                continue
+            if other.get("version") != version:
+                return True  # version mismatch
+            other_content = other.get("content", "")
+            if other_content != content:
+                diff = list(
+                    difflib.unified_diff(
+                        other_content.splitlines(),
+                        content.splitlines(),
+                        lineterm="",
+                    )
+                )
+                if diff:
+                    return True  # overlapping edits
+        return False
 
 
 @dataclass
@@ -11,13 +74,12 @@ class ConflictResolver:
     """Detects conflicts in agent outputs and coordinates resolution."""
 
     history: List[str] = field(default_factory=list)
+    strategy: ConflictDetectionStrategy = field(default_factory=KeywordConflictStrategy)
 
-    def detect(self, output: str) -> bool:
-        """Return True if the output contains signs of conflict."""
+    def detect(self, agent_name: str, logs: Dict[str, str]) -> bool:
+        """Return True if the agent's output conflicts with existing logs."""
 
-        lowered = output.lower()
-        keywords = ["conflict", "version mismatch", "overlap", "error"]
-        return any(keyword in lowered for keyword in keywords)
+        return self.strategy.detect(agent_name, logs)
 
     def resolve(self, agent_name: str, logs: Dict[str, str]) -> str:
         """Resolve detected conflicts by rolling back or merging.
@@ -36,7 +98,7 @@ class ConflictResolver:
         """
 
         output = logs[agent_name]
-        if self.detect(output):
+        if self.detect(agent_name, logs):
             logs[agent_name] = f"ROLLED BACK: {output}"
             decision = f"{agent_name}: rollback"
         else:

--- a/tests/genesis_team/test_conflict.py
+++ b/tests/genesis_team/test_conflict.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evolution.genesis_team.conflict import (
+    ConflictResolver,
+    StructuredDataConflictStrategy,
+)
+
+
+def test_overlapping_edits_detection():
+    """Conflicts arise when agents edit the same file differently."""
+
+    logs = {
+        "agent1": json.dumps({"file": "module.py", "version": 1, "content": "a = 1"}),
+        "agent2": json.dumps({"file": "module.py", "version": 1, "content": "a = 2"}),
+    }
+    resolver = ConflictResolver(strategy=StructuredDataConflictStrategy())
+    assert resolver.detect("agent2", logs)
+    decision = resolver.resolve("agent2", logs)
+    assert "rollback" in decision
+
+
+def test_version_mismatch_detection():
+    """Conflicts arise when agents disagree on version numbers."""
+
+    logs = {
+        "agent1": json.dumps({"file": "module.py", "version": 1, "content": "a = 1"}),
+        "agent2": json.dumps({"file": "module.py", "version": 2, "content": "a = 1"}),
+    }
+    resolver = ConflictResolver(strategy=StructuredDataConflictStrategy())
+    assert resolver.detect("agent2", logs)
+    decision = resolver.resolve("agent2", logs)
+    assert "rollback" in decision
+


### PR DESCRIPTION
## Summary
- add ConflictDetectionStrategy interface with keyword and JSON diff implementations
- allow ConflictResolver to accept custom strategies and expose them from package
- test overlapping edits and version mismatches via structured strategy

## Testing
- `pytest tests/genesis_team/test_conflict.py tests/genesis_team/test_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4624fcc8832fa4e1f89307e30d30