### PR TITLE
feat: add self awareness assessment with reflection

### DIFF
--- a/backend/self_model/__init__.py
+++ b/backend/self_model/__init__.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List, Tuple
+
+from backend.reflection.reflection import ReflectionModule
+from backend.memory.long_term import LongTermMemory
 
 
 class SelfModel:
     """Estimate the agent's own state using environment predictions."""
+
+    def __init__(self, memory: LongTermMemory | None = None) -> None:
+        self._reflection = ReflectionModule()
+        self._history: List[str] = []
+        self._memory = memory
 
     def estimate(self, data: Dict[str, float], env_pred: Dict[str, float]) -> Dict[str, float]:
         """Return corrected CPU and memory predictions.
@@ -19,3 +27,32 @@ class SelfModel:
             "cpu": max(data.get("cpu", 0.0) - adjustment_cpu, 0.0),
             "memory": max(data.get("memory", 0.0) - adjustment_mem, 0.0),
         }
+
+    def assess_state(
+        self,
+        data: Dict[str, float],
+        env_pred: Dict[str, float],
+        last_action: str,
+    ) -> Tuple[Dict[str, float], str]:
+        """Return corrected metrics and an introspective summary.
+
+        The summary is generated using :class:`ReflectionModule` and recent
+        results are stored for future reference.
+        """
+
+        metrics = self.estimate(data, env_pred)
+        base = (
+            f"cpu={metrics['cpu']:.2f}, memory={metrics['memory']:.2f}; "
+            f"last_action={last_action}"
+        )
+        evaluation, revised = self._reflection.reflect(base)
+        summary = f"{evaluation} | {revised}"
+        self._history.append(summary)
+        self._history = self._history[-5:]
+        if self._memory:
+            self._memory.add("self_awareness", summary)
+        return metrics, summary
+
+    @property
+    def history(self) -> List[str]:
+        return list(self._history)

--- a/tests/self_model/test_self_awareness.py
+++ b/tests/self_model/test_self_awareness.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import pytest
+
+# Ensure repository root is on PYTHONPATH
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend.self_model import SelfModel
+from backend.memory.long_term import LongTermMemory
+class DummyBus:
+    def __init__(self) -> None:
+        self._subs = []
+
+    def subscribe(self, _topic, handler):
+        self._subs.append(handler)
+
+    def publish(self, _topic, event):
+        for h in self._subs:
+            h(event)
+
+
+def test_assess_state_and_event():
+    data = {"cpu": 1.0, "memory": 2.0}
+    env_pred = {"avg_cpu": 2.0, "avg_memory": 3.0}
+    self_model = SelfModel(LongTermMemory(":memory:"))
+
+    metrics, summary = self_model.assess_state(data, env_pred, "idle")
+
+    assert metrics["cpu"] == pytest.approx(0.8)
+    assert metrics["memory"] == pytest.approx(1.7)
+    assert summary in self_model.history
+
+    bus = DummyBus()
+    received = []
+    bus.subscribe("agent.self_awareness", lambda e: received.append(e))
+    bus.publish("agent.self_awareness", {"agent": "test", "summary": summary})
+
+    assert received and received[0]["summary"] == summary


### PR DESCRIPTION
## Summary
- extend SelfModel with assess_state using ReflectionModule, history tracking, and optional long-term memory
- invoke assess_state during resource management and publish self-awareness events
- cover self-awareness flow with new tests

## Testing
- `pytest tests/self_model/test_self_awareness.py tests/world_self_model/test_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc3c6fd8e0832fa7166060e2bb4758