### PR TITLE
feat: add global workspace and reflection loop

### DIFF
--- a/backend/autogpt/autogpt/core/global_workspace.py
+++ b/backend/autogpt/autogpt/core/global_workspace.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class SelfState:
+    """Container for the agent's internal self state."""
+
+    current_goal: str = ""
+    memory_pointer: int = 0
+    action_history: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "current_goal": self.current_goal,
+            "memory_pointer": self.memory_pointer,
+            "recent_actions": self.action_history[-5:],
+        }
+
+
+class GlobalWorkspace:
+    """Simple global workspace for coordinating agent subsystems."""
+
+    def __init__(self) -> None:
+        self.state = SelfState()
+
+    def update_state(
+        self,
+        goal: str | None = None,
+        memory_pointer: int | None = None,
+        action: str | None = None,
+    ) -> None:
+        if goal is not None:
+            self.state.current_goal = goal
+        if memory_pointer is not None:
+            self.state.memory_pointer = memory_pointer
+        if action is not None:
+            self.state.action_history.append(action)
+
+    def get_context(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the current self state."""
+        return self.state.as_dict()
+
+    def reflect(self, predicted_action: str, actual_action: str) -> None:
+        """Very small reflection mechanism comparing expected and actual actions."""
+        if predicted_action != actual_action:
+            self.state.action_history.append(
+                f"reflection: expected {predicted_action} but executed {actual_action}"
+            )

--- a/backend/autogpt/autogpt/core/planning/prompt_strategies/next_ability.py
+++ b/backend/autogpt/autogpt/core/planning/prompt_strategies/next_ability.py
@@ -39,6 +39,8 @@ class NextAbility(PromptStrategy):
         "{action_history}\n\n"
         "Here is additional information that may be useful to you:\n"
         "{additional_info}\n\n"
+        "Your current self state is:\n"
+        "{self_state}\n\n"
         "Additionally, you should consider the following:\n"
         "{user_input}\n\n"
         "Your task of {task_objective} is complete when the following acceptance"
@@ -138,6 +140,12 @@ class NextAbility(PromptStrategy):
             no_items_response=(
                 "There is no additional information available at this time."
             ),
+            **template_kwargs,
+        )
+        state_context = kwargs.get("state_context") or {}
+        template_kwargs["self_state"] = to_numbered_list(
+            [f"{k}: {v}" for k, v in state_context.items()],
+            no_items_response="No self state available.",
             **template_kwargs,
         )
         template_kwargs["user_input"] = to_numbered_list(

--- a/backend/autogpt/autogpt/core/planning/simple.py
+++ b/backend/autogpt/autogpt/core/planning/simple.py
@@ -137,11 +137,13 @@ class SimplePlanner(Configurable):
         self,
         task: Task,
         ability_specs: list[CompletionModelFunction],
+        state_context: dict | None = None,
     ):
         return await self.chat_with_model(
             self._prompt_strategies["next_ability"],
             task=task,
             ability_specs=ability_specs,
+            state_context=state_context,
         )
 
     async def chat_with_model(


### PR DESCRIPTION
## Summary
- introduce GlobalWorkspace to track agent self state and action history
- feed state context into planning and next ability prompts
- add simple reflection loop updating state after each ability execution

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68bc389bd0b4832fa24df6c913e74af1