### PR TITLE
feat: broadcast self-awareness summaries

### DIFF
--- a/backend/self_model/__init__.py
+++ b/backend/self_model/__init__.py
@@ -13,6 +13,7 @@ class SelfModel:
         self._reflection = ReflectionModule()
         self._history: List[str] = []
         self._memory = memory
+        self._last_summary: str | None = None
         self._self_state: Dict[str, Any] = {
             "goals": [],
             "capabilities": [],
@@ -79,11 +80,27 @@ class SelfModel:
 
         self._history.append(summary)
         self._history = self._history[-5:]
+        self._last_summary = summary
         if self._memory:
             self._memory.add("self_awareness", summary)
             self._memory.add("self_narrative", narrative)
         return metrics, summary
 
+    # ------------------------------------------------------------------
+    def introspect(
+        self, data: Dict[str, float], env_pred: Dict[str, float], last_action: str
+    ) -> Dict[str, float | str]:
+        """Return CPU/memory estimates together with a reflection summary."""
+
+        metrics, summary = self.assess_state(data, env_pred, last_action)
+        return {"cpu": metrics["cpu"], "memory": metrics["memory"], "summary": summary}
+
     @property
     def history(self) -> List[str]:
         return list(self._history)
+
+    @property
+    def last_summary(self) -> str | None:
+        """Return the most recent introspection summary."""
+
+        return self._last_summary

--- a/modules/tests/test_global_workspace.py
+++ b/modules/tests/test_global_workspace.py
@@ -23,3 +23,11 @@ def test_broadcast_propagates_state() -> None:
     assert b.received == [("a", {"value": 1}, 0.5)]
     assert gw.state("a") == {"value": 1}
     assert gw.attention("a") == 0.5
+
+
+def test_subscribe_state_receives_updates() -> None:
+    gw = GlobalWorkspace()
+    received = []
+    gw.subscribe_state("self_model", lambda s: received.append(s))
+    gw.broadcast("self_model", {"agent": "a", "summary": "hi"})
+    assert received == [{"agent": "a", "summary": "hi"}]

--- a/tests/self_model/test_self_awareness.py
+++ b/tests/self_model/test_self_awareness.py
@@ -53,3 +53,12 @@ def test_update_state_from_events():
     assert "build features" in model._self_state["goals"]
     assert "planning" in model._self_state["capabilities"]
     assert model._self_state["mood"] == "satisfied"
+
+
+def test_introspect_exposes_last_summary():
+    data = {"cpu": 1.0, "memory": 2.0}
+    env_pred = {"avg_cpu": 0.5, "avg_memory": 1.0}
+    model = SelfModel()
+    result = model.introspect(data, env_pred, "idle")
+    assert "summary" in result
+    assert model.last_summary == result["summary"]


### PR DESCRIPTION
## Summary
- add introspection utilities and last_summary to SelfModel
- broadcast self-awareness updates from AgentLifecycleManager via global workspace
- allow modules to subscribe to self-awareness state

## Testing
- `PYTHONPATH=backend pytest tests/self_model/test_self_awareness.py modules/tests/test_global_workspace.py`
- `PYTHONPATH=backend pytest tests/self_model/test_self_awareness.py modules/tests/test_global_workspace.py modules/tests/test_manager_cleanup.py modules/tests/test_manager_error_handling.py` *(fails: ModuleNotFoundError: No module named 'events')*


------
https://chatgpt.com/codex/tasks/task_e_68bcc9d3f8a8832fb999ae74b5c613d1