### PR TITLE
feat: add centralized exception handling

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,4 @@
+"""Common utilities for AutoGPT."""
+from .exceptions import AutoGPTException, log_and_format_exception
+
+__all__ = ["AutoGPTException", "log_and_format_exception"]

--- a/common/exceptions.py
+++ b/common/exceptions.py
@@ -1,0 +1,18 @@
+"""Project-wide exception utilities."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+
+class AutoGPTException(Exception):
+    """Base class for AutoGPT project specific exceptions."""
+
+
+def log_and_format_exception(
+    exc: Exception, logger: Optional[logging.Logger] = None
+) -> dict[str, str]:
+    """Log *exc* and return a standardized error representation."""
+    log = logger or logging.getLogger(__name__)
+    log.exception("%s: %s", type(exc).__name__, exc)
+    return {"error_type": type(exc).__name__, "message": str(exc)}

--- a/monitoring/performance_monitor.py
+++ b/monitoring/performance_monitor.py
@@ -8,6 +8,8 @@ from typing import Any, Callable, Iterable, List
 import smtplib
 
 from .storage import TimeSeriesStorage
+from common import AutoGPTException, log_and_format_exception
+from smtplib import SMTPException
 
 AlertHandler = Callable[[str, str], None]
 
@@ -130,8 +132,12 @@ class PerformanceMonitor:
         for handler in self.alert_handlers:
             try:
                 handler(subject, message)
-            except Exception:
-                pass
+            except AutoGPTException as err:
+                log_and_format_exception(err)
+            except SMTPException as err:
+                log_and_format_exception(err)
+            except Exception as err:  # pragma: no cover - unexpected
+                log_and_format_exception(err)
 
 
 def email_alert(

--- a/tests/test_manager_error_handling.py
+++ b/tests/test_manager_error_handling.py
@@ -1,0 +1,107 @@
+import sys, os, types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+# Stub heavy dependencies before importing manager
+sys.modules["agent_factory"] = types.SimpleNamespace(
+    create_agent_from_blueprint=lambda *a, **k: object()
+)
+sys.modules["autogpt"] = types.SimpleNamespace()
+sys.modules["autogpt.config"] = types.SimpleNamespace(Config=object)
+sys.modules["autogpt.core.resource.model_providers"] = types.SimpleNamespace(
+    ChatModelProvider=object
+)
+sys.modules["autogpt.file_storage.base"] = types.SimpleNamespace(FileStorage=object)
+sys.modules["autogpt.agents.agent"] = types.SimpleNamespace(Agent=object)
+
+
+class _StubWatcher:
+    def __init__(self, cb):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+sys.modules["org_charter.watchdog"] = types.SimpleNamespace(BlueprintWatcher=_StubWatcher)
+
+from events import InMemoryEventBus
+from common import AutoGPTException
+import execution.manager as manager
+from execution.manager import AgentLifecycleManager
+
+
+class DummyMetrics:
+    def __init__(self, bus):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def register(self, name, pid):
+        pass
+
+    def unregister(self, name):
+        pass
+
+
+class DummyWatcher:
+    def __init__(self, cb):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def _make_manager(bus, monkeypatch):
+    monkeypatch.setattr(manager, "SystemMetricsCollector", DummyMetrics)
+    monkeypatch.setattr(manager, "BlueprintWatcher", DummyWatcher)
+    return AgentLifecycleManager(
+        config=types.SimpleNamespace(),
+        llm_provider=object(),
+        file_storage=object(),
+        event_bus=bus,
+    )
+
+
+def test_on_blueprint_change_spawn(monkeypatch):
+    events = []
+    bus = InMemoryEventBus()
+    bus.subscribe("agent.lifecycle", lambda e: events.append(e))
+    monkeypatch.setattr(manager, "create_agent_from_blueprint", lambda *a, **k: object())
+    mgr = _make_manager(bus, monkeypatch)
+    path = Path("agent_v1.json")
+    mgr._on_blueprint_change(path)
+    bus.join()
+    assert any(e["action"] == "spawned" for e in events)
+    mgr.stop()
+
+
+def test_on_blueprint_change_error(monkeypatch, caplog):
+    events = []
+    bus = InMemoryEventBus()
+    bus.subscribe("agent.lifecycle", lambda e: events.append(e))
+
+    def raising(*a, **k):
+        raise AutoGPTException("boom")
+
+    monkeypatch.setattr(manager, "create_agent_from_blueprint", raising)
+    mgr = _make_manager(bus, monkeypatch)
+    path = Path("agent_v1.json")
+    with caplog.at_level("ERROR"):
+        mgr._on_blueprint_change(path)
+    bus.join()
+    assert events[0]["action"] == "failed"
+    assert events[0]["error_type"] == "AutoGPTException"
+    assert any("AutoGPTException" in r.message for r in caplog.records)
+    mgr.stop()


### PR DESCRIPTION
## Summary
- add project-wide AutoGPTException and logging utility
- integrate structured exception handling in PerformanceMonitor and AgentLifecycleManager
- cover new error paths with targeted unit tests

## Testing
- `pytest tests/test_performance_monitor.py tests/test_manager_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac71a1e028832f853b665688ba5881