### PR TITLE
feat: async skill loading with cache

### DIFF
--- a/capability/librarian.py
+++ b/capability/librarian.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict, List
 from concurrent.futures import ThreadPoolExecutor
 import os
+import asyncio
 
 try:
     from autogpt.core.knowledge_graph import (
@@ -100,7 +101,7 @@ class Librarian:
         return ids
 
     def get_skill(self, name: str):
-        return self.library.get_skill(name)
+        return asyncio.run(self.library.get_skill(name))
 
     def list_skills(self) -> List[str]:
         return self.library.list_skills()

--- a/evolution/strategist.py
+++ b/evolution/strategist.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List, Tuple, Optional
+import asyncio
 from datetime import datetime
 from threading import Timer
 from heapq import heappop, heappush
@@ -33,7 +34,9 @@ class Strategist(Agent):
 
     def perform(self, logs: Iterable[Path] | None = None) -> Path:
         # Load strategist reasoning template to guide log analysis
-        template, _meta = self.library.get_skill(META_SKILL_STRATEGY_EVOLUTION)
+        template, _meta = asyncio.run(
+            self.library.get_skill(META_SKILL_STRATEGY_EVOLUTION)
+        )
         lines: List[str] = template.splitlines()
         for log in logs or []:
             path = Path(log)

--- a/execution/executor.py
+++ b/execution/executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from typing import Any, Dict, List
+import asyncio
 
 from capability.skill_library import SkillLibrary
 from .task_graph import TaskGraph
@@ -57,7 +58,7 @@ class Executor:
         implementations to route tasks to remote agents or specialized
         resources.
         """
-        code, _ = self.skill_library.get_skill(name)
+        code, _ = asyncio.run(self.skill_library.get_skill(name))
         namespace: Dict[str, Any] = {}
         exec(code, namespace)
         func = namespace.get(name)

--- a/tests/test_skill_library.py
+++ b/tests/test_skill_library.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.getcwd()))
 import json
 import subprocess
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_add_and_get_skill(tmp_path: Path) -> None:
     metadata = {"lang": "python"}
 
     lib.add_skill("hello", code, metadata)
-    retrieved_code, retrieved_meta = lib.get_skill("hello")
+    retrieved_code, retrieved_meta = asyncio.run(lib.get_skill("hello"))
 
     assert "return 'hi'" in retrieved_code
     assert retrieved_meta == metadata
@@ -47,7 +48,7 @@ def test_meta_skill_requires_activation(tmp_path: Path) -> None:
     }
     lib.add_skill("MetaSkill_Test", code, metadata)
     with pytest.raises(PermissionError):
-        lib.get_skill("MetaSkill_Test")
+        asyncio.run(lib.get_skill("MetaSkill_Test"))
     lib.activate_meta_skill("MetaSkill_Test")
-    _, meta = lib.get_skill("MetaSkill_Test")
+    _, meta = asyncio.run(lib.get_skill("MetaSkill_Test"))
     assert meta["active"] is True


### PR DESCRIPTION
## Summary
- make SkillLibrary load skills asynchronously using aiofiles
- add manual LRU cache to reduce disk I/O
- update callers and tests for async get_skill

## Testing
- `pytest tests/test_skill_library.py tests/test_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac56f77af4832fa5a52fa56603bab3