### PR TITLE
Add auto scheduler for periodic self-learning tasks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -30,6 +30,7 @@ def setup():
     """Installs dependencies needed for your system. Works with Linux, MacOS and Windows WSL."""
     import os
     import subprocess
+    import sys
 
     click.echo(
         click.style(
@@ -331,6 +332,11 @@ def start(agent_name, no_setup):
         subprocess.Popen(["./run"], cwd=agent_dir)
         click.echo(f"⌛ (Re)starting agent '{agent_name}'...")
         wait_until_conn_ready(8000)
+
+        subprocess.Popen(
+            [sys.executable, "execution/auto_scheduler.py"], cwd=script_dir
+        )
+        click.echo("⌛ Starting auto scheduler...")
         click.echo("✅ Agent application started and available on port 8000")
     elif not os.path.exists(agent_dir):
         click.echo(

--- a/docs/self_learning.md
+++ b/docs/self_learning.md
@@ -25,3 +25,28 @@ Warnings emitted during failed deployments or rollbacks should be fed into the
 system's monitoring and alerting pipeline. This enables operators to react
 promptly when model quality regresses or automated rollbacks are triggered.
 
+## Automatic Scheduling
+
+AutoGPT can automatically run the retraining pipeline and self-improvement
+routine at fixed intervals. When an agent is started via
+`python cli.py agent start <name>`, a background scheduler is launched.
+
+Intervals are configured through environment variables (values are in seconds):
+
+| Variable | Purpose |
+| --- | --- |
+| `AUTO_RETRAIN_INTERVAL` | Run `ml.retraining_pipeline.main` periodically |
+| `AUTO_SELF_IMPROVE_INTERVAL` | Invoke `SelfImprovement.run` periodically |
+| `AUTO_SCHEDULE_INTERVAL` | Fallback interval if the above are unset |
+
+If none of these variables are set to a positive value the scheduler exits
+immediately.
+
+Example:
+
+```bash
+export AUTO_RETRAIN_INTERVAL=3600           # retrain hourly
+export AUTO_SELF_IMPROVE_INTERVAL=86400     # self-improve daily
+python cli.py agent start forge
+```
+

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -2,5 +2,13 @@ from .executor import Executor
 from .task_graph import Task, TaskGraph
 from .scheduler import Scheduler
 from .coordinator import AgentCoordinator
+from .auto_scheduler import AutoScheduler
 
-__all__ = ["Executor", "Task", "TaskGraph", "Scheduler", "AgentCoordinator"]
+__all__ = [
+    "Executor",
+    "Task",
+    "TaskGraph",
+    "Scheduler",
+    "AgentCoordinator",
+    "AutoScheduler",
+]

--- a/execution/auto_scheduler.py
+++ b/execution/auto_scheduler.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Callable, List
+
+logger = logging.getLogger(__name__)
+
+
+class AutoScheduler:
+    """Simple scheduler for periodically executing jobs."""
+
+    def __init__(self) -> None:
+        self._jobs: List[tuple[Callable[[], None], float]] = []
+        self._stop = threading.Event()
+
+    def add_job(self, func: Callable[[], None], interval: float) -> None:
+        """Register ``func`` to run every ``interval`` seconds."""
+
+        self._jobs.append((func, interval))
+
+    def _run_job(self, func: Callable[[], None], interval: float) -> None:
+        while not self._stop.wait(interval):
+            try:
+                func()
+            except Exception:  # pragma: no cover - job may raise arbitrary errors
+                logger.exception("Scheduled job failed")
+
+    def start(self) -> None:
+        """Start all registered jobs and block until stopped."""
+
+        for func, interval in self._jobs:
+            thread = threading.Thread(
+                target=self._run_job, args=(func, interval), daemon=True
+            )
+            thread.start()
+
+        try:
+            while not self._stop.is_set():
+                time.sleep(1)
+        except KeyboardInterrupt:
+            self.stop()
+
+    def stop(self) -> None:
+        """Signal all jobs to stop."""
+
+        self._stop.set()
+
+
+def _env_interval(var: str, default: float) -> float:
+    try:
+        return float(os.getenv(var, default))
+    except ValueError:
+        return default
+
+
+def main() -> None:
+    scheduler = AutoScheduler()
+
+    default_interval = _env_interval("AUTO_SCHEDULE_INTERVAL", 0.0)
+    retrain_interval = _env_interval("AUTO_RETRAIN_INTERVAL", default_interval)
+    self_improve_interval = _env_interval(
+        "AUTO_SELF_IMPROVE_INTERVAL", default_interval
+    )
+
+    if retrain_interval > 0:
+        from ml import retraining_pipeline
+
+        scheduler.add_job(retraining_pipeline.main, retrain_interval)
+
+    if self_improve_interval > 0:
+        from evolution.self_improvement import SelfImprovement
+
+        scheduler.add_job(lambda: SelfImprovement().run(), self_improve_interval)
+
+    if scheduler._jobs:
+        logger.info("Starting AutoScheduler with %d job(s)", len(scheduler._jobs))
+        scheduler.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce AutoScheduler for running periodic jobs like retraining and self improvement
- export AutoScheduler and start it automatically when launching an agent
- document scheduling usage and environment variable configuration

## Testing
- `pytest` *(fails: Defining 'pytest_plugins' in a non-top-level conftest is no longer supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ad31063a6c832f90d21e59c34ff5a0