### PR TITLE
Add Windows setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Commands:
 ```
 
 克隆仓库后在根目录运行 `poetry install` 安装所有依赖，再使用 `./run setup` 开始！
+Windows 用户请先在 PowerShell 中执行 `./setup.ps1`（或 `powershell -ExecutionPolicy Bypass -File setup.ps1`），该脚本会检测并安装 Python 与 Poetry，然后再运行上述命令。
 
 安装完成后，可通过以下命令验证项目能否正常运行：
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 5.0
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    Write-Error 'setup.ps1 should be run on Windows.'
+    exit 1
+}
+
+function Install-Python {
+    Write-Host 'Python not found. Attempting installation...'
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Host 'Installing Python 3.11 via winget.'
+        try {
+            winget install --id Python.Python.3.11 -e --source winget
+        } catch {
+            Write-Error 'Failed to install Python via winget. Please install it manually from https://www.python.org/downloads/'
+            exit 1
+        }
+    } else {
+        Write-Error 'winget is not available. Install Python manually from https://www.python.org/downloads/'
+        exit 1
+    }
+}
+
+function Install-Poetry {
+    Write-Host 'Poetry not found. Attempting installation...'
+    try {
+        (Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
+    } catch {
+        Write-Error 'Failed to install Poetry. See https://python-poetry.org/docs/#installation for help.'
+        exit 1
+    }
+}
+
+# Check Python
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) {
+    Install-Python
+} else {
+    $pyVersion = & python --version
+    Write-Host "Python found: $pyVersion"
+}
+
+# Check Poetry
+$poetry = Get-Command poetry -ErrorAction SilentlyContinue
+if (-not $poetry) {
+    Install-Poetry
+} else {
+    $poetryVersion = & poetry --version
+    Write-Host "Poetry found: $poetryVersion"
+}
+
+Write-Host 'Environment setup complete.'


### PR DESCRIPTION
## Summary
- add `setup.ps1` to install Python and Poetry on Windows using winget and the official Poetry installer
- document how Windows users can run the new script before installing dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68af6efa266c832f8a87cebb11004de1