### PR TITLE
docs: update embedding benchmark path

### DIFF
--- a/docs/embedding_search.md
+++ b/docs/embedding_search.md
@@ -8,7 +8,7 @@ approaches:
 * **Weighted-average** – compute embeddings for each chunk of a document and use
   the token-length weighted average as the document representation.
 
-The benchmark (see `benchmark/embedding_search_benchmark.py`) evaluated retrieval
+The benchmark (see `modules/benchmark/embedding_search_benchmark.py`) evaluated retrieval
 accuracy on a small corpus of animal facts. Results:
 
 ```


### PR DESCRIPTION
## Summary
- fix embedding search benchmark script path in documentation

## Testing
- `pytest modules/benchmark/tests/test_benchmark_workflow.py` *(fails: HTTPConnectionPool port 8000 connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bba75f11e0832fb1f79ada297e8290