### PR TITLE
Integrate divergent-convergent solving into planning and execution

### DIFF
--- a/backend/creative_engine/problem_solver.py
+++ b/backend/creative_engine/problem_solver.py
@@ -1,0 +1,54 @@
+"""Problem solving utilities using associative reasoning and reflection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from backend.reasoning import MultiHopAssociator
+from backend.reflection import ReflectionModule
+
+
+@dataclass
+class DivergentConvergentSolver:
+    """Generate multiple solution paths and evaluate them.
+
+    The solver first explores divergent solution paths between ``start`` and
+    ``goal`` using :class:`~backend.reasoning.MultiHopAssociator`. Each path is
+    then scored using :class:`~backend.reflection.ReflectionModule` and the
+    highest scoring path is returned.
+    """
+
+    associator: MultiHopAssociator
+    reflection: ReflectionModule
+
+    def _generate_paths(
+        self, start: str, goal: str, strategies: List[str]
+    ) -> List[List[str]]:
+        """Create possible solution paths via intermediate ``strategies``."""
+
+        paths: List[List[str]] = []
+        for strat in strategies:
+            first = self.associator.find_path(start, strat)
+            second = self.associator.find_path(strat, goal)
+            if first and second:
+                paths.append(first + second[1:])
+        return paths
+
+    def solve(
+        self, start: str, goal: str, strategies: List[str]
+    ) -> Tuple[List[str], int]:
+        """Return the highest scoring path and its score."""
+
+        candidates = []
+        for path in self._generate_paths(start, goal, strategies):
+            evaluation, _ = self.reflection.reflect(" ".join(path))
+            try:
+                score = int(evaluation.split("=")[-1])
+            except ValueError:
+                score = 0
+            candidates.append((score, path))
+        if not candidates:
+            return [], 0
+        score, best = max(candidates, key=lambda x: x[0])
+        return best, score

--- a/backend/execution/executor.py
+++ b/backend/execution/executor.py
@@ -4,7 +4,7 @@ import ast
 import hashlib
 import re
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence, Tuple
 
 from autogpts.autogpt.autogpt.core.errors import (
     SkillExecutionError,
@@ -73,7 +73,17 @@ class Executor:
         return graph
 
     # Task scheduling and execution
-    def execute(self, goal: str) -> Dict[str, Any]:
+    def execute(self, plans: Sequence[Tuple[str, float]] | str) -> Dict[str, Any]:
+        """Execute the best plan from ``plans``.
+
+        ``plans`` may be a single goal string or a sequence of ``(goal, score)``
+        tuples. The plan with the highest score is selected for execution.
+        """
+
+        if isinstance(plans, str):
+            goal = plans
+        else:
+            goal, _ = max(plans, key=lambda p: p[1]) if plans else ("", 0)
         graph = self.decompose_goal(goal)
         return self.scheduler.submit(
             graph, lambda agent, skill: run_async(self._call_skill(agent, skill))

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -1,0 +1,122 @@
+"""Tests for planning and execution helpers."""
+
+from __future__ import annotations
+
+import hashlib
+
+from backend.reasoning import MultiHopAssociator
+from backend.reflection import ReflectionModule
+import importlib.util
+from pathlib import Path
+
+
+def _load(name: str, path: str):
+    abs_path = Path(__file__).resolve().parent.parent / path
+    spec = importlib.util.spec_from_file_location(name, str(abs_path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    import sys
+
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ps = _load("backend.creative_engine.problem_solver", "backend/creative_engine/problem_solver.py")
+import types, sys
+
+backend_ce = types.ModuleType("backend.creative_engine")
+backend_ce.problem_solver = ps
+sys.modules["backend.creative_engine"] = backend_ce
+sys.modules["backend.creative_engine.problem_solver"] = ps
+backend_execution = types.ModuleType("backend.execution")
+backend_execution.__path__ = []
+sys.modules["backend.execution"] = backend_execution
+
+# Stub modules required by executor
+errors_module = types.ModuleType("autogpts.autogpt.autogpt.core.errors")
+errors_module.SkillExecutionError = type("SkillExecutionError", (Exception,), {})
+errors_module.SkillSecurityError = type("SkillSecurityError", (Exception,), {})
+sys.modules["autogpts"] = types.ModuleType("autogpts")
+sys.modules["autogpts.autogpt"] = types.ModuleType("autogpts.autogpt")
+sys.modules["autogpts.autogpt.autogpt"] = types.ModuleType("autogpts.autogpt.autogpt")
+sys.modules["autogpts.autogpt.autogpt.core"] = types.ModuleType(
+    "autogpts.autogpt.autogpt.core"
+)
+sys.modules["autogpts.autogpt.autogpt.core.errors"] = errors_module
+skill_lib_module = types.ModuleType("capability.skill_library")
+skill_lib_module.SkillLibrary = object
+sys.modules["capability"] = types.ModuleType("capability")
+sys.modules["capability.skill_library"] = skill_lib_module
+async_utils = types.ModuleType("common.async_utils")
+
+def _run_async(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+async_utils.run_async = _run_async
+sys.modules["common"] = types.ModuleType("common")
+sys.modules["common.async_utils"] = async_utils
+
+task_graph_mod = _load("backend.execution.task_graph", "backend/execution/task_graph.py")
+scheduler_mod = _load("backend.execution.scheduler", "backend/execution/scheduler.py")
+planner_mod = _load("backend.execution.planner", "backend/execution/planner.py")
+executor_mod = _load("backend.execution.executor", "backend/execution/executor.py")
+
+DivergentConvergentSolver = ps.DivergentConvergentSolver
+Planner = planner_mod.Planner
+Executor = executor_mod.Executor
+
+
+class DummySkillLibrary:
+    def __init__(self) -> None:
+        self.skills = {}
+        self.add_skill("plan_a", "def plan_a():\n    return 'A'")
+        self.add_skill("plan_b", "def plan_b():\n    return 'B'")
+
+    def add_skill(self, name: str, code: str) -> None:
+        sig = hashlib.sha256(code.encode("utf-8")).hexdigest()
+        self.skills[name] = (code, {"signature": sig})
+
+    def list_skills(self):  # pragma: no cover - trivial
+        return list(self.skills.keys())
+
+    async def get_skill(self, name: str):  # pragma: no cover - simple awaitable
+        return self.skills[name]
+
+
+def test_divergent_convergent_solver():
+    graph = {
+        "A": ["B", "C"],
+        "B": ["D"],
+        "C": ["E"],
+        "E": ["D"],
+        "D": [],
+    }
+    solver = DivergentConvergentSolver(MultiHopAssociator(graph), ReflectionModule())
+    path, score = solver.solve("A", "D", ["B", "C"])
+    assert path == ["A", "C", "E", "D"]
+    assert score == 4
+
+
+def test_planner_solve_delegates_solver():
+    graph = {
+        "A": ["B", "C"],
+        "B": ["D"],
+        "C": ["E"],
+        "E": ["D"],
+        "D": [],
+    }
+    solver = DivergentConvergentSolver(MultiHopAssociator(graph), ReflectionModule())
+    planner = Planner(solver=solver)
+    result = planner.solve({"start": "A", "goal": "D", "strategies": ["B", "C"]})
+    assert result == ["A", "C", "E", "D"]
+
+
+def test_executor_selects_best_plan():
+    lib = DummySkillLibrary()
+    executor = Executor(lib)
+    plans = [("plan_a", 0.1), ("plan_b", 0.9)]
+    result = executor.execute(plans)
+    assert result["plan_b"] == "B"


### PR DESCRIPTION
## Summary
- add DivergentConvergentSolver combining MultiHopAssociator with ReflectionModule
- support multi-strategy solving in Planner via new `solve` method
- update Executor to pick highest scoring plan before execution and add tests

## Testing
- `pytest tests/test_new_modules.py tests/test_planner_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bccd24437c832fa392fecb3a41d7f3