### PR TITLE
Add neuro-symbolic logic engine and integrate with coordinator

### DIFF
--- a/algorithms/neuro_symbolic/__init__.py
+++ b/algorithms/neuro_symbolic/__init__.py
@@ -1,0 +1,2 @@
+"""Neuro-symbolic reasoning components."""
+

--- a/algorithms/neuro_symbolic/logic_engine.py
+++ b/algorithms/neuro_symbolic/logic_engine.py
@@ -1,0 +1,49 @@
+"""Simple neuro-symbolic logic engine.
+
+This module bridges neural network outputs with symbolic reasoning. Given the
+output of a neural model (expressed as a mapping of symbols to booleans or
+truthy values) and a set of symbolic rules, the :class:`LogicEngine` evaluates
+those rules to derive additional facts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class LogicEngine:
+    """Evaluate symbolic rules against neural network outputs.
+
+    Parameters
+    ----------
+    rules:
+        Mapping of rule names to boolean expressions using symbols present in
+        the neural network output.
+    """
+
+    def __init__(self, rules: Dict[str, str] | None = None) -> None:
+        self.rules = rules or {}
+
+    def evaluate(self, nn_output: Dict[str, Any]) -> Dict[str, bool]:
+        """Run symbolic reasoning based on neural network predictions.
+
+        Parameters
+        ----------
+        nn_output:
+            Mapping of symbol names to values produced by a neural network.
+
+        Returns
+        -------
+        Dict[str, bool]
+            The evaluated truth values for each rule.
+        """
+
+        context = {key: bool(value) for key, value in nn_output.items()}
+        results: Dict[str, bool] = {}
+        for name, expr in self.rules.items():
+            try:
+                results[name] = bool(eval(expr, {"__builtins__": {}}, context))
+            except NameError as exc:
+                raise ValueError(f"Unknown symbol in rule '{expr}': {exc}") from exc
+        return results
+

--- a/backend/execution/coordinator.py
+++ b/backend/execution/coordinator.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from events import EventBus
 from events.coordination import TaskDispatchEvent, TaskStatus
+from algorithms.neuro_symbolic.logic_engine import LogicEngine
 
 
 class AgentCoordinator:
@@ -18,6 +19,13 @@ class AgentCoordinator:
     def dispatch_task(
         self, task_id: str, payload: Dict[str, Any], agent_id: str | None = None
     ) -> None:
+        payload = dict(payload)
+        logic_cfg = payload.get("logic")
+        if logic_cfg:
+            engine = LogicEngine(logic_cfg.get("rules"))
+            nn_output = logic_cfg.get("nn_output", {})
+            payload["logic_result"] = engine.evaluate(nn_output)
+
         event = TaskDispatchEvent(task_id=task_id, payload=payload, assigned_to=agent_id)
         self._bus.publish("task.dispatch", event.to_dict())
 

--- a/tests/neuro_symbolic/test_logic_engine.py
+++ b/tests/neuro_symbolic/test_logic_engine.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from algorithms.neuro_symbolic.logic_engine import LogicEngine
+
+
+def test_logic_engine_evaluates_rules():
+    nn_output = {"a": 1, "b": 0}
+    rules = {"c": "a and not b", "d": "a or b"}
+    engine = LogicEngine(rules)
+    result = engine.evaluate(nn_output)
+    assert result == {"c": True, "d": True}
+
+
+def test_unknown_symbol_raises_error():
+    engine = LogicEngine({"c": "missing"})
+    with pytest.raises(ValueError):
+        engine.evaluate({"a": True})


### PR DESCRIPTION
## Summary
- add neuro-symbolic logic engine to evaluate symbolic rules using neural network outputs
- integrate logic engine into AgentCoordinator for optional reasoning on tasks
- test logic engine behavior and error handling

## Testing
- `pytest tests/neuro_symbolic/test_logic_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc1eaab8b4832fb60af7caa6ddc922