### PR TITLE
refactor: centralize skill security utilities

### DIFF
--- a/agent_factory.py
+++ b/agent_factory.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Iterable
 
 import ast
-import hashlib
 import logging
 from json import JSONDecodeError
 
@@ -34,40 +33,10 @@ from autogpts.autogpt.autogpt.core.errors import AutoGPTError
 from capability.librarian import Librarian
 from org_charter import io as charter_io
 from common.async_utils import run_async
+from common.security import SAFE_BUILTINS, SkillSecurityError, _verify_skill
 
 
 logger = logging.getLogger(__name__)
-
-
-class SkillSecurityError(AutoGPTError):
-    """Raised when a skill fails security verification."""
-
-    def __init__(self, skill: str, cause: str) -> None:
-        super().__init__(f"Skill {skill} blocked: {cause}")
-        self.skill = skill
-        self.cause = cause
-
-
-SAFE_BUILTINS: dict[str, object] = {
-    "__import__": __import__,
-    "len": len,
-    "range": range,
-    "print": print,
-    "Exception": Exception,
-    "RuntimeError": RuntimeError,
-}
-
-
-def _verify_skill(name: str, code: str, metadata: dict) -> None:
-    """Ensure skill source passes signature verification."""
-
-    signature = metadata.get("signature")
-    if not signature:
-        raise SkillSecurityError(name, "missing signature")
-    digest = hashlib.sha256(code.encode("utf-8")).hexdigest()
-    if signature != digest:
-        raise SkillSecurityError(name, "invalid signature")
-
 
 def _parse_blueprint(path: Path) -> dict:
     """Load and validate a blueprint file.

--- a/common/security.py
+++ b/common/security.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict
+
+from autogpts.autogpt.autogpt.core.errors import AutoGPTError
+
+
+class SkillSecurityError(AutoGPTError):
+    """Raised when a skill fails security verification."""
+
+    def __init__(self, skill: str, cause: str) -> None:
+        super().__init__(f"Skill {skill} blocked: {cause}")
+        self.skill = skill
+        self.cause = cause
+
+
+SAFE_BUILTINS: Dict[str, Any] = {
+    "__import__": __import__,
+    "len": len,
+    "range": range,
+    "print": print,
+    "Exception": Exception,
+    "RuntimeError": RuntimeError,
+}
+
+
+def _verify_skill(name: str, code: str, metadata: Dict[str, Any]) -> None:
+    """Ensure skill source passes signature verification."""
+
+    signature = metadata.get("signature")
+    if not signature:
+        raise SkillSecurityError(name, "missing signature")
+    digest = hashlib.sha256(code.encode("utf-8")).hexdigest()
+    if signature != digest:
+        raise SkillSecurityError(name, "invalid signature")


### PR DESCRIPTION
## Summary
- centralize skill verification logic in `common/security.py`
- refactor `agent_factory` and executor to reuse shared security utilities
- make executor's `_call_skill` callable synchronously via internal async wrapper

## Testing
- `pytest tests/test_executor.py tests/test_agent_factory_executor_integration.py tests/test_skill_library.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac91a87550832f99c87a9af3429c42