### PR TITLE
feat: add anomaly detection to performance monitor

### DIFF
--- a/docs/performance_monitor.md
+++ b/docs/performance_monitor.md
@@ -1,0 +1,33 @@
+# Performance Monitor Anomaly Detection
+
+The `PerformanceMonitor` can automatically learn baseline performance characteristics and flag abnormal behavior using an Isolation Forest model.
+
+## Configuration
+
+Enable anomaly detection when constructing the monitor:
+
+```python
+from monitoring import PerformanceMonitor, TimeSeriesStorage
+
+storage = TimeSeriesStorage()
+monitor = PerformanceMonitor(
+    storage,
+    training_accuracy=0.95,
+    degradation_threshold=0.05,
+    enable_anomaly_detection=True,
+    model_update_interval=3600,  # seconds between model retraining
+    contamination=0.05,          # expected proportion of anomalies
+)
+```
+
+### Parameters
+
+- **enable_anomaly_detection** – turn on automatic anomaly detection.
+- **model_update_interval** – seconds between model retraining on recent metrics.
+- **contamination** – estimated fraction of anomalous samples in the data.
+
+The model uses CPU and memory usage events stored in `TimeSeriesStorage` as input features and periodically retrains to adapt to changing baselines.
+
+## Alerts
+
+When the detector flags an anomalous deviation, the monitor triggers configured alert handlers. The alert message includes the component with the highest failure count returned by `TimeSeriesStorage.bottlenecks()` to hint at the most likely bottleneck.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ agbenchmark = { path = "benchmark", optional = true }
 pytest-benchmark = "^3.4.1"
 coverage = "^7.2.7"
 cachetools = "^5.3.1"
+scikit-learn = "^1.4.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tests/test_performance_anomaly_detection.py
+++ b/tests/test_performance_anomaly_detection.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "modules"))
+sys.modules.setdefault("events", types.SimpleNamespace(EventBus=object))
+
+import importlib.util
+pkg = types.ModuleType("monitoring")
+pkg.__path__ = [str(ROOT / "backend" / "monitoring")]
+sys.modules.setdefault("monitoring", pkg)
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+performance_monitor = load_module(
+    "monitoring.performance_monitor",
+    ROOT / "backend" / "monitoring" / "performance_monitor.py",
+)
+storage_module = load_module(
+    "monitoring.storage", ROOT / "backend" / "monitoring" / "storage.py"
+)
+PerformanceMonitor = performance_monitor.PerformanceMonitor
+TimeSeriesStorage = storage_module.TimeSeriesStorage
+
+
+def test_anomaly_detection_triggers_alert(tmp_path):
+    storage = TimeSeriesStorage(tmp_path / "mon.db")
+    alerts = []
+    monitor = PerformanceMonitor(
+        storage,
+        training_accuracy=0.0,
+        degradation_threshold=0.0,
+        alert_handlers=[lambda s, m: alerts.append((s, m))],
+        enable_anomaly_detection=True,
+        model_update_interval=9999,
+    )
+
+    for cpu, mem in [(10, 10), (11, 11), (9, 9), (10, 9), (9, 10)]:
+        monitor.log_resource_usage("agent", cpu=cpu, memory=mem)
+    monitor.check_performance()
+
+    storage.store("agent.lifecycle", {"stage": "database", "status": "error"})
+    storage.store("agent.lifecycle", {"stage": "database", "status": "error"})
+
+    monitor.log_resource_usage("agent", cpu=95, memory=95)
+    monitor.check_performance()
+
+    assert any("Anomalous performance metrics" in subj for subj, _ in alerts)
+    assert "database" in alerts[0][1]


### PR DESCRIPTION
## Summary
- integrate IsolationForest-based anomaly detection into `PerformanceMonitor`
- trigger alerts with suspected bottleneck component when metrics deviate
- document anomaly detection configuration

## Testing
- `pytest tests/test_performance_anomaly_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ed725178832f8b1b6b0a0f4455b3