### PR TITLE
chore: add lint and typecheck tooling

### DIFF
--- a/.github/workflows/autogpt-ci.yml
+++ b/.github/workflows/autogpt-ci.yml
@@ -55,8 +55,8 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           poetry install
 
-      - name: Lint with flake8
-        run: poetry run flake8
+      - name: Run lint checks
+        run: ../scripts/lint.sh
 
       - name: Check black formatting
         run: poetry run black . --check
@@ -66,9 +66,9 @@ jobs:
         run: poetry run isort . --check
         if: success() || failure()
 
-      # - name: Check mypy formatting
-      #   run: poetry run mypy
-      #   if: success() || failure()
+      - name: Run type checks
+        run: ../scripts/typecheck.sh
+        if: success() || failure()
 
       # - name: Check for unused imports and pass statements
       #   run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,23 @@ mypy = "^1.4.1"
 pre-commit = "^3.3.3"
 autoflake = "^2.2.0"
 types-requests = "^2.31.0.2"
+ruff = "^0.1.11"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+exclude = ["tests/vcr_cassettes"]
+
+[tool.ruff.lint]
+ignore = ["E203"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Prefer Poetry-managed environment if available, fall back to system ruff
+poetry run ruff check . 2>/dev/null || ruff check .

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Prefer Poetry-managed environment if available, fall back to system mypy
+poetry run mypy . 2>/dev/null || mypy .


### PR DESCRIPTION
## Summary
- configure ruff and mypy in `pyproject.toml`
- add reusable `lint.sh` and `typecheck.sh` helper scripts
- run linting and type checks during CI

## Testing
- `scripts/lint.sh` *(fails: Found 427 errors)*
- `scripts/typecheck.sh` *(fails: algorithms/data_structures/advanced/binary_tree.py:54: error: Invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e917aae4832f9a2b51e461bbd5bf