### PR TITLE
feat: add pluggable emotion analysis with profiles

### DIFF
--- a/modules/common/emotion.py
+++ b/modules/common/emotion.py
@@ -1,30 +1,80 @@
 """Utilities for analyzing and tracking emotional state in dialogues.
 
-This module provides a simple :class:`EmotionAnalyzer` for classifying the
-sentiment of user utterances and an :class:`EmotionState` container for
-tracking the current conversational mood.  A helper function
-:func:`adjust_response_style` can be used to adapt generated responses to the
-latest detected emotion.
+This module provides a pluggable architecture for emotion analysis through
+the :class:`BaseEmotionModel` interface.  A lightweight
+ :class:`KeywordModel` implements a simple keyword heuristic while
+ :class:`MLModel` acts as a placeholder for more advanced machine‑learning
+ approaches.  An :class:`EmotionAnalyzer` facade exposes a uniform API for
+ these models.
 
-The implementation is intentionally lightweight and relies on a small
-keyword‑based heuristic so that it can run in environments where heavy machine
-learning dependencies are unavailable.  It can easily be replaced with a more
-advanced model if desired.
+An :class:`EmotionState` container tracks conversational mood and the helper
+:func:`adjust_response_style` can adapt responses to detected emotions.  The
+optional :class:`EmotionProfile` allows culture or personality specific
+thresholds and response styles.  Voice analysis hooks are present so a
+speech‑to‑text pipeline can be integrated in the future.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Iterable
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Protocol
 
 
-class EmotionAnalyzer:
-    """Classify text into coarse emotional categories.
+# ---------------------------------------------------------------------------
+# Profiles
 
-    The current implementation performs a very small heuristic lookup against
-    sets of positive and negative keywords.  The interface is designed so that
-    the classifier can later be swapped out for a real ML model without
-    changing the rest of the code base.
+
+@dataclass
+class EmotionProfile:
+    """Customize emotion classification thresholds and response style.
+
+    Parameters
+    ----------
+    positive_threshold:
+        Difference in positive vs. negative keyword counts required to label a
+        message as positive.
+    negative_threshold:
+        Difference in negative vs. positive keyword counts required to label a
+        message as negative.
+    positive_suffix:
+        Suffix appended to positive responses.
+    negative_prefix:
+        Prefix prepended to negative responses.
     """
+
+    positive_threshold: int = 1
+    negative_threshold: int = 1
+    positive_suffix: str = " \U0001F60A"  # smiling face emoji
+    negative_prefix: str = "I'm sorry to hear that."
+
+
+# ---------------------------------------------------------------------------
+# Model interface and implementations
+
+
+class BaseEmotionModel(Protocol):
+    """Protocol for pluggable emotion classification models."""
+
+    def analyze_text(self, text: str, profile: EmotionProfile | None = None) -> str:
+        """Return an emotion label for *text*."""
+
+    def analyze_voice(self, audio_bytes: bytes, profile: EmotionProfile | None = None) -> str:
+        """Return an emotion label for *audio_bytes*."""
+
+
+def _speech_to_text(audio_bytes: bytes) -> str:
+    """Placeholder speech‑to‑text pipeline.
+
+    The current implementation simply decodes the bytes as UTF‑8, ignoring
+    errors.  Replace this function with a call to a real speech‑to‑text model
+    when integrating with an audio processing library.
+    """
+
+    return audio_bytes.decode("utf-8", errors="ignore")
+
+
+class KeywordModel(BaseEmotionModel):
+    """Classify emotions using simple keyword heuristics."""
 
     POSITIVE_KEYWORDS = {
         "good",
@@ -36,6 +86,7 @@ class EmotionAnalyzer:
         "fantastic",
         "amazing",
     }
+
     NEGATIVE_KEYWORDS = {
         "bad",
         "sad",
@@ -47,32 +98,48 @@ class EmotionAnalyzer:
         "worse",
     }
 
-    def analyze_text(self, text: str) -> str:
-        """Return an emotion label for *text*.
-
-        The label will be ``"positive"``, ``"negative"`` or ``"neutral"``
-        depending on the keyword counts in the supplied text.  The comparison is
-        case‑insensitive.
-        """
-
+    def analyze_text(self, text: str, profile: EmotionProfile | None = None) -> str:
+        profile = profile or EmotionProfile()
         lowered = text.lower()
         pos = sum(word in lowered for word in self.POSITIVE_KEYWORDS)
         neg = sum(word in lowered for word in self.NEGATIVE_KEYWORDS)
-        if pos > neg:
+        if pos - neg >= profile.positive_threshold:
             return "positive"
-        if neg > pos:
+        if neg - pos >= profile.negative_threshold:
             return "negative"
         return "neutral"
 
-    def analyze_voice(self, _audio_bytes: bytes) -> str:  # pragma: no cover - placeholder
-        """Placeholder for voice analysis.
+    def analyze_voice(self, audio_bytes: bytes, profile: EmotionProfile | None = None) -> str:
+        text = _speech_to_text(audio_bytes)
+        return self.analyze_text(text, profile)
 
-        Voice‑based sentiment analysis is outside the scope of this lightweight
-        implementation.  The method exists to document the intended interface
-        and may be implemented with a speech‑to‑text pipeline in the future.
-        """
 
-        raise NotImplementedError("Voice emotion analysis is not implemented")
+class MLModel(BaseEmotionModel):  # pragma: no cover - placeholder
+    """Placeholder for an ML‑based emotion classification model."""
+
+    def analyze_text(self, _text: str, _profile: EmotionProfile | None = None) -> str:
+        raise NotImplementedError("ML based emotion model is not implemented")
+
+    def analyze_voice(self, _audio_bytes: bytes, _profile: EmotionProfile | None = None) -> str:
+        raise NotImplementedError("ML based emotion model is not implemented")
+
+
+# ---------------------------------------------------------------------------
+# Analyzer facade and state
+
+
+class EmotionAnalyzer:
+    """Facade providing a uniform interface over concrete emotion models."""
+
+    def __init__(self, model: BaseEmotionModel | None = None, profile: EmotionProfile | None = None) -> None:
+        self.model = model or KeywordModel()
+        self.profile = profile
+
+    def analyze_text(self, text: str) -> str:
+        return self.model.analyze_text(text, self.profile)
+
+    def analyze_voice(self, audio_bytes: bytes) -> str:
+        return self.model.analyze_voice(audio_bytes, self.profile)
 
 
 @dataclass
@@ -84,12 +151,7 @@ class EmotionState:
     satisfaction: float = 0.0
 
     def update(self, text: str, analyzer: EmotionAnalyzer) -> None:
-        """Update state based on *text* classified by *analyzer*.
-
-        The excitement and satisfaction scores are adjusted in a small range
-        [0.0, 1.0] to simulate an evolving emotional state.  Positive inputs
-        increase the scores while negative inputs decrease them.
-        """
+        """Update state based on *text* classified by *analyzer*."""
 
         self.label = analyzer.analyze_text(text)
         if self.label == "positive":
@@ -100,24 +162,51 @@ class EmotionState:
             self.satisfaction = max(0.0, self.satisfaction - 0.1)
 
 
-def adjust_response_style(response: str, state: EmotionState) -> str:
-    """Return *response* adapted to the current :class:`EmotionState`.
+# ---------------------------------------------------------------------------
+# Response adjustment
 
-    The function adds a very small amount of stylistic variation based on the
-    latest detected emotion.  While intentionally simple, this demonstrates how
-    downstream components can modulate their behaviour based on emotional
-    context.
+
+def adjust_response_style(
+    response: str,
+    state: EmotionState,
+    profile: EmotionProfile | None = None,
+    signals: Iterable[str] | None = None,
+) -> str:
+    """Return *response* adapted to the current emotion and extra signals.
+
+    Parameters
+    ----------
+    response:
+        The base response text to adjust.
+    state:
+        The :class:`EmotionState` used as the primary signal.
+    profile:
+        Optional :class:`EmotionProfile` controlling thresholds and style.
+    signals:
+        Additional emotion labels from other modalities (e.g., voice).  The
+        final label is the majority among ``state.label`` and these signals.
     """
 
-    if state.label == "positive":
-        return f"{response} \U0001F60A"  # smiling face emoji
-    if state.label == "negative":
-        return f"I'm sorry to hear that. {response}"
+    all_labels = [state.label]
+    if signals:
+        all_labels.extend(signals)
+    label = Counter(all_labels).most_common(1)[0][0]
+
+    profile = profile or EmotionProfile()
+    if label == "positive":
+        return f"{response}{profile.positive_suffix}"
+    if label == "negative":
+        return f"{profile.negative_prefix} {response}".strip()
     return response
 
 
 __all__ = [
+    "BaseEmotionModel",
+    "KeywordModel",
+    "MLModel",
     "EmotionAnalyzer",
+    "EmotionProfile",
     "EmotionState",
     "adjust_response_style",
 ]
+

--- a/modules/tests/test_emotion.py
+++ b/modules/tests/test_emotion.py
@@ -3,7 +3,17 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.getcwd()))
 
-from modules.common.emotion import EmotionAnalyzer, EmotionState, adjust_response_style
+from modules.common.emotion import (
+    EmotionAnalyzer,
+    EmotionProfile,
+    EmotionState,
+    adjust_response_style,
+)
+
+
+def test_keyword_model_classifies_voice():
+    analyzer = EmotionAnalyzer()
+    assert analyzer.analyze_voice(b"I love this") == "positive"
 
 
 def test_emotion_analyzer_classifies_basic_sentiment():
@@ -13,23 +23,27 @@ def test_emotion_analyzer_classifies_basic_sentiment():
     assert analyzer.analyze_text("It is a table") == "neutral"
 
 
-def test_emotion_state_updates_and_tracks_variables():
-    analyzer = EmotionAnalyzer()
+def test_emotion_profile_influences_classification_and_style():
+    profile = EmotionProfile(positive_threshold=2, positive_suffix=":)", negative_prefix="Apologies:")
+    analyzer = EmotionAnalyzer(profile=profile)
     state = EmotionState()
-    state.update("I love this!", analyzer)
+
+    state.update("good", analyzer)
+    assert state.label == "neutral"  # not enough positive keywords
+
+    state.update("good great", analyzer)
     assert state.label == "positive"
-    positive_excitement = state.excitement
-    state.update("I hate that", analyzer)
-    assert state.label == "negative"
-    assert state.excitement < positive_excitement
+
+    response = adjust_response_style("Thanks", state, profile)
+    assert response.endswith(":)")
 
 
-def test_adjust_response_style_reflects_emotion():
+def test_adjust_response_style_handles_multimodal_signals():
     analyzer = EmotionAnalyzer()
     state = EmotionState()
-    state.update("I love this", analyzer)
-    response = adjust_response_style("Thanks for the feedback.", state)
-    assert "😊" in response
-    state.update("I hate that", analyzer)
-    response = adjust_response_style("Thanks for the feedback.", state)
+    state.update("good", analyzer)
+
+    # Voice indicates negativity twice; majority vote yields negative response
+    response = adjust_response_style("Hello", state, signals=["negative", "negative"])
     assert response.startswith("I'm sorry to hear that.")
+


### PR DESCRIPTION
## Summary
- add BaseEmotionModel interface with keyword and placeholder ML models
- support optional EmotionProfile to tweak thresholds and response style
- enable voice analysis via speech-to-text hook and multimodal style adjustment

## Testing
- `pytest modules/tests/test_emotion.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc59cfb450832f8b721ba822fa9ce9