### PR TITLE
chore: use explicit SDK imports

### DIFF
--- a/autogpts/forge/forge/sdk/__init__.py
+++ b/autogpts/forge/forge/sdk/__init__.py
@@ -5,7 +5,20 @@ core of the Forge.
 from ..llm import chat_completion_request, create_embedding_request, transcribe_audio
 from .agent import Agent
 from .db import AgentDB, Base
-from .errors import *
+from .errors import (
+    AccessDeniedError,
+    AgentException,
+    CodeExecutionError,
+    CommandExecutionError,
+    ConfigurationError,
+    DuplicateOperationError,
+    InvalidAgentResponseError,
+    InvalidArgumentError,
+    NotFoundError,
+    OperationNotAllowedError,
+    TooMuchOutputError,
+    UnknownCommandError,
+)
 from .forge_log import ForgeLogger
 from .model import (
     Artifact,
@@ -23,3 +36,40 @@ from .model import (
 )
 from .prompting import PromptEngine
 from .workspace import LocalWorkspace, Workspace
+
+__all__ = [
+    "chat_completion_request",
+    "create_embedding_request",
+    "transcribe_audio",
+    "Agent",
+    "AgentDB",
+    "Base",
+    "AccessDeniedError",
+    "AgentException",
+    "CodeExecutionError",
+    "CommandExecutionError",
+    "ConfigurationError",
+    "DuplicateOperationError",
+    "InvalidAgentResponseError",
+    "InvalidArgumentError",
+    "NotFoundError",
+    "OperationNotAllowedError",
+    "TooMuchOutputError",
+    "UnknownCommandError",
+    "ForgeLogger",
+    "Artifact",
+    "ArtifactUpload",
+    "Pagination",
+    "Status",
+    "Step",
+    "StepOutput",
+    "StepRequestBody",
+    "Task",
+    "TaskArtifactsListResponse",
+    "TaskListResponse",
+    "TaskRequestBody",
+    "TaskStepsListResponse",
+    "PromptEngine",
+    "LocalWorkspace",
+    "Workspace",
+]

--- a/autogpts/forge/forge/sdk/db_test.py
+++ b/autogpts/forge/forge/sdk/db_test.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 
-from forge.sdk.db import (
+from .db import (
     AgentDB,
     ArtifactModel,
     StepModel,
@@ -13,14 +13,8 @@ from forge.sdk.db import (
     convert_to_step,
     convert_to_task,
 )
-from forge.sdk.errors import NotFoundError as DataNotFoundError
-from forge.sdk.model import (
-    Artifact,
-    Status,
-    Step,
-    StepRequestBody,
-    Task,
-)
+from .errors import NotFoundError as DataNotFoundError
+from .model import Artifact, Status, Step, StepRequestBody, Task
 
 
 @pytest.mark.asyncio

--- a/autogpts/forge/forge/sdk/routes/agent_protocol.py
+++ b/autogpts/forge/forge/sdk/routes/agent_protocol.py
@@ -28,14 +28,25 @@ from typing import Optional
 from fastapi import APIRouter, Query, Request, Response, UploadFile
 from fastapi.responses import FileResponse
 
-from forge.sdk.errors import *
-from forge.sdk.forge_log import ForgeLogger
-from forge.sdk.model import *
-from forge.sdk.utils import get_detailed_traceback, get_exception_message
+from ..errors import NotFoundError
+from ..forge_log import ForgeLogger
+from ..model import (
+    Artifact,
+    Step,
+    StepRequestBody,
+    Task,
+    TaskArtifactsListResponse,
+    TaskListResponse,
+    TaskRequestBody,
+    TaskStepsListResponse,
+)
+from ..utils import get_detailed_traceback, get_exception_message
 
 base_router = APIRouter()
 
 LOG = ForgeLogger(__name__)
+
+__all__ = ["base_router"]
 
 
 @base_router.get("/", tags=["root"])


### PR DESCRIPTION
## Summary
- avoid wildcard imports in `forge.sdk` and expose symbols via `__all__`
- narrow `agent_protocol` imports and export router explicitly
- adjust SDK tests to import local modules directly

## Testing
- `pytest autogpts/forge/forge/sdk -q` *(fails: NameError: name 'StepInput' is not defined; AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68ac719246ac832fbde17268340470d9