### PR TITLE
feat: add global workspace and metrics tracking

### DIFF
--- a/backend/agent_factory.py
+++ b/backend/agent_factory.py
@@ -36,6 +36,7 @@ from autogpts.autogpt.autogpt.core.errors import (
 
 from capability.librarian import Librarian
 from org_charter import io as charter_io
+from backend.monitoring.global_workspace import global_workspace
 
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,16 @@ def create_agent_from_blueprint(
         app_config=config,
         file_storage=file_storage,
         llm_provider=llm_provider,
+    )
+
+    # Register core components with the global workspace so they can
+    # exchange state and attention with other modules.
+    global_workspace.register_module(agent.settings.agent_id, agent)
+    global_workspace.register_module(
+        f"{agent.settings.agent_id}.command_registry", agent.command_registry
+    )
+    global_workspace.register_module(
+        f"{agent.settings.agent_id}.llm_provider", agent.llm_provider
     )
 
     # Restrict commands to authorised tools

--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -6,6 +6,7 @@ from .system_metrics import SystemMetricsCollector
 from .metrics_collector import MetricsCollector
 from .performance_monitor import PerformanceMonitor, email_alert, dashboard_alert
 from .reflection import Reflection
+from .global_workspace import GlobalWorkspace, global_workspace
 
 __all__ = [
     "TimeSeriesStorage",
@@ -16,4 +17,6 @@ __all__ = [
     "email_alert",
     "dashboard_alert",
     "Reflection",
+    "GlobalWorkspace",
+    "global_workspace",
 ]

--- a/backend/monitoring/global_workspace.py
+++ b/backend/monitoring/global_workspace.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Shared global workspace for broadcasting state between modules."""
+
+from typing import Any, Dict
+
+
+class GlobalWorkspace:
+    """Registry that enables modules to share state and attention."""
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, Any] = {}
+        self._state: Dict[str, Any] = {}
+        self._attention: Dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    def register_module(self, name: str, module: Any) -> None:
+        """Register *module* under *name* in the workspace."""
+        self._modules[name] = module
+
+    def broadcast(self, sender: str, state: Any, attention: float | None = None) -> None:
+        """Broadcast *state* and optional *attention* from *sender* to all other modules."""
+        self._state[sender] = state
+        if attention is not None:
+            self._attention[sender] = float(attention)
+        for name, module in self._modules.items():
+            if name == sender:
+                continue
+            handler = getattr(module, "receive_broadcast", None)
+            if callable(handler):
+                handler(sender, state, attention)
+
+    # ------------------------------------------------------------------
+    def state(self, name: str) -> Any:
+        """Return the last state published by *name*."""
+        return self._state.get(name)
+
+    def attention(self, name: str) -> float | None:
+        """Return the last attention weight published by *name*."""
+        return self._attention.get(name)
+
+
+# Global workspace instance
+
+global_workspace = GlobalWorkspace()

--- a/modules/metrics/workspace.py
+++ b/modules/metrics/workspace.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Metrics for evaluating the impact of the global workspace on task performance."""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class WorkspaceRun:
+    """Metrics for a single task run."""
+
+    task_id: str
+    baseline_score: float
+    workspace_score: float
+
+    @property
+    def improvement(self) -> float:
+        """Return improvement from using the global workspace."""
+        return self.workspace_score - self.baseline_score
+
+
+class WorkspaceImpactTracker:
+    """Accumulates metrics to assess global workspace contribution."""
+
+    def __init__(self) -> None:
+        self.runs: List[WorkspaceRun] = []
+
+    def record(self, task_id: str, baseline_score: float, workspace_score: float) -> None:
+        """Record metrics for *task_id* comparing baseline and workspace scores."""
+        self.runs.append(
+            WorkspaceRun(
+                task_id=task_id,
+                baseline_score=float(baseline_score),
+                workspace_score=float(workspace_score),
+            )
+        )
+
+    def average_improvement(self) -> float:
+        """Return average improvement across all recorded runs."""
+        if not self.runs:
+            return 0.0
+        return sum(run.improvement for run in self.runs) / len(self.runs)

--- a/modules/tests/test_global_workspace.py
+++ b/modules/tests/test_global_workspace.py
@@ -1,0 +1,25 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "backend/monitoring")))
+
+from global_workspace import GlobalWorkspace
+
+
+class DummyModule:
+    def __init__(self) -> None:
+        self.received = []
+
+    def receive_broadcast(self, sender, state, attention):
+        self.received.append((sender, state, attention))
+
+
+def test_broadcast_propagates_state() -> None:
+    gw = GlobalWorkspace()
+    a = DummyModule()
+    b = DummyModule()
+    gw.register_module("a", a)
+    gw.register_module("b", b)
+    gw.broadcast("a", {"value": 1}, 0.5)
+    assert b.received == [("a", {"value": 1}, 0.5)]
+    assert gw.state("a") == {"value": 1}
+    assert gw.attention("a") == 0.5

--- a/modules/tests/test_workspace_metrics.py
+++ b/modules/tests/test_workspace_metrics.py
@@ -1,0 +1,14 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), "modules")))
+
+import pytest
+
+from metrics.workspace import WorkspaceImpactTracker
+
+
+def test_average_improvement() -> None:
+    tracker = WorkspaceImpactTracker()
+    tracker.record("t1", 0.5, 0.8)
+    tracker.record("t2", 0.4, 0.6)
+    assert tracker.average_improvement() == pytest.approx((0.3 + 0.2) / 2)


### PR DESCRIPTION
## Summary
- implement a global workspace to broadcast shared state and attention across modules
- register new agents and core components in the global workspace during factory creation
- add metrics utilities to measure global workspace impact

## Testing
- `PYTHONPATH=backend:modules pytest modules/tests/test_global_workspace.py modules/tests/test_workspace_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc35a02594832f8af03cd76bd9750b