### PR TITLE
Integrate experience logging and pipeline accumulation

### DIFF
--- a/autogpts/autogpt/autogpt/agents/layers/evolution.py
+++ b/autogpts/autogpt/autogpt/agents/layers/evolution.py
@@ -11,6 +11,7 @@ from ...core.agent.simple import PerformanceEvaluator
 from autogpt.core.agent.layered import LayeredAgent
 from autogpt.core.memory import Memory
 from autogpt.core.planning import SimplePlanner
+from ml.experience_collector import log_interaction
 
 
 class EvolutionAgent(LayeredAgent):
@@ -116,6 +117,10 @@ class EvolutionAgent(LayeredAgent):
             )
 
         self._log_training(self._last_state, self._last_action, reward)
+        try:
+            log_interaction(self._last_state, ability_name, result, reward)
+        except Exception:
+            pass
         self._generation_count += 1
         if self._generation_count >= self._generations:
             for state_prefs in self._policy.values():

--- a/ml/experience_collector.py
+++ b/ml/experience_collector.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+LOG_FILE = Path("data") / "new_logs.csv"
+
+
+def log_interaction(task: Any, ability: str, result: Any, reward: float) -> None:
+    """Record an interaction to ``data/new_logs.csv``.
+
+    Parameters
+    ----------
+    task:
+        The task or state associated with this interaction.
+    ability:
+        Name of the ability that was executed.
+    result:
+        Result object from the ability execution. ``input`` and ``output``
+        attributes (or keys if ``result`` is a mapping) are extracted if
+        available.
+    reward:
+        Numeric reward representing the quality of the result.
+    """
+    state = getattr(task, "id", getattr(task, "name", str(task)))
+
+    if isinstance(result, dict):
+        input_data = result.get("input") or result.get("prompt") or ""
+        output_data = result.get("output") or result.get("response") or str(result)
+    else:
+        input_data = getattr(result, "input", "")
+        output_data = getattr(result, "output", str(result))
+
+    LOG_FILE.parent.mkdir(exist_ok=True)
+    file_exists = LOG_FILE.exists()
+    with LOG_FILE.open("a", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["state", "ability", "input", "output", "reward"]
+        )
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(
+            {
+                "state": state,
+                "ability": ability,
+                "input": input_data,
+                "output": output_data,
+                "reward": reward,
+            }
+        )

--- a/ml/retraining_pipeline.py
+++ b/ml/retraining_pipeline.py
@@ -25,18 +25,20 @@ CURRENT = ARTIFACTS / "current"
 def accumulate_logs() -> None:
     """Append new logs to the main dataset and clear the buffer file.
 
-    New logs are expected in ``data/new_logs.csv`` with columns ``text`` and
-    ``target``.  They are appended to ``data/dataset.csv`` which serves as the
-    aggregated dataset for training.  The buffer file is removed afterwards.
+    New logs are expected in ``data/new_logs.csv`` with columns
+    ``state, ability, input, output, reward``. They are appended to
+    ``data/dataset.csv`` which serves as the aggregated dataset for training.
+    The buffer file is removed afterwards.
     """
     if not NEW_LOGS.exists():
         return
 
     DATA_DIR.mkdir(exist_ok=True)
+    columns = ["state", "ability", "input", "output", "reward"]
     if DATASET.exists():
         df = pd.read_csv(DATASET)
     else:
-        df = pd.DataFrame(columns=["text", "target"])
+        df = pd.DataFrame(columns=columns)
     new_df = pd.read_csv(NEW_LOGS)
     df = pd.concat([df, new_df], ignore_index=True)
     df.to_csv(DATASET, index=False)


### PR DESCRIPTION
## Summary
- add `ml/experience_collector.py` for logging interactions to `data/new_logs.csv`
- record evolution agent feedback with `log_interaction`
- update retraining pipeline to merge new interaction logs

## Testing
- `python3 -m pytest` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0f986198832fa33f327c705d78ba