### PR TITLE
feat(memory): parse code structure for embeddings

### DIFF
--- a/backend/autogpt/autogpt/commands/file_operations.py
+++ b/backend/autogpt/autogpt/commands/file_operations.py
@@ -8,6 +8,7 @@ import os
 import os.path
 from pathlib import Path
 from typing import Iterator, Literal
+import asyncio
 
 from typing import TYPE_CHECKING
 
@@ -206,10 +207,16 @@ def ingest_file(
                 memory.discard(item)
 
         if file_path.suffix.lower() in CODE_EXTENSIONS:
-            file_memory = MemoryItemFactory.from_code_file(content, location)
+            file_memory = asyncio.run(
+                MemoryItemFactory.from_code_file(
+                    content, location, agent.legacy_config
+                )
+            )
         else:
-            file_memory = MemoryItemFactory.from_text_file(
-                content, location, agent.legacy_config
+            file_memory = asyncio.run(
+                MemoryItemFactory.from_text_file(
+                    content, location, agent.legacy_config
+                )
             )
 
         logger.debug(f"Created memory: {file_memory.dump(True)}")


### PR DESCRIPTION
## Summary
- enhance code memory ingestion to parse code symbols and language before embedding
- capture metadata for code files and run factory asynchronously during ingestion
- add tests for code memory and update ingestion tests for async behavior

## Testing
- `pytest` *(fails: 46 errors during collection)*
- `pytest modules/tests/test_memory_processing.py backend/autogpt/tests/unit/test_ingest_file.py` *(fails: ModuleNotFoundError: No module named 'playsound')*


------
https://chatgpt.com/codex/tasks/task_e_68c4340989ec832fb896b4125f562efc