### PR TITLE
centralize skill exceptions and standardize logging

### DIFF
--- a/agent_factory.py
+++ b/agent_factory.py
@@ -29,24 +29,16 @@ from autogpt.core.resource.model_providers import ChatModelProvider
 from autogpt.file_storage.base import FileStorage
 from autogpt.models.command_registry import CommandRegistry
 
-from autogpts.autogpt.autogpt.core.errors import AutoGPTError
+from autogpts.autogpt.autogpt.core.errors import (
+    AutoGPTError,
+    SkillSecurityError,
+)
 
 from capability.librarian import Librarian
 from org_charter import io as charter_io
 
 
 logger = logging.getLogger(__name__)
-
-
-class SkillSecurityError(AutoGPTError):
-    """Raised when a skill fails security verification."""
-
-    def __init__(self, skill: str, cause: str) -> None:
-        super().__init__(f"Skill {skill} blocked: {cause}")
-        self.skill = skill
-        self.cause = cause
-
-
 SAFE_BUILTINS: dict[str, object] = {
     "__import__": __import__,
     "len": len,
@@ -101,7 +93,7 @@ def _load_additional_tool(
     try:
         _verify_skill(name, code, meta)
     except SkillSecurityError as err:
-        logger.warning("Rejected tool '%s': %s", name, err.cause)
+        logger.exception("Security violation for skill %s: %s", name, err.cause)
         raise
 
     namespace: dict[str, object] = {}

--- a/autogpts/autogpt/autogpt/core/errors.py
+++ b/autogpts/autogpt/autogpt/core/errors.py
@@ -16,3 +16,21 @@ class PluginError(AutoGPTError):
 
 class EventBusError(AutoGPTError):
     """Raised for problems related to the event bus."""
+
+
+class SkillSecurityError(AutoGPTError):
+    """Raised when a skill fails security verification."""
+
+    def __init__(self, skill: str, cause: str) -> None:
+        super().__init__(f"Skill {skill} blocked: {cause}")
+        self.skill = skill
+        self.cause = cause
+
+
+class SkillExecutionError(AutoGPTError):
+    """Raised when a skill fails during execution."""
+
+    def __init__(self, skill: str, cause: str) -> None:
+        super().__init__(f"Skill {skill} failed: {cause}")
+        self.skill = skill
+        self.cause = cause

--- a/execution/executor.py
+++ b/execution/executor.py
@@ -7,25 +7,15 @@ import logging
 from typing import Any, Dict, List
 import asyncio
 
+from autogpts.autogpt.autogpt.core.errors import (
+    SkillExecutionError,
+    SkillSecurityError,
+)
 from capability.skill_library import SkillLibrary
 from .task_graph import TaskGraph
 from .scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-
-
-class SkillExecutionError(RuntimeError):
-    def __init__(self, skill: str, cause: str) -> None:
-        super().__init__(f"Skill {skill} failed: {cause}")
-        self.skill = skill
-        self.cause = cause
-
-
-class SkillSecurityError(RuntimeError):
-    def __init__(self, skill: str, cause: str) -> None:
-        super().__init__(f"Skill {skill} blocked: {cause}")
-        self.skill = skill
-        self.cause = cause
 
 
 SAFE_BUILTINS: Dict[str, Any] = {
@@ -99,7 +89,7 @@ class Executor:
         try:
             _verify_skill(name, code, meta)
         except SkillSecurityError as err:
-            logger.error("Security violation for skill %s: %s", name, err.cause)
+            logger.exception("Security violation for skill %s: %s", name, err.cause)
             raise
         namespace: Dict[str, Any] = {}
         parsed = ast.parse(code, mode="exec")
@@ -107,7 +97,7 @@ class Executor:
         func = namespace.get(name)
         if not callable(func):
             err = SkillExecutionError(name, f"did not define a callable {name}()")
-            logger.error(str(err))
+            logger.error("Error executing skill %s: %s", name, err.cause)
             raise err
         try:
             return func()

--- a/tests/test_agent_factory_executor_integration.py
+++ b/tests/test_agent_factory_executor_integration.py
@@ -58,7 +58,7 @@ sys.modules.setdefault("autogpt.commands", commands_module)
 from agent_factory import create_agent_from_blueprint
 from capability.skill_library import SkillLibrary
 from execution import Executor
-from execution.executor import SkillExecutionError
+from autogpts.autogpt.autogpt.core.errors import SkillExecutionError
 from autogpt.config import Config
 from autogpt.file_storage.local import LocalFileStorage, FileStorageConfiguration
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,7 +10,7 @@ import pytest
 
 from capability.skill_library import SkillLibrary
 from execution import Executor
-from execution.executor import SkillExecutionError
+from autogpts.autogpt.autogpt.core.errors import SkillExecutionError
 
 
 def init_repo(path: Path) -> None:


### PR DESCRIPTION
## Summary
- add SkillSecurityError and SkillExecutionError to core exception module
- refactor agent factory and executor to import centralized exceptions
- log skill security violations consistently with stack traces

## Testing
- `pytest tests/test_executor.py tests/test_agent_factory_executor_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f403840832fba2c8958ed616ae6