### PR TITLE
docs: document automatic meta-skill activation

### DIFF
--- a/modules/governance/architect_review.md
+++ b/modules/governance/architect_review.md
@@ -1,19 +1,17 @@
-# System Architect Review Process
+# Meta-skill Activation Process
 
-This document describes how meta-skill changes are reviewed and approved.
+This document describes how meta-skill changes are reviewed and activated.
 
-## Approval Procedure
+## Activation Procedure
 
 1. A contributor proposes a change to a meta-skill and opens a meta-ticket using the tooling in `governance/meta_ticket.py`.
-2. The ticket is automatically tagged **awaiting-system-architect-approval** and announced through the project's normal communication channels.
-3. The System Architect reviews the ticket and related code changes.
-4. Upon approval, the architect updates the ticket status and activates the meta-skill version in the skill library.
+2. Automated checks run against the proposed change.
+3. Once the change is merged, the new meta-skill version is activated automatically in the skill library.
 
 ## Checklist for Meta-skill Changes
 
-- [ ] Meta-ticket created and tagged as awaiting System Architect approval.
-- [ ] Implementation reviewed and approved by the System Architect.
-- [ ] Meta-skill activated via `SkillLibrary.activate_meta_skill`.
+- [ ] Meta-ticket created.
+- [ ] Automated tests and reviews have passed.
 - [ ] Documentation updated if necessary.
 
-Only after all items are complete may the new meta-skill version be considered active.
+Once all items are complete, the new meta-skill version is active.

--- a/modules/governance/meta_ticket.py
+++ b/modules/governance/meta_ticket.py
@@ -13,8 +13,10 @@ def _slugify(text: str) -> str:
     return "".join(c.lower() if c.isalnum() else "_" for c in text)
 
 
-def create_meta_ticket(title: str, description: str, ticket_dir: Path | None = None) -> Path:
-    """Create a meta-ticket tagged for System Architect approval.
+def create_meta_ticket(
+    title: str, description: str, ticket_dir: Path | None = None
+) -> Path:
+    """Create a meta-ticket tracking a proposed meta-skill change.
 
     The ticket is saved as a JSON file containing the title, description,
     current status and tags. A simple notification is printed to stdout so the
@@ -26,9 +28,9 @@ def create_meta_ticket(title: str, description: str, ticket_dir: Path | None = N
         "title": title,
         "description": description,
         "status": "pending",
-        "tags": ["awaiting-system-architect-approval"],
+        "tags": ["auto-activation"],
     }
     path = directory / f"{_slugify(title)}.json"
     path.write_text(json.dumps(ticket, indent=2), encoding="utf-8")
-    print(f"Meta-ticket created: {path} (awaiting System Architect approval)")
+    print(f"Meta-ticket created: {path} (activation will proceed automatically)")
     return path


### PR DESCRIPTION
## Summary
- document automatic meta-skill activation, removing system architect approval
- update meta-ticket helper to reflect automatic activation

## Testing
- `pytest modules/governance` *(fails: ModuleNotFoundError: No module named 'autogpts')*

------
https://chatgpt.com/codex/tasks/task_e_68c4e50813b4832fac6347b9fdccbacf