### PR TITLE
feat: validate Task.type with TaskType enum

### DIFF
--- a/autogpts/autogpt/tests/unit/test_capability_agent.py
+++ b/autogpts/autogpt/tests/unit/test_capability_agent.py
@@ -5,7 +5,7 @@ import pytest
 
 from autogpt.core.ability.base import AbilityRegistry, AbilityConfiguration
 from autogpt.core.ability.schema import AbilityResult
-from autogpt.core.planning.schema import Task
+from autogpt.core.planning.schema import Task, TaskType
 
 
 def _load_capability_agent():
@@ -85,7 +85,7 @@ async def test_capability_agent_selects_matching_ability():
 
     task = Task(
         objective="Write some code",
-        type="write",
+        type=TaskType.WRITE,
         priority=1,
         ready_criteria=[],
         acceptance_criteria=[],

--- a/autogpts/autogpt/tests/unit/test_task_queue.py
+++ b/autogpts/autogpt/tests/unit/test_task_queue.py
@@ -1,6 +1,6 @@
 import heapq
 from autogpt.core.agent.simple import SimpleAgent
-from autogpt.core.planning.schema import Task
+from autogpt.core.planning.schema import Task, TaskType
 
 
 def _dummy_agent() -> SimpleAgent:
@@ -12,7 +12,7 @@ def _dummy_agent() -> SimpleAgent:
 def _make_task(priority: int) -> Task:
     return Task(
         objective=f"task {priority}",
-        type="test",
+        type=TaskType.TEST,
         priority=priority,
         ready_criteria=[],
         acceptance_criteria=[],

--- a/benchmark/task_queue_benchmark.py
+++ b/benchmark/task_queue_benchmark.py
@@ -6,12 +6,12 @@ import time
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "autogpts" / "autogpt"))
-from autogpt.core.planning.schema import Task
+from autogpt.core.planning.schema import Task, TaskType
 
 
 def _make_tasks(n: int) -> list[Task]:
     return [
-        Task(objective=f"task {i}", type="test", priority=random.randint(1, 100), ready_criteria=[], acceptance_criteria=[])
+        Task(objective=f"task {i}", type=TaskType.TEST, priority=random.randint(1, 100), ready_criteria=[], acceptance_criteria=[])
         for i in range(n)
     ]
 

--- a/tests/test_reasoning_planner.py
+++ b/tests/test_reasoning_planner.py
@@ -8,14 +8,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "autogpts", "autogp
 
 from autogpt.agent_manager import AgentManager
 from autogpt.core.planning.reasoner import ReasoningPlanner
-from autogpt.core.planning.schema import Task, TaskStatus
+from autogpt.core.planning.schema import Task, TaskStatus, TaskType
 from autogpt.file_storage.local import FileStorageConfiguration, LocalFileStorage
 
 
 def make_task(objective: str) -> Task:
     return Task(
         objective=objective,
-        type="plan",
+        type=TaskType.PLAN,
         priority=1,
         ready_criteria=["gather requirements", "outline approach"],
         acceptance_criteria=[],

--- a/tests/test_task_completion.py
+++ b/tests/test_task_completion.py
@@ -90,7 +90,7 @@ sys.modules["monitoring"] = monitoring_mod
 
 import heapq
 from autogpt.core.agent.simple import SimpleAgent
-from autogpt.core.planning.schema import Task, TaskStatus
+from autogpt.core.planning.schema import Task, TaskStatus, TaskType
 from autogpt.core.ability import AbilityResult
 
 
@@ -139,7 +139,7 @@ async def test_tasks_marked_complete_when_acceptance_criteria_met(tmp_path):
 
     current_task = Task(
         objective="Task 1",
-        type="task",
+        type=TaskType.TEST,
         priority=1,
         ready_criteria=["start"],
         acceptance_criteria=["done"],
@@ -147,7 +147,7 @@ async def test_tasks_marked_complete_when_acceptance_criteria_met(tmp_path):
 
     other_task = Task(
         objective="Task 2",
-        type="task",
+        type=TaskType.TEST,
         priority=2,
         ready_criteria=["start"],
         acceptance_criteria=["finish"],

--- a/tests/test_task_quality_filtering.py
+++ b/tests/test_task_quality_filtering.py
@@ -59,7 +59,7 @@ monitoring_mod.ActionLogger = _ActionLogger
 sys.modules["monitoring"] = monitoring_mod
 
 from autogpt.core.agent.simple import SimpleAgent
-from autogpt.core.planning.schema import TaskStatus
+from autogpt.core.planning.schema import TaskStatus, TaskType
 
 
 class DummyPlan:
@@ -98,14 +98,14 @@ async def test_low_quality_tasks_filtered_and_prioritized():
         "task_list": [
             {
                 "objective": "Good task",
-                "type": "task",
+                "type": TaskType.TEST,
                 "priority": 1,
                 "ready_criteria": ["do it"],
                 "acceptance_criteria": ["done"],
             },
             {
                 "objective": "Bad task",
-                "type": "task",
+                "type": TaskType.TEST,
                 "priority": 1,
                 "ready_criteria": [],
                 "acceptance_criteria": [],
@@ -118,7 +118,7 @@ async def test_low_quality_tasks_filtered_and_prioritized():
         logger=logging.getLogger("test"),
         ability_registry=DummyAbilityRegistry(),
         memory=DummyMemory(),
-        openai_provider=DummyOpenAIProvider(),
+        model_providers={},
         planning=DummyPlanner(plan),
         workspace=DummyWorkspace(),
     )

--- a/tests/test_task_schema.py
+++ b/tests/test_task_schema.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+
+from autogpt.core.planning.schema import Task, TaskType
+
+
+def test_task_type_accepts_valid_string():
+    task = Task(
+        objective="Example",
+        type="write",
+        priority=1,
+        ready_criteria=[],
+        acceptance_criteria=[],
+    )
+    assert task.type is TaskType.WRITE
+
+
+def test_task_type_rejects_invalid_string():
+    with pytest.raises(ValidationError):
+        Task(
+            objective="Example",
+            type="invalid",
+            priority=1,
+            ready_criteria=[],
+            acceptance_criteria=[],
+        )


### PR DESCRIPTION
## Summary
- use `TaskType` enum for `Task.type` and coerce incoming strings
- update task construction in tests and benchmarks to use `TaskType`
- add tests for valid/invalid task type handling

## Testing
- `pytest tests/test_reasoning_planner.py tests/test_task_completion.py tests/test_creative_planner.py tests/test_task_quality_filtering.py tests/test_task_schema.py -q`
- ⚠️ `pytest tests/test_reasoning_planner.py tests/test_task_completion.py tests/test_creative_planner.py tests/test_task_quality_filtering.py autogpts/autogpt/tests/unit/test_capability_agent.py autogpts/autogpt/tests/unit/test_task_queue.py autogpts/autogpt/tests/unit/test_task_schema.py -q` (missing google.cloud.logging_v2)


------
https://chatgpt.com/codex/tasks/task_e_68acfeed48dc832f8985fd0f06970911