### PR TITLE
feat: add environment validation

### DIFF
--- a/autogpts/autogpt/autogpt/app/cli.py
+++ b/autogpts/autogpt/autogpt/app/cli.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from pydantic import ValidationError
+
+from autogpt.config.validation import validate_env
 
 from autogpt.logs.config import LogFormatName
 
@@ -14,6 +17,14 @@ from .telemetry import setup_telemetry
 @click.pass_context
 def cli(ctx: click.Context):
     setup_telemetry()
+    try:
+        validate_env()
+    except ValidationError as err:
+        missing = ", ".join(e["loc"][0] for e in err.errors())
+        click.echo(
+            f"Missing required environment variables: {missing}", err=True
+        )
+        raise SystemExit(1) from err
 
     # Invoke `run` by default
     if ctx.invoked_subcommand is None:

--- a/autogpts/autogpt/autogpt/config/validation.py
+++ b/autogpts/autogpt/autogpt/config/validation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseSettings, Field, SecretStr
+
+
+class EnvConfig(BaseSettings):
+    """Required environment variables for AutoGPT."""
+
+    openai_api_key: SecretStr = Field(..., env="OPENAI_API_KEY")
+
+
+def validate_env() -> EnvConfig:
+    """Validate required environment variables.
+
+    Returns the parsed ``EnvConfig``. Raises ``ValidationError`` if validation
+    fails.
+    """
+
+    EnvConfig.update_forward_refs(SecretStr=SecretStr)
+    return EnvConfig()

--- a/docs/content/AutoGPT/setup/index.md
+++ b/docs/content/AutoGPT/setup/index.md
@@ -114,5 +114,9 @@ Once you have cloned or downloaded the project:
 
 You should now be able to explore the CLI (`./autogpt.sh --help`) and run the application.
 
+### Configuration validation
+
+On startup AutoGPT validates that required environment variables are present and correctly typed. Missing values, such as a missing `OPENAI_API_KEY`, cause the CLI to print an error and exit. Double-check your `.env` file for misspelled keys or empty values if validation fails.
+
 See the [user guide](../usage.md) for further instructions.
 

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import importlib.util
+
+import pytest
+from pydantic import ValidationError
+
+spec = importlib.util.spec_from_file_location(
+    "validation", Path("autogpts/autogpt/autogpt/config/validation.py")
+)
+validation = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validation)
+validate_env = validation.validate_env
+
+
+def test_validate_env_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    validate_env()
+
+
+def test_validate_env_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(ValidationError):
+        validate_env()


### PR DESCRIPTION
## Summary
- validate required environment variables using Pydantic
- fail fast from CLI when configuration is missing
- document configuration validation and provide tests

## Testing
- `pytest tests/test_env_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af7fbc98d8832f86b079fed48bf170