### PR TITLE
Simplify meta-ticket activation workflow

### DIFF
--- a/modules/governance/architect_review.md
+++ b/modules/governance/architect_review.md
@@ -4,9 +4,19 @@ This document describes how meta-skill changes are reviewed and activated.
 
 ## Activation Procedure
 
-1. A contributor proposes a change to a meta-skill and opens a meta-ticket using the tooling in `governance/meta_ticket.py`.
+1. A contributor proposes a change to a meta-skill and opens a meta-ticket using the tooling in `governance/meta_ticket.py`. The ticket records the title, description and pending status; no approval tags are added because activation is automatic.
 2. Automated checks run against the proposed change.
 3. Once the change is merged, the new meta-skill version is activated automatically in the skill library.
+
+Example meta-ticket JSON:
+
+```json
+{
+  "title": "Improve search algorithm",
+  "description": "Switch to new heuristic",
+  "status": "pending"
+}
+```
 
 ## Checklist for Meta-skill Changes
 

--- a/modules/governance/meta_ticket.py
+++ b/modules/governance/meta_ticket.py
@@ -18,9 +18,10 @@ def create_meta_ticket(
 ) -> Path:
     """Create a meta-ticket tracking a proposed meta-skill change.
 
-    The ticket is saved as a JSON file containing the title, description,
-    current status and tags. A simple notification is printed to stdout so the
-    message can be captured by existing communication channels.
+    The ticket is saved as a JSON file containing the title, description and
+    current status. No approval tags are recorded because meta-skill changes
+    are activated automatically. A simple notification is printed to stdout so
+    the message can be captured by existing communication channels.
     """
     directory = ticket_dir or DEFAULT_DIR
     directory.mkdir(parents=True, exist_ok=True)
@@ -28,9 +29,8 @@ def create_meta_ticket(
         "title": title,
         "description": description,
         "status": "pending",
-        "tags": ["auto-activation"],
     }
     path = directory / f"{_slugify(title)}.json"
     path.write_text(json.dumps(ticket, indent=2), encoding="utf-8")
-    print(f"Meta-ticket created: {path} (activation will proceed automatically)")
+    print(f"Meta-ticket created: {path} (auto-activation enabled)")
     return path


### PR DESCRIPTION
## Summary
- remove approval tags from meta-ticket JSON and update activation message
- document auto-activation process and provide example meta-ticket JSON

## Testing
- ⚠️ `pytest` *(missing dependencies: ModuleNotFoundError: No module named 'pydantic', 'chromadb', 'litellm', etc.)*
- ⚠️ `pytest modules/governance/test_{queue,human_architect}.py` *(ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_68c4e5a467c8832fbe0450947847e9a2