### PR TITLE
Add algorithm documentation and examples

### DIFF
--- a/algorithms/docs/docs/dynamic_programming/fibonacci.md
+++ b/algorithms/docs/docs/dynamic_programming/fibonacci.md
@@ -1,0 +1,18 @@
+# Fibonacci
+
+**Purpose:** Compute the n-th Fibonacci number using dynamic programming.
+
+**Input:** `n` (int) — position in the sequence.
+
+**Output:** n-th Fibonacci number as `int`.
+
+## Example
+```python
+from algorithms.dynamic_programming.basic.fibonacci import Fibonacci
+
+Fibonacci().execute(7)
+```
+Output:
+```
+13
+```

--- a/algorithms/docs/docs/dynamic_programming/lcs.md
+++ b/algorithms/docs/docs/dynamic_programming/lcs.md
@@ -1,0 +1,20 @@
+# Longest Common Subsequence
+
+**Purpose:** Find the length of the longest sequence present in two strings.
+
+**Input:**
+- `s1`: first string
+- `s2`: second string
+
+**Output:** Length of the longest common subsequence as `int`.
+
+## Example
+```python
+from algorithms.dynamic_programming.basic.lcs import LongestCommonSubsequence
+
+LongestCommonSubsequence().execute("abcde", "ace")
+```
+Output:
+```
+3
+```

--- a/algorithms/docs/docs/graph/bfs.md
+++ b/algorithms/docs/docs/graph/bfs.md
@@ -1,0 +1,26 @@
+# Breadth-First Search
+
+**Purpose:** Traverse a graph level by level.
+
+**Input:**
+- `graph`: `Graph` instance
+- `start`: starting node
+
+**Output:** `List[Any]` of nodes visited in BFS order.
+
+## Example
+```python
+from algorithms.graph.basic.bfs import BreadthFirstSearch
+from algorithms.utils import Graph
+
+g = Graph()
+g.add_edge('A', 'B')
+g.add_edge('A', 'C')
+g.add_edge('B', 'D')
+
+BreadthFirstSearch().execute(g, 'A')
+```
+Output:
+```
+['A', 'B', 'C', 'D']
+```

--- a/algorithms/docs/docs/graph/dfs.md
+++ b/algorithms/docs/docs/graph/dfs.md
@@ -1,0 +1,26 @@
+# Depth-First Search
+
+**Purpose:** Traverse a graph exploring as far as possible along each branch before backtracking.
+
+**Input:**
+- `graph`: `Graph` instance
+- `start`: starting node
+
+**Output:** `List[Any]` of nodes visited in DFS order.
+
+## Example
+```python
+from algorithms.graph.basic.dfs import DepthFirstSearch
+from algorithms.utils import Graph
+
+g = Graph()
+g.add_edge('A', 'B')
+g.add_edge('A', 'C')
+g.add_edge('B', 'D')
+
+DepthFirstSearch().execute(g, 'A')
+```
+Output:
+```
+['A', 'B', 'D', 'C']
+```

--- a/algorithms/docs/docs/index.md
+++ b/algorithms/docs/docs/index.md
@@ -1,0 +1,4 @@
+# Algorithm Library
+
+This site documents the algorithms included in the project.
+Each page describes the algorithm's purpose, inputs, outputs, and shows a minimal example.

--- a/algorithms/docs/docs/searching/binary_search.md
+++ b/algorithms/docs/docs/searching/binary_search.md
@@ -1,0 +1,20 @@
+# Binary Search
+
+**Purpose:** Locate a target value within a sorted list.
+
+**Input:**
+- `data`: sorted `List[Any]`
+- `target`: value to search for
+
+**Output:** Index of `target` in `data` or `-1` if not found.
+
+## Example
+```python
+from algorithms.searching.basic.binary_search import BinarySearch
+
+BinarySearch().execute([1, 2, 3, 4], 3)
+```
+Output:
+```
+2
+```

--- a/algorithms/docs/docs/searching/linear_search.md
+++ b/algorithms/docs/docs/searching/linear_search.md
@@ -1,0 +1,20 @@
+# Linear Search
+
+**Purpose:** Scan a list sequentially to find a target value.
+
+**Input:**
+- `data`: `List[Any]`
+- `target`: value to search for
+
+**Output:** Index of `target` in `data` or `-1` if not found.
+
+## Example
+```python
+from algorithms.searching.basic.linear_search import LinearSearch
+
+LinearSearch().execute([1, 2, 3, 4], 3)
+```
+Output:
+```
+2
+```

--- a/algorithms/docs/docs/sorting/bubble_sort.md
+++ b/algorithms/docs/docs/sorting/bubble_sort.md
@@ -1,0 +1,18 @@
+# Bubble Sort
+
+**Purpose:** Sort a list by repeatedly swapping adjacent elements.
+
+**Input:** `List[Any]` of comparable items.
+
+**Output:** Sorted `List[Any]` in non-decreasing order.
+
+## Example
+```python
+from algorithms.sorting.basic.bubble_sort import BubbleSort
+
+BubbleSort().execute([3, 1, 2])
+```
+Output:
+```
+[1, 2, 3]
+```

--- a/algorithms/docs/docs/sorting/quick_sort.md
+++ b/algorithms/docs/docs/sorting/quick_sort.md
@@ -1,0 +1,18 @@
+# Quick Sort
+
+**Purpose:** Sort a list using the divide and conquer strategy.
+
+**Input:** `List[Any]` of comparable items.
+
+**Output:** Sorted `List[Any]` in non-decreasing order.
+
+## Example
+```python
+from algorithms.sorting.basic.quick_sort import QuickSort
+
+QuickSort().execute([3, 1, 2])
+```
+Output:
+```
+[1, 2, 3]
+```

--- a/algorithms/docs/mkdocs.yml
+++ b/algorithms/docs/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: Algorithm Library
+nav:
+  - Home: index.md
+  - Sorting:
+      - Bubble Sort: sorting/bubble_sort.md
+      - Quick Sort: sorting/quick_sort.md
+  - Searching:
+      - Linear Search: searching/linear_search.md
+      - Binary Search: searching/binary_search.md
+  - Dynamic Programming:
+      - Fibonacci: dynamic_programming/fibonacci.md
+      - Longest Common Subsequence: dynamic_programming/lcs.md
+  - Graph:
+      - Breadth-First Search: graph/bfs.md
+      - Depth-First Search: graph/dfs.md
+plugins:
+  - search
+theme:
+  name: mkdocs

--- a/algorithms/examples.py
+++ b/algorithms/examples.py
@@ -1,0 +1,30 @@
+"""Run minimal examples for algorithms."""
+
+from algorithms.sorting.basic.bubble_sort import BubbleSort
+from algorithms.sorting.basic.quick_sort import QuickSort
+from algorithms.searching.basic.linear_search import LinearSearch
+from algorithms.searching.basic.binary_search import BinarySearch
+from algorithms.dynamic_programming.basic.fibonacci import Fibonacci
+from algorithms.dynamic_programming.basic.lcs import LongestCommonSubsequence
+from algorithms.graph.basic.bfs import BreadthFirstSearch
+from algorithms.graph.basic.dfs import DepthFirstSearch
+from algorithms.utils import Graph
+
+
+def run_examples() -> None:
+    print("BubbleSort:", BubbleSort().execute([3, 1, 2]))
+    print("QuickSort:", QuickSort().execute([3, 1, 2]))
+    print("LinearSearch:", LinearSearch().execute([1, 2, 3, 4], 3))
+    print("BinarySearch:", BinarySearch().execute([1, 2, 3, 4], 3))
+    print("Fibonacci:", Fibonacci().execute(7))
+    print("LCS:", LongestCommonSubsequence().execute("abcde", "ace"))
+    graph = Graph()
+    graph.add_edge("A", "B")
+    graph.add_edge("A", "C")
+    graph.add_edge("B", "D")
+    print("BFS:", BreadthFirstSearch().execute(graph, "A"))
+    print("DFS:", DepthFirstSearch().execute(graph, "A"))
+
+
+if __name__ == "__main__":
+    run_examples()


### PR DESCRIPTION
## Summary
- Document bubble/quick sort, linear/binary search, Fibonacci, LCS, BFS, and DFS algorithms
- Add minimal runnable examples and an example runner script
- Create MkDocs site with navigation and search for algorithms

## Testing
- `PYTHONPATH=. python algorithms/examples.py`
- `pytest algorithms -q`
- `cd algorithms/docs && mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68bbc956e5cc832f96929b241713f288