### PR TITLE
Make skill loading async and improve loop handling

### DIFF
--- a/agent_factory.py
+++ b/agent_factory.py
@@ -33,6 +33,7 @@ from autogpts.autogpt.autogpt.core.errors import AutoGPTError
 
 from capability.librarian import Librarian
 from org_charter import io as charter_io
+from common.async_utils import run_async
 
 
 logger = logging.getLogger(__name__)
@@ -93,7 +94,7 @@ def _load_additional_tool(
     """
     librarian = Librarian(str(repo_path))
     try:
-        code, meta = librarian.get_skill(name)
+        code, meta = run_async(librarian.get_skill(name))
     except (OSError, PermissionError, JSONDecodeError) as err:
         logger.exception("Failed to retrieve tool '%s' from skill library", name)
         raise AutoGPTError(f"Failed to load tool '{name}'") from err

--- a/autogpts/autogpt/agbenchmark_config/benchmarks.py
+++ b/autogpts/autogpt/agbenchmark_config/benchmarks.py
@@ -11,13 +11,14 @@ from autogpt.config import AIProfile, ConfigBuilder
 from autogpt.file_storage import FileStorageBackendName, get_storage
 from autogpt.logs.config import configure_logging
 from autogpt.models.command_registry import CommandRegistry
+from common.async_utils import run_async
 
 LOG_DIR = Path(__file__).parent / "logs"
 
 
 def run_specific_agent(task: str, continuous_mode: bool = False) -> None:
     agent = bootstrap_agent(task, continuous_mode)
-    asyncio.run(run_interaction_loop(agent))
+    run_async(run_interaction_loop(agent))
 
 
 def bootstrap_agent(task: str, continuous_mode: bool) -> Agent:

--- a/autogpts/autogpt/autogpt/core/runner/client_lib/utils.py
+++ b/autogpts/autogpt/autogpt/core/runner/client_lib/utils.py
@@ -54,9 +54,14 @@ def handle_exceptions(
     return wrapped
 
 
-def coroutine(f: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T]:
+def coroutine(f: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T | asyncio.Task[T]]:
     @functools.wraps(f)
     def wrapper(*args: P.args, **kwargs: P.kwargs):
-        return asyncio.run(f(*args, **kwargs))
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(f(*args, **kwargs))
+        else:
+            return loop.create_task(f(*args, **kwargs))
 
     return wrapper

--- a/capability/skill_library.py
+++ b/capability/skill_library.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import subprocess
 from collections import OrderedDict
@@ -74,10 +73,10 @@ class SkillLibrary:
         """Retrieve a skill's source code and metadata using an in-memory cache."""
         return await self._load_skill(name)
 
-    def activate_meta_skill(self, name: str) -> None:
+    async def activate_meta_skill(self, name: str) -> None:
         """Mark a meta-skill as active and commit the change to Git."""
         meta_file = self.storage_dir / f"{name}.json"
-        metadata = json.loads(asyncio.run(self._read_file(meta_file)))
+        metadata = json.loads(await self._read_file(meta_file))
         metadata["active"] = True
         meta_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
         subprocess.run(["git", "add", str(meta_file)], cwd=self.repo_path, check=True)

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,4 +1,5 @@
 """Common utilities for AutoGPT."""
 from .exceptions import AutoGPTException, log_and_format_exception
+from .async_utils import run_async
 
-__all__ = ["AutoGPTException", "log_and_format_exception"]
+__all__ = ["AutoGPTException", "log_and_format_exception", "run_async"]

--- a/common/async_utils.py
+++ b/common/async_utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable
+
+
+def run_async(coro: Awaitable[Any]) -> Any:
+    """Run ``coro`` respecting any running event loop.
+
+    If no loop is running in the current thread, ``asyncio.run`` is used. When a
+    loop is already running, the coroutine is scheduled on that loop and its
+    result is awaited in a thread-safe manner.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()

--- a/evolution/strategist.py
+++ b/evolution/strategist.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List, Tuple, Optional
-import asyncio
 from datetime import datetime
 from threading import Timer
 from heapq import heappop, heappush
@@ -12,6 +11,7 @@ import json
 
 from capability.meta_skill import META_SKILL_STRATEGY_EVOLUTION
 from capability.skill_library import SkillLibrary
+from common.async_utils import run_async
 
 from . import Agent
 
@@ -34,7 +34,7 @@ class Strategist(Agent):
 
     def perform(self, logs: Iterable[Path] | None = None) -> Path:
         # Load strategist reasoning template to guide log analysis
-        template, _meta = asyncio.run(
+        template, _meta = run_async(
             self.library.get_skill(META_SKILL_STRATEGY_EVOLUTION)
         )
         lines: List[str] = template.splitlines()

--- a/tests/test_skill_library.py
+++ b/tests/test_skill_library.py
@@ -49,6 +49,6 @@ def test_meta_skill_requires_activation(tmp_path: Path) -> None:
     lib.add_skill("MetaSkill_Test", code, metadata)
     with pytest.raises(PermissionError):
         asyncio.run(lib.get_skill("MetaSkill_Test"))
-    lib.activate_meta_skill("MetaSkill_Test")
+    asyncio.run(lib.activate_meta_skill("MetaSkill_Test"))
     _, meta = asyncio.run(lib.get_skill("MetaSkill_Test"))
     assert meta["active"] is True


### PR DESCRIPTION
## Summary
- Convert skill execution path to async, including Executor._call_skill, SkillLibrary.activate_meta_skill, and Librarian.get_skill
- Add run_async helper and replace coroutine decorator to respect existing event loops
- Gate remaining asyncio.run usages across the codebase

## Testing
- `pytest tests/test_skill_library.py tests/test_agent_factory_executor_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f2b7990832fab4c8bae865d2f37