### PR TITLE
Scan local OpenAI plugin directories

### DIFF
--- a/autogpts/autogpt/tests/unit/data/test_plugins/local_openai_plugin/ai-plugin.json
+++ b/autogpts/autogpt/tests/unit/data/test_plugins/local_openai_plugin/ai-plugin.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Local OpenAI Plugin",
+  "name_for_model": "local-openai-plugin",
+  "description_for_human": "Local plugin for testing.",
+  "description_for_model": "Local plugin for testing.",
+  "auth": {"type": "none"},
+  "api": {"type": "openapi", "url": "https://example.com"},
+  "logo_url": "https://example.com/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "https://example.com/legal"
+}

--- a/autogpts/autogpt/tests/unit/data/test_plugins/local_openai_plugin/openapi.json
+++ b/autogpts/autogpt/tests/unit/data/test_plugins/local_openai_plugin/openapi.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.1",
+  "info": {"title": "Local Test Plugin", "version": "1.0"},
+  "paths": {
+    "/hello": {
+      "get": {
+        "operationId": "hello_hello_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response",
+                  "type": "object",
+                  "properties": {"greeting": {"type": "string"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/autogpts/autogpt/tests/unit/test_plugins.py
+++ b/autogpts/autogpt/tests/unit/test_plugins.py
@@ -11,6 +11,7 @@ PLUGINS_TEST_DIR = "tests/unit/data/test_plugins"
 PLUGIN_TEST_ZIP_FILE = "Auto-GPT-Plugin-Test-master.zip"
 PLUGIN_TEST_INIT_PY = "Auto-GPT-Plugin-Test-master/src/auto_gpt_vicuna/__init__.py"
 PLUGIN_TEST_OPENAI = "https://weathergpt.vercel.app/"
+LOCAL_OPENAI_PLUGIN = "local_openai_plugin"
 
 
 def test_scan_plugins_openai(config: Config):
@@ -23,6 +24,20 @@ def test_scan_plugins_openai(config: Config):
     # Test that the function returns the correct number of plugins
     result = scan_plugins(config)
     assert len(result) == 1
+
+
+def test_scan_plugins_openai_local(config: Config):
+    config.plugins_openai = []
+    plugins_config = config.plugins_config
+    plugins_config.plugins[LOCAL_OPENAI_PLUGIN] = PluginConfig(
+        name=LOCAL_OPENAI_PLUGIN, enabled=True
+    )
+
+    result = scan_plugins(config)
+    assert len(result) == 1
+    from autogpt.models.base_open_ai_plugin import BaseOpenAIPlugin
+
+    assert any(isinstance(p, BaseOpenAIPlugin) for p in result)
 
 
 def test_scan_plugins_generic(config: Config):


### PR DESCRIPTION
## Summary
- walk plugin directory to locate ai-plugin.json manifests and load them alongside remote plugin URLs
- initialize OpenAI plugins using stored plugin directories
- add test plugin and unit test covering local OpenAI plugin discovery

## Testing
- `pytest autogpts/autogpt/tests/unit/test_plugins.py::test_scan_plugins_openai_local -q` *(fails: ModuleNotFoundError: No module named 'spacy')*
- `python - <<'PY'\nimport os, sys, types\nos.chdir('autogpts/autogpt')\nsys.path.append('.')\nsys.modules['playsound'] = types.SimpleNamespace(playsound=lambda *a, **k: None)\nfrom autogpt.config import Config\nfrom autogpt.plugins.plugins_config import PluginsConfig\nfrom autogpt.plugins.plugin_config import PluginConfig\nfrom autogpt.plugins import scan_plugins\nconfig = Config()\nconfig.plugins_dir = 'tests/unit/data/test_plugins'\nconfig.plugins_config = PluginsConfig(plugins={'local_openai_plugin': PluginConfig(name='local_openai_plugin', enabled=True)})\nconfig.plugins_openai = []\nconfig.noninteractive_mode = True\nplugins = scan_plugins(config)\nprint('loaded', [type(p).__name__ for p in plugins])\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68aca7b30bd8832f980957caca5db9e4