### PR TITLE
Add intrinsic reward and exploration planning

### DIFF
--- a/backend/arena/__init__.py
+++ b/backend/arena/__init__.py
@@ -1,0 +1,1 @@
+"""Arena package providing interaction utilities for agents."""

--- a/backend/arena/interaction.py
+++ b/backend/arena/interaction.py
@@ -1,0 +1,52 @@
+"""Interaction flow for the arena with optional exploration mode."""
+from __future__ import annotations
+
+from typing import List, Protocol
+
+from ..execution.planner import Planner
+from ..founder_agent.analytics import Analytics
+
+
+class AgentProtocol(Protocol):
+    """Protocol that arena agents are expected to follow."""
+
+    def act(self, task: str) -> dict:
+        """Execute a task and return metric events."""
+
+    def generate_goal(self, reward: float) -> str | None:
+        """Optionally generate a new goal based on an intrinsic reward."""
+
+
+class Arena:
+    """Coordinate agent interaction and optionally explore new goals."""
+
+    def __init__(self, planner: Planner | None = None, analytics: Analytics | None = None) -> None:
+        self.planner = planner or Planner()
+        self.analytics = analytics or Analytics()
+
+    def interact(self, agent: AgentProtocol, goal: str, exploration: bool = False) -> None:
+        """Run interaction steps for a given goal.
+
+        Parameters
+        ----------
+        agent:
+            The agent participating in the arena.
+        goal:
+            High level objective for the agent.
+        exploration:
+            When ``True``, the agent may propose new goals based on the
+            intrinsic reward computed from the interaction so far.
+        """
+        tasks: List[str] = self.planner.decompose(goal)
+        idx = 0
+        while idx < len(tasks):
+            task = tasks[idx]
+            result = agent.act(task)
+            if isinstance(result, dict):
+                self.analytics.handle_event(result)
+            if exploration:
+                reward = self.analytics.get_intrinsic_reward()
+                new_goal = agent.generate_goal(reward)
+                if new_goal:
+                    tasks.extend(self.planner.decompose(new_goal))
+            idx += 1

--- a/backend/execution/__init__.py
+++ b/backend/execution/__init__.py
@@ -4,6 +4,7 @@ from .scheduler import Scheduler
 from .coordinator import AgentCoordinator
 from .auto_scheduler import AutoScheduler
 from .strategy_search import StrategySearch
+from .planner import Planner
 
 __all__ = [
     "Executor",
@@ -13,4 +14,5 @@ __all__ = [
     "AgentCoordinator",
     "AutoScheduler",
     "StrategySearch",
+    "Planner",
 ]

--- a/backend/execution/planner.py
+++ b/backend/execution/planner.py
@@ -1,0 +1,25 @@
+"""Simple planner to decompose high level goals into executable sub-tasks."""
+from __future__ import annotations
+
+from typing import List
+
+
+class Planner:
+    """Decompose high level goals into ordered sub-tasks."""
+
+    def decompose(self, goal: str) -> List[str]:
+        """Return a list of sub-tasks derived from a high level goal.
+
+        The default implementation uses a few heuristic separators to
+        break the goal into manageable pieces. It can be replaced with a
+        more sophisticated planner or LLM powered approach in the future.
+        """
+        if not goal:
+            return []
+        # Replace common separators with newlines to unify splitting logic
+        separators = ["\n", ";", " and ", " then "]
+        normalized = goal
+        for sep in separators[1:]:
+            normalized = normalized.replace(sep, "\n")
+        tasks = [task.strip() for task in normalized.splitlines() if task.strip()]
+        return tasks

--- a/backend/founder_agent/analytics.py
+++ b/backend/founder_agent/analytics.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from typing import Deque, Dict
 
+from .intrinsic_reward import compute_intrinsic_reward
+
 
 class Analytics:
     """Maintain rolling metric history and compute simple trends."""
@@ -29,3 +31,7 @@ class Analytics:
             elif values:
                 trends[key] = 0.0
         return trends
+
+    def get_intrinsic_reward(self) -> float:
+        """Calculate an intrinsic reward based on current metric trends."""
+        return compute_intrinsic_reward(self.get_trends())

--- a/backend/founder_agent/intrinsic_reward.py
+++ b/backend/founder_agent/intrinsic_reward.py
@@ -1,0 +1,25 @@
+"""Intrinsic reward calculation utilities for founder agent."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def compute_intrinsic_reward(trends: Dict[str, float]) -> float:
+    """Compute an intrinsic reward signal from metric trends.
+
+    The default implementation encourages exploration by rewarding
+    large changes in the agent's observed metrics, regardless of
+    direction. This is a simple heuristic that can be replaced with
+    a more sophisticated novelty or curiosity model in the future.
+
+    Parameters
+    ----------
+    trends:
+        Mapping of metric names to their recent trend values.
+
+    Returns
+    -------
+    float
+        The computed intrinsic reward.
+    """
+    return float(sum(abs(v) for v in trends.values()))


### PR DESCRIPTION
## Summary
- introduce intrinsic reward calculation and expose via analytics
- implement goal decomposition planner
- add arena interaction flow with optional exploration mode

## Testing
- `python -m py_compile backend/founder_agent/analytics.py backend/founder_agent/intrinsic_reward.py backend/execution/planner.py backend/arena/interaction.py backend/arena/__init__.py backend/execution/__init__.py`
- `pytest` *(fails: 35 errors)*
- `pytest tests/test_algorithms.py tests/test_storage_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d1f75e8832fa64df56a62d15b30