### PR TITLE
Add LLM fine-tuning support with LoRA

### DIFF
--- a/docs/retraining_pipeline.md
+++ b/docs/retraining_pipeline.md
@@ -5,17 +5,27 @@ entries.
 
 1. **Accumulate logs** – new logs are stored in `data/new_logs.csv` and are
    appended to the aggregated dataset `data/dataset.csv`.
-2. **Retrain and evaluate** – the dataset is used to train a fresh model via
-   `ml/train_models.py`. The resulting metrics are compared against the current
-   baseline located in `artifacts/current/`.
-3. **Deploy on improvement** – if the new model achieves a lower test MSE, it
-   replaces the existing model in `artifacts/current/`.
+2. **Retrain and evaluate** – the dataset is used to train a fresh model.
+   Classic models are trained via `ml/train_models.py` while LLMs use
+   `ml/fine_tune_llm.py` when calling the pipeline with `--model llm`. The
+   resulting metrics (MSE for classic models or perplexity for LLMs) are
+   compared against the current baseline located in `artifacts/current/`.
+3. **Deploy on improvement** – if the new model achieves a lower metric, it
+   replaces the existing model in `artifacts/current/`. Older versions remain in
+   `artifacts/<version>/` and can be restored manually to roll back.
 
 To execute the pipeline periodically, use the provided `retrain_cron.sh` script
-in a cron job or workflow:
+in a cron job or workflow. The script forwards all arguments to the Python
+module, allowing LLM training:
 
 ```cron
-0 0 * * * /path/to/retrain_cron.sh >> /path/to/retrain.log 2>&1
+0 0 * * * /path/to/retrain_cron.sh --model llm >> /path/to/retrain.log 2>&1
 ```
 
-This runs the pipeline every day at midnight.
+This runs the pipeline every day at midnight. To roll back to a previous model
+version, copy the desired directory back to `artifacts/current/`:
+
+```bash
+rm -rf artifacts/current
+cp -r artifacts/<old_version> artifacts/current
+```

--- a/ml/fine_tune_llm.py
+++ b/ml/fine_tune_llm.py
@@ -1,0 +1,95 @@
+"""Fine-tune a language model using LoRA/PEFT on a CSV dataset.
+
+This script loads a dataset with ``input`` and ``output`` columns, combines
+them into a dialogue-style training text and performs LoRA fine-tuning using
+HuggingFace ``transformers`` and ``peft``. The resulting weights and metrics
+are stored under ``artifacts/<version>/``.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+from datasets import Dataset
+from peft import LoraConfig, get_peft_model
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+
+
+def load_dataset(path: str) -> Dataset:
+    """Load dataset from ``path`` and return a HF ``Dataset``."""
+    df = pd.read_csv(path)
+    if "input" not in df.columns or "output" not in df.columns:
+        raise ValueError("CSV must contain 'input' and 'output' columns")
+    df["text"] = "User: " + df["input"].astype(str) + "\nAssistant: " + df["output"].astype(str)
+    return Dataset.from_pandas(df[["text"]])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune LLM with LoRA")
+    parser.add_argument("data", help="Path to dataset CSV with columns 'input' and 'output'")
+    parser.add_argument("--base_model", default="gpt2", help="Base model name")
+    parser.add_argument("--version", default="v1", help="Version string for artifacts")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    args = parser.parse_args()
+
+    dataset = load_dataset(args.data)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    def tokenize(batch):
+        return tokenizer(batch["text"], truncation=True, max_length=512)
+
+    tokenized = dataset.map(tokenize, batched=True, remove_columns=["text"])
+
+    model = AutoModelForCausalLM.from_pretrained(args.base_model)
+    lora_config = LoraConfig(
+        r=8,
+        lora_alpha=32,
+        target_modules=["q_proj", "v_proj"],
+        lora_dropout=0.1,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    model = get_peft_model(model, lora_config)
+
+    training_args = TrainingArguments(
+        output_dir="artifacts/tmp",
+        per_device_train_batch_size=1,
+        per_device_eval_batch_size=1,
+        num_train_epochs=args.epochs,
+        logging_steps=10,
+        save_strategy="no",
+        report_to=[],
+    )
+    collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized,
+        eval_dataset=tokenized,
+        data_collator=collator,
+    )
+    trainer.train()
+    eval_result = trainer.evaluate()
+    perplexity = float(torch.exp(torch.tensor(eval_result["eval_loss"])))
+
+    version_dir = Path("artifacts") / args.version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(version_dir)
+    tokenizer.save_pretrained(version_dir)
+    with open(version_dir / "metrics.txt", "w") as f:
+        f.write(f"Perplexity: {perplexity}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/retrain_cron.sh
+++ b/retrain_cron.sh
@@ -4,4 +4,4 @@
 # 0 0 * * * /path/to/retrain_cron.sh >> /path/to/retrain.log 2>&1
 set -e
 cd "$(dirname "$0")"
-python -m ml.retraining_pipeline
+python -m ml.retraining_pipeline "$@"


### PR DESCRIPTION
## Summary
- Implement `ml/fine_tune_llm.py` to fine-tune causal language models with LoRA/PEFT and store artifacts
- Extend retraining pipeline with `--model` option and metric-based deployment logic
- Forward arguments in `retrain_cron.sh` and document automatic fine-tuning and rollback

## Testing
- `pytest tests/test_founder_ml_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad152a508c832f8026d89552c2bea6