### PR TITLE
Add tests for algorithms module and CI integration

### DIFF
--- a/.github/workflows/algorithms-tests.yml
+++ b/.github/workflows/algorithms-tests.yml
@@ -1,0 +1,26 @@
+name: Algorithms Tests
+
+on:
+  push:
+    paths:
+      - 'algorithms/**'
+      - '.github/workflows/algorithms-tests.yml'
+  pull_request:
+    paths:
+      - 'algorithms/**'
+      - '.github/workflows/algorithms-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run pytest
+        run: PYTHONPATH=. pytest algorithms/tests

--- a/algorithms/tests/test_data_structures.py
+++ b/algorithms/tests/test_data_structures.py
@@ -1,0 +1,42 @@
+from algorithms.data_structures.basic.stack import Stack
+from algorithms.data_structures.basic.queue import Queue
+from algorithms.data_structures.basic.linked_list import LinkedList
+
+
+def test_stack_operations():
+    stack = Stack()
+    assert stack.is_empty()
+    stack.push(1)
+    stack.push(2)
+    assert stack.peek() == 2
+    assert stack.pop() == 2
+    assert stack.pop() == 1
+    assert stack.pop() is None
+    assert stack.is_empty()
+
+
+def test_queue_operations():
+    queue = Queue()
+    assert queue.is_empty()
+    queue.enqueue(1)
+    queue.enqueue(2)
+    assert queue.peek() == 1
+    assert queue.dequeue() == 1
+    assert queue.dequeue() == 2
+    assert queue.dequeue() is None
+    assert queue.is_empty()
+
+
+def test_linked_list_operations():
+    linked = LinkedList()
+    assert linked.find(1) is None
+    assert not linked.delete(1)
+    linked.append(1)
+    linked.append(2)
+    linked.append(3)
+    node = linked.find(2)
+    assert node is not None and node.value == 2
+    assert linked.delete(2)
+    assert linked.find(2) is None
+    assert not linked.delete(4)
+    assert linked.to_list() == [1, 3]

--- a/algorithms/tests/test_searching.py
+++ b/algorithms/tests/test_searching.py
@@ -1,0 +1,35 @@
+import pytest
+
+from algorithms.searching.basic.linear_search import LinearSearch
+from algorithms.searching.basic.binary_search import BinarySearch
+
+
+@pytest.mark.parametrize("searcher", [LinearSearch(), BinarySearch()])
+def test_search_found(searcher):
+    data = [1, 3, 5, 7, 9]
+    target = 7
+    assert searcher.execute(data, target) == data.index(target)
+
+
+def test_binary_search_boundaries():
+    searcher = BinarySearch()
+    data = [1, 3, 5, 7]
+    assert searcher.execute(data, 1) == 0
+    assert searcher.execute(data, 7) == len(data) - 1
+
+
+def test_search_not_found():
+    data = [1, 3, 5]
+    assert LinearSearch().execute(data, 7) == -1
+    assert BinarySearch().execute(data, 7) == -1
+
+
+def test_search_empty_list():
+    assert LinearSearch().execute([], 1) == -1
+    assert BinarySearch().execute([], 1) == -1
+
+
+@pytest.mark.parametrize("searcher", [LinearSearch(), BinarySearch()])
+def test_search_type_error(searcher):
+    with pytest.raises(TypeError):
+        searcher.execute(None, 1)

--- a/algorithms/tests/test_sorting.py
+++ b/algorithms/tests/test_sorting.py
@@ -1,0 +1,24 @@
+import pytest
+
+from algorithms.sorting.basic.bubble_sort import BubbleSort
+from algorithms.sorting.basic.quick_sort import QuickSort
+
+
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort()])
+def test_sorting_basic(algorithm):
+    data = [5, 1, 4, 2, 8]
+    original = list(data)
+    assert algorithm.execute(data) == sorted(data)
+    assert data == original
+
+
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort()])
+def test_sorting_empty_and_single(algorithm):
+    assert algorithm.execute([]) == []
+    assert algorithm.execute([1]) == [1]
+
+
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort()])
+def test_sorting_type_error(algorithm):
+    with pytest.raises(TypeError):
+        algorithm.execute([1, "a"])


### PR DESCRIPTION
## Summary
- add pytest suites for sorting, searching, and data structure modules
- add GitHub Actions workflow to run algorithms tests automatically

## Testing
- `PYTHONPATH=. pytest algorithms/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c4e8475444832fa247cf54ee640f15