### PR TITLE
Add strategy search and reflection modules

### DIFF
--- a/backend/execution/__init__.py
+++ b/backend/execution/__init__.py
@@ -3,6 +3,7 @@ from .task_graph import Task, TaskGraph
 from .scheduler import Scheduler
 from .coordinator import AgentCoordinator
 from .auto_scheduler import AutoScheduler
+from .strategy_search import StrategySearch
 
 __all__ = [
     "Executor",
@@ -11,4 +12,5 @@ __all__ = [
     "Scheduler",
     "AgentCoordinator",
     "AutoScheduler",
+    "StrategySearch",
 ]

--- a/backend/execution/strategy_search.py
+++ b/backend/execution/strategy_search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import random
+from typing import Any, Callable, Iterable, List
+
+
+class StrategySearch:
+    """Generate multiple solution paths using random and heuristic strategies."""
+
+    def __init__(
+        self,
+        heuristics: Iterable[Callable[[Any], List[str]]] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self.heuristics = list(heuristics or [])
+        self._rand = random.Random(seed)
+
+    def random_paths(self, options: List[str], count: int) -> List[List[str]]:
+        """Return ``count`` random permutations of *options*."""
+
+        paths: List[List[str]] = []
+        for _ in range(max(count, 0)):
+            items = list(options)
+            self._rand.shuffle(items)
+            paths.append(items)
+        return paths
+
+    def heuristic_paths(self, context: Any) -> List[List[str]]:
+        """Generate paths using registered heuristic callables."""
+
+        paths: List[List[str]] = []
+        for func in self.heuristics:
+            try:
+                path = func(context)
+            except Exception:  # noqa: BLE001
+                continue
+            if path:
+                paths.append(list(path))
+        return paths
+
+    def search(
+        self, options: List[str], count: int, context: Any | None = None
+    ) -> List[List[str]]:
+        """Combine heuristic and random strategies to generate candidate paths."""
+
+        paths = []
+        if context is not None:
+            paths.extend(self.heuristic_paths(context))
+        remaining = count - len(paths)
+        if remaining > 0:
+            paths.extend(self.random_paths(options, remaining))
+        return paths

--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -5,6 +5,7 @@ from .storage import TimeSeriesStorage
 from .system_metrics import SystemMetricsCollector
 from .metrics_collector import MetricsCollector
 from .performance_monitor import PerformanceMonitor, email_alert, dashboard_alert
+from .reflection import Reflection
 
 __all__ = [
     "TimeSeriesStorage",
@@ -14,4 +15,5 @@ __all__ = [
     "PerformanceMonitor",
     "email_alert",
     "dashboard_alert",
+    "Reflection",
 ]

--- a/backend/monitoring/reflection.py
+++ b/backend/monitoring/reflection.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, List, Tuple
+
+
+class Reflection:
+    """Evaluate candidate solutions and select the best option."""
+
+    def __init__(self, score_fn: Callable[[Any], float]) -> None:
+        self.score_fn = score_fn
+
+    def evaluate(self, candidates: Iterable[Any]) -> List[Tuple[Any, float]]:
+        """Return ``(candidate, score)`` pairs sorted by score."""
+
+        scored: List[Tuple[Any, float]] = []
+        for candidate in candidates:
+            try:
+                score = self.score_fn(candidate)
+            except Exception:  # noqa: BLE001
+                continue
+            scored.append((candidate, score))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        return scored
+
+    def select_best(self, candidates: Iterable[Any]) -> Any | None:
+        """Return the candidate with the highest score or ``None``."""
+
+        scored = self.evaluate(candidates)
+        return scored[0][0] if scored else None

--- a/modules/events/coordination.py
+++ b/modules/events/coordination.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 
 class TaskStatus(str, Enum):
@@ -39,3 +39,31 @@ class TaskStatusEvent:
         data = asdict(self)
         data["status"] = self.status.value
         return data
+
+
+@dataclass
+class IterationEvent:
+    """Event representing a reflexive iteration step."""
+
+    iteration: int
+    candidates: List[str]
+    selected: str
+    scores: Dict[str, float] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def render_iteration_timeline(events: List[IterationEvent]) -> str:
+    """Return a simple textual visualization of iteration events."""
+
+    lines = []
+    for ev in events:
+        score_part = ""
+        if ev.scores:
+            formatted = ", ".join(
+                f"{name}:{score:.2f}" for name, score in ev.scores.items()
+            )
+            score_part = f" [{formatted}]"
+        lines.append(f"{ev.iteration}: {ev.selected}{score_part}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- generate candidate solution paths via StrategySearch with heuristic and random approaches
- evaluate and select optimal solutions using Reflection utility
- record and visualize reflexive iteration steps through new IterationEvent and timeline renderer

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68bc17932b60832f9bc34dfc79044dcb