### PR TITLE
feat: add multitask trainer and module registry

### DIFF
--- a/backend/capability/__init__.py
+++ b/backend/capability/__init__.py
@@ -1,0 +1,13 @@
+from .module_registry import (
+    available_modules,
+    combine_modules,
+    get_module,
+    register_module,
+)
+
+__all__ = [
+    "available_modules",
+    "combine_modules",
+    "get_module",
+    "register_module",
+]

--- a/backend/capability/module_registry.py
+++ b/backend/capability/module_registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+_REGISTRY: Dict[str, Callable[..., Any]] = {}
+
+
+def register_module(name: str, factory: Callable[..., Any]) -> None:
+    """Register a module factory under ``name``."""
+    _REGISTRY[name] = factory
+
+
+def get_module(name: str, *args, **kwargs) -> Any:
+    """Instantiate a registered module."""
+    if name not in _REGISTRY:
+        raise KeyError(f"Module '{name}' is not registered")
+    return _REGISTRY[name](*args, **kwargs)
+
+
+def available_modules() -> List[str]:
+    """Return a list of registered module names."""
+    return list(_REGISTRY.keys())
+
+
+def combine_modules(names: List[str]) -> List[Any]:
+    """Instantiate multiple modules by name."""
+    return [get_module(name) for name in names]

--- a/backend/ml/multitask_trainer.py
+++ b/backend/ml/multitask_trainer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+from .feature_extractor import FeatureExtractor
+
+
+class MultiTaskTrainer:
+    """Train separate models for multiple tasks with a shared encoder.
+
+    Each task dataset must be a CSV file containing ``text`` and ``target`` columns.
+    The :class:`FeatureExtractor` is fitted on the union of all task texts and
+    reused for every individual model.
+    """
+
+    def __init__(self, tasks: Dict[str, str]):
+        # Map task name to dataset path
+        self.tasks = {name: Path(path) for name, path in tasks.items()}
+        self.extractor = FeatureExtractor()
+        self._datasets: Dict[str, Tuple[list[str], list[float]]] = {}
+
+    def load_datasets(self) -> None:
+        """Load datasets and fit the shared feature extractor."""
+        texts: list[str] = []
+        for name, path in self.tasks.items():
+            df = pd.read_csv(path)
+            if "text" not in df.columns or "target" not in df.columns:
+                raise ValueError(
+                    f"Dataset {path} must contain 'text' and 'target' columns"
+                )
+            task_texts = df["text"].astype(str).tolist()
+            targets = df["target"].values
+            self._datasets[name] = (task_texts, targets)
+            texts.extend(task_texts)
+        if texts:
+            self.extractor.fit(texts)
+
+    def train(self) -> Dict[str, Tuple[LinearRegression, float]]:
+        """Train a model for each task and return metrics."""
+        if not self._datasets:
+            self.load_datasets()
+
+        results: Dict[str, Tuple[LinearRegression, float]] = {}
+        for name, (texts, targets) in self._datasets.items():
+            X = self.extractor.transform(texts)
+            X_train, X_test, y_train, y_test = train_test_split(
+                X, targets, test_size=0.2, random_state=42
+            )
+            model = LinearRegression()
+            model.fit(X_train, y_train)
+            mse = mean_squared_error(y_test, model.predict(X_test))
+            results[name] = (model, mse)
+        return results

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -226,6 +226,28 @@ def execute(goal):
     click.echo(results)
 
 
+@cli.command()
+@click.option('--multitask', is_flag=True, help='Enable multi-task training mode')
+@click.option('--modules', multiple=True, help='Modules to include in training')
+def train(multitask, modules):
+    """Train models with optional multi-task support."""
+    from capability import register_module, combine_modules
+    from ml.multitask_trainer import MultiTaskTrainer
+
+    for name in modules:
+        register_module(name, lambda path=f'data/{name}.csv': path)
+
+    datasets = dict(zip(modules, combine_modules(list(modules))))
+
+    if multitask:
+        trainer = MultiTaskTrainer(datasets)
+        trainer.load_datasets()
+        results = trainer.train()
+        for name, (_, mse) in results.items():
+            click.echo(f'{name}: MSE {mse:.4f}')
+    else:
+        click.echo('Multi-task mode disabled; no training executed.')
+
 @cli.command(name="meta-tickets")
 def list_meta_tickets():
     """List pending meta-upgrade tickets."""


### PR DESCRIPTION
## Summary
- add MultiTaskTrainer to train separate tasks with shared encoder
- introduce module registry for dynamic capability composition
- extend CLI with options to enable multi-task training and specify modules

## Testing
- `pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf2dd0cac832f9adc70472aa8b69b