### PR TITLE
feat: auto-activate meta skills

### DIFF
--- a/backend/capability/skill_library.py
+++ b/backend/capability/skill_library.py
@@ -139,9 +139,8 @@ class SkillLibrary:
         code = await self._read_file(skill_file)
         metadata = json.loads(await self._read_file(meta_file))
         if name.startswith("MetaSkill_") and not metadata.get("active"):
-            raise PermissionError(
-                "Meta-skill version not activated by System Architect"
-            )
+            await self.activate_meta_skill(name)
+            metadata["active"] = True
         self._cache[name] = (code, metadata)
         self._save_to_persist(name, code, metadata)
         return code, metadata


### PR DESCRIPTION
## Summary
- transparently activate inactive meta-skills when retrieved
- test automatic activation and caching of meta-skills

## Testing
- `pytest modules/tests/test_skill_library.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4e376f848832fbd7b9dc8dbe8de0b