### PR TITLE
feat: add async skill retrieval interface

### DIFF
--- a/agent_factory.py
+++ b/agent_factory.py
@@ -36,7 +36,6 @@ from autogpts.autogpt.autogpt.core.errors import (
 
 from capability.librarian import Librarian
 from org_charter import io as charter_io
-from common.async_utils import run_async
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +85,7 @@ def _load_additional_tool(
     """
     librarian = Librarian(str(repo_path))
     try:
-        code, meta = run_async(librarian.get_skill(name))
+        code, meta = librarian.get_skill(name)
     except (OSError, PermissionError, JSONDecodeError) as err:
         logger.exception("Failed to retrieve tool '%s' from skill library", name)
         raise AutoGPTError(f"Failed to load tool '{name}'") from err


### PR DESCRIPTION
## Summary
- add `Librarian.get_skill_async` and sync wrapper `get_skill`
- use new sync `get_skill` in `agent_factory`

## Testing
- `pytest tests/test_agent_factory_executor_integration.py::test_agent_factory_and_executor -q`
- `pytest tests/test_skill_library.py::test_add_and_get_skill -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac95f30e38832fa8b79807c4b0d10c