### PR TITLE
feat: add configurable model selection

### DIFF
--- a/backend/autogpt/autogpt/agents/prompt_strategies/one_shot.py
+++ b/backend/autogpt/autogpt/agents/prompt_strategies/one_shot.py
@@ -115,6 +115,9 @@ class OneShotAgentPromptConfiguration(SystemConfiguration):
         },
     )
 
+    model_classification: LanguageModelClassification = UserConfigurable(
+        default=LanguageModelClassification.FAST_MODEL
+    )
     body_template: str = UserConfigurable(default=DEFAULT_BODY_TEMPLATE)
     response_schema: dict = UserConfigurable(
         default_factory=DEFAULT_RESPONSE_SCHEMA.to_dict
@@ -148,7 +151,7 @@ class OneShotAgentPromptStrategy(PromptStrategy):
 
     @property
     def model_classification(self) -> LanguageModelClassification:
-        return LanguageModelClassification.FAST_MODEL  # FIXME: dynamic switching
+        return self.config.model_classification
 
     def build_prompt(
         self,

--- a/tests/test_one_shot_model_classification.py
+++ b/tests/test_one_shot_model_classification.py
@@ -1,0 +1,129 @@
+import logging
+import sys
+from pathlib import Path
+import types
+import enum
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "backend/autogpt"))
+
+# Stub out heavy dependencies from autogpt.config to avoid importing modules
+config_stub = types.ModuleType("autogpt.config")
+
+class AIProfile:  # minimal placeholder
+    pass
+
+
+class AIDirectives:  # minimal placeholder
+    pass
+
+
+config_stub.AIProfile = AIProfile
+config_stub.AIDirectives = AIDirectives
+sys.modules["autogpt.config"] = config_stub
+
+# Stub out minimal core prompting and resource modules
+prompting_stub = types.ModuleType("autogpt.core.prompting")
+
+class LanguageModelClassification(str, enum.Enum):
+    FAST_MODEL = "fast_model"
+    SMART_MODEL = "smart_model"
+
+
+class PromptStrategy:
+    pass
+
+
+class ChatPrompt:
+    def __init__(self, messages=None, functions=None):
+        self.messages = messages or []
+        self.functions = functions or []
+
+
+prompting_stub.LanguageModelClassification = LanguageModelClassification
+prompting_stub.PromptStrategy = PromptStrategy
+prompting_stub.ChatPrompt = ChatPrompt
+sys.modules["autogpt.core.prompting"] = prompting_stub
+
+resource_schema_stub = types.ModuleType(
+    "autogpt.core.resource.model_providers.schema"
+)
+
+
+class AssistantChatMessage:
+    pass
+
+
+class ChatMessage:
+    @staticmethod
+    def system(content):
+        return content
+
+    @staticmethod
+    def user(content):
+        return content
+
+
+class CompletionModelFunction:
+    pass
+
+
+resource_schema_stub.AssistantChatMessage = AssistantChatMessage
+resource_schema_stub.ChatMessage = ChatMessage
+resource_schema_stub.CompletionModelFunction = CompletionModelFunction
+sys.modules["autogpt.core.resource.model_providers.schema"] = resource_schema_stub
+
+json_schema_stub = types.ModuleType("autogpt.core.utils.json_schema")
+
+
+class JSONSchema(dict):
+    class Type:
+        OBJECT = "object"
+        STRING = "string"
+        ARRAY = "array"
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(d)
+
+    def to_dict(self):
+        return dict(self)
+
+
+json_schema_stub.JSONSchema = JSONSchema
+sys.modules["autogpt.core.utils.json_schema"] = json_schema_stub
+
+json_utils_stub = types.ModuleType("autogpt.core.utils.json_utils")
+json_utils_stub.extract_dict_from_json = lambda x: {}
+sys.modules["autogpt.core.utils.json_utils"] = json_utils_stub
+
+prompts_utils_stub = types.ModuleType("autogpt.prompts.utils")
+prompts_utils_stub.format_numbered_list = lambda x: ""
+prompts_utils_stub.indent = lambda text, indent_level=0: text
+sys.modules["autogpt.prompts.utils"] = prompts_utils_stub
+
+from autogpt.agents.prompt_strategies.one_shot import (
+    OneShotAgentPromptConfiguration,
+    OneShotAgentPromptStrategy,
+)
+from autogpt.core.prompting import LanguageModelClassification
+
+
+def test_model_classification_fast():
+    config = OneShotAgentPromptConfiguration(
+        model_classification=LanguageModelClassification.FAST_MODEL
+    )
+    strategy = OneShotAgentPromptStrategy(
+        configuration=config, logger=logging.getLogger(__name__)
+    )
+    assert strategy.model_classification == LanguageModelClassification.FAST_MODEL
+
+
+def test_model_classification_smart():
+    config = OneShotAgentPromptConfiguration(
+        model_classification=LanguageModelClassification.SMART_MODEL
+    )
+    strategy = OneShotAgentPromptStrategy(
+        configuration=config, logger=logging.getLogger(__name__)
+    )
+    assert strategy.model_classification == LanguageModelClassification.SMART_MODEL


### PR DESCRIPTION
## Summary
- allow OneShotAgentPromptStrategy to choose fast or smart model based on config
- expose model_classification setting
- test fast vs smart model selection

## Testing
- `pytest tests/test_one_shot_model_classification.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4341eb868832f92a52fae7ef97d1d