### PR TITLE
feat: async in-memory event bus

### DIFF
--- a/benchmarks/event_bus_latency.py
+++ b/benchmarks/event_bus_latency.py
@@ -1,0 +1,30 @@
+"""Benchmark publish latency for InMemoryEventBus."""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from events import InMemoryEventBus, publish, subscribe
+
+
+def _handler(event):
+    time.sleep(0.001)
+
+
+def measure(bus: InMemoryEventBus, n: int = 100) -> float:
+    unsub = subscribe(bus, "topic", _handler)
+    start = time.perf_counter()
+    for i in range(n):
+        publish(bus, "topic", {"i": i})
+    end = time.perf_counter()
+    if hasattr(bus, "join"):
+        bus.join()
+    unsub()
+    return (end - start) / n
+
+
+if __name__ == "__main__":
+    latency = measure(InMemoryEventBus())
+    print(f"Average publish latency: {latency*1000:.3f} ms")

--- a/tests/test_manager_cleanup.py
+++ b/tests/test_manager_cleanup.py
@@ -115,6 +115,7 @@ def test_cleanup_removes_long_sleeping_agents(monkeypatch):
     mgr._paths["test"] = Path("dummy")
 
     mgr._cleanup_sleeping_agents(time.time())
+    bus.join()
 
     assert "test" not in mgr._states
     assert "test" not in mgr._agents

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -13,6 +13,7 @@ def test_metrics_collector_stores_events(tmp_path: Path) -> None:
     collector = MetricsCollector(bus, db_path)
     bus.publish("agent.lifecycle", {"agent": "test", "action": "spawned"})
     bus.publish("agent.resource", {"agent": "test", "cpu": 10.0, "memory": 20.0})
+    bus.join()
     events = collector.storage.events("agent.resource")
     assert events[0]["cpu"] == 10.0
     collector.close()


### PR DESCRIPTION
## Summary
- process `InMemoryEventBus` events on background worker threads and expose `join` to wait for queue
- update tests to account for asynchronous event processing
- add publish latency benchmark utility

## Testing
- `pytest tests/test_metrics_collector.py tests/test_manager_cleanup.py`
- `python benchmarks/event_bus_latency.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac543f6858832f950451ff58631c8f