### PR TITLE
Add modular knowledge, memory, reasoning, and reflection utilities

### DIFF
--- a/backend/knowledge/__init__.py
+++ b/backend/knowledge/__init__.py
@@ -1,0 +1,10 @@
+"""Knowledge integration utilities.
+
+This package provides components for integrating multiple knowledge sources
+into a unified representation that can be queried by other parts of the
+system.
+"""
+
+from .unified import UnifiedKnowledgeBase
+
+__all__ = ["UnifiedKnowledgeBase"]

--- a/backend/knowledge/unified.py
+++ b/backend/knowledge/unified.py
@@ -1,0 +1,66 @@
+"""Unified knowledge base module.
+
+This module defines :class:`UnifiedKnowledgeBase`, a very small utility that
+collects knowledge from heterogeneous sources (science, arts, humanities, etc.)
+into a single representation.  The implementation is intentionally lightweight
+and serves as a reference for how a more sophisticated integration layer could
+work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable
+
+
+@dataclass
+class KnowledgeSource:
+    """Simple container for a knowledge source.
+
+    Attributes
+    ----------
+    name:
+        Identifier for the knowledge source.
+    data:
+        Mapping of concept names to descriptions.
+    """
+
+    name: str
+    data: Dict[str, str]
+
+
+@dataclass
+class UnifiedKnowledgeBase:
+    """Container that stores multiple knowledge sources.
+
+    The class exposes :meth:`add_source` for registering a new knowledge source
+    and :meth:`query` for retrieving information across all registered sources.
+    """
+
+    sources: Dict[str, KnowledgeSource] = field(default_factory=dict)
+
+    def add_source(self, source: KnowledgeSource) -> None:
+        """Register a new knowledge source."""
+
+        self.sources[source.name] = source
+
+    def query(self, concept: str) -> Dict[str, str]:
+        """Return a mapping of ``source_name -> description`` for ``concept``.
+
+        The function performs a naive lookup in each source's data mapping.  A
+        more capable implementation could involve indexing structures or vector
+        search for semantic retrieval.
+        """
+
+        results: Dict[str, str] = {}
+        for name, source in self.sources.items():
+            if concept in source.data:
+                results[name] = source.data[concept]
+        return results
+
+    def concepts(self) -> Iterable[str]:
+        """Iterate over all known concept names."""
+
+        for source in self.sources.values():
+            for concept in source.data.keys():
+                yield concept

--- a/backend/memory/__init__.py
+++ b/backend/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Long-term memory storage utilities."""
+
+from .long_term import LongTermMemory
+
+__all__ = ["LongTermMemory"]

--- a/backend/memory/long_term.py
+++ b/backend/memory/long_term.py
@@ -1,0 +1,66 @@
+"""SQLite backed long-term memory store.
+
+The implementation is intentionally minimal – it creates a single table to
+persist pieces of information along with a category.  This allows the system to
+record dialogue snippets, tasks, or references to external knowledge sources
+and retrieve them later.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class LongTermMemory:
+    """Light‑weight long-term memory based on SQLite."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.conn = sqlite3.connect(self.path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL,
+                content TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add(self, category: str, content: str) -> None:
+        """Store a piece of ``content`` under ``category``."""
+
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO memory (category, content) VALUES (?, ?)",
+            (category, content),
+        )
+        self.conn.commit()
+
+    def get(self, category: Optional[str] = None) -> Iterable[str]:
+        """Retrieve stored memories.
+
+        Parameters
+        ----------
+        category:
+            If provided, filter results by this category.  Otherwise all stored
+            memories are returned.
+        """
+
+        cur = self.conn.cursor()
+        if category is None:
+            cur.execute("SELECT content FROM memory")
+        else:
+            cur.execute("SELECT content FROM memory WHERE category = ?", (category,))
+        for (content,) in cur.fetchall():
+            yield content
+
+    def close(self) -> None:
+        self.conn.close()

--- a/backend/reasoning/__init__.py
+++ b/backend/reasoning/__init__.py
@@ -1,0 +1,5 @@
+"""Reasoning-related helpers."""
+
+from .multi_hop import MultiHopAssociator
+
+__all__ = ["MultiHopAssociator"]

--- a/backend/reasoning/multi_hop.py
+++ b/backend/reasoning/multi_hop.py
@@ -1,0 +1,41 @@
+"""Multi-hop association utilities.
+
+The algorithm implemented here performs a breadth-first search over a simple
+knowledge graph in order to connect concepts from potentially different
+domains.  It serves as a reference for how a reasoning step could actively
+combine disparate pieces of knowledge during inference.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Dict, Iterable, List
+
+Graph = Dict[str, Iterable[str]]
+
+
+class MultiHopAssociator:
+    """Perform multi-hop association over a knowledge graph."""
+
+    def __init__(self, graph: Graph):
+        self.graph = graph
+
+    def find_path(self, start: str, goal: str) -> List[str]:
+        """Return a list of nodes connecting ``start`` to ``goal``.
+
+        The function implements a straightforward breadth-first search and
+        returns the first path found.  If no path is present, an empty list is
+        returned.
+        """
+
+        queue = deque([(start, [start])])
+        visited = {start}
+        while queue:
+            node, path = queue.popleft()
+            if node == goal:
+                return path
+            for neighbor in self.graph.get(node, []):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    queue.append((neighbor, path + [neighbor]))
+        return []

--- a/backend/reflection/__init__.py
+++ b/backend/reflection/__init__.py
@@ -1,0 +1,5 @@
+"""Post-generation reflection utilities."""
+
+from .reflection import ReflectionModule
+
+__all__ = ["ReflectionModule"]

--- a/backend/reflection/reflection.py
+++ b/backend/reflection/reflection.py
@@ -1,0 +1,41 @@
+"""Simple post-generation reflection module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+EvaluationFn = Callable[[str], str]
+RewriteFn = Callable[[str], str]
+
+
+@dataclass
+class ReflectionModule:
+    """Evaluate and rewrite an initial response."""
+
+    evaluate: EvaluationFn | None = None
+    rewrite: RewriteFn | None = None
+
+    def __post_init__(self) -> None:
+        if self.evaluate is None:
+            self.evaluate = self._default_evaluate
+        if self.rewrite is None:
+            self.rewrite = self._default_rewrite
+
+    def _default_evaluate(self, text: str) -> str:
+        """Return a naive quality assessment for ``text``."""
+
+        length = len(text.split())
+        return f"response_length={length}"
+
+    def _default_rewrite(self, text: str) -> str:
+        """Provide a very small revision for ``text``."""
+
+        return text + " [revised]"
+
+    def reflect(self, text: str) -> Tuple[str, str]:
+        """Evaluate ``text`` and return (evaluation, revised_text)."""
+
+        evaluation = self.evaluate(text)
+        revised = self.rewrite(text)
+        return evaluation, revised

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.reasoning.multi_hop import MultiHopAssociator
+from backend.knowledge import UnifiedKnowledgeBase
+from backend.knowledge.unified import KnowledgeSource
+from backend.memory import LongTermMemory
+from backend.reflection import ReflectionModule
+
+
+def test_unified_knowledge_base():
+    kb = UnifiedKnowledgeBase()
+    kb.add_source(KnowledgeSource(name="science", data={"atom": "basic unit"}))
+    kb.add_source(KnowledgeSource(name="art", data={"atom": "indivisible style"}))
+    result = kb.query("atom")
+    assert result == {"science": "basic unit", "art": "indivisible style"}
+
+
+def test_long_term_memory(tmp_path):
+    db_path = tmp_path / "memory.db"
+    memory = LongTermMemory(db_path)
+    memory.add("dialogue", "hello")
+    memory.add("task", "write code")
+    assert list(memory.get("dialogue")) == ["hello"]
+    assert sorted(memory.get()) == ["hello", "write code"]
+    memory.close()
+
+
+def test_multi_hop_associator():
+    graph = {
+        "A": ["B"],
+        "B": ["C"],
+        "C": [],
+    }
+    assoc = MultiHopAssociator(graph)
+    assert assoc.find_path("A", "C") == ["A", "B", "C"]
+
+
+def test_reflection_module():
+    module = ReflectionModule()
+    evaluation, revised = module.reflect("test response")
+    assert "response_length" in evaluation
+    assert revised.endswith("[revised]")


### PR DESCRIPTION
## Summary
- add unified knowledge base for combining multiple domain sources
- introduce SQLite-backed long-term memory store
- implement multi-hop associator for graph-based reasoning
- add simple reflection module to evaluate and revise responses
- include unit tests for the new components

## Testing
- `pytest tests/test_new_modules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a14d0c4832f9de847e56e6bc0c6