### PR TITLE
Add A/B testing benchmark framework

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,3 +36,22 @@ trajectory for the adaptive run.
 ```
 python benchmarks/pso_benchmark.py
 ```
+
+## A/B testing framework
+
+The `ab_testing` module enables side-by-side evaluation of two algorithm
+variants. `run_ab_test.py` executes both versions in parallel on a synthetic
+classification dataset, collects accuracy and timing metrics, and performs
+basic statistical analysis (confidence intervals and a paired t-test).
+
+### Running the benchmark
+
+```
+python benchmarks/run_ab_test.py --algoA benchmarks.ab_testing.sample_algorithms:algo_random --algoB benchmarks.ab_testing.sample_algorithms:algo_knn
+```
+
+### CI integration
+
+In continuous integration, run the script with your production algorithm as
+`--algoA` and the candidate change as `--algoB`. Fail the pipeline if the
+reported p-value indicates a significant drop in accuracy.

--- a/benchmarks/ab_testing/__init__.py
+++ b/benchmarks/ab_testing/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities for algorithm A/B testing benchmarks."""
+
+from .config import ABTestConfig
+from .runner import AlgorithmResult, ABTestResult, run_ab_test
+from .analysis import confidence_interval, significance_test
+
+__all__ = [
+    "ABTestConfig",
+    "AlgorithmResult",
+    "ABTestResult",
+    "run_ab_test",
+    "confidence_interval",
+    "significance_test",
+]

--- a/benchmarks/ab_testing/analysis.py
+++ b/benchmarks/ab_testing/analysis.py
@@ -1,0 +1,34 @@
+"""Statistical tools for comparing A/B test results."""
+
+from __future__ import annotations
+
+import math
+import statistics
+from typing import Iterable, Tuple
+
+
+def confidence_interval(samples: Iterable[float], confidence: float = 0.95) -> Tuple[float, float]:
+    """Return the normal confidence interval for the given samples."""
+
+    data = list(samples)
+    dist = statistics.NormalDist.from_samples(data)
+    z = statistics.NormalDist().inv_cdf(0.5 + confidence / 2)
+    margin = z * dist.stdev / math.sqrt(len(data))
+    return dist.mean - margin, dist.mean + margin
+
+
+def significance_test(a: Iterable[int], b: Iterable[int]) -> Tuple[float, float]:
+    """Paired t-test for per-sample metric differences.
+
+    Returns the t statistic and two-tailed p-value.
+    """
+
+    differences = [x - y for x, y in zip(a, b)]
+    if len(differences) < 2:
+        return float("nan"), float("nan")
+
+    mean_diff = statistics.mean(differences)
+    sd_diff = statistics.stdev(differences)
+    t_stat = mean_diff / (sd_diff / math.sqrt(len(differences)))
+    p_value = 2 * statistics.NormalDist().cdf(-abs(t_stat))
+    return t_stat, p_value

--- a/benchmarks/ab_testing/config.py
+++ b/benchmarks/ab_testing/config.py
@@ -1,0 +1,25 @@
+"""Configuration objects for A/B algorithm tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence, Tuple
+
+
+@dataclass
+class ABTestConfig:
+    """Define an A/B experiment setup.
+
+    Attributes:
+        algo_a: Callable implementing algorithm variant A.
+        algo_b: Callable implementing algorithm variant B.
+        data:   Tuple of features and ground-truth labels.
+        name_a: Optional display name for algorithm A.
+        name_b: Optional display name for algorithm B.
+    """
+
+    algo_a: Callable[[Any, Sequence[int]], Sequence[int]]
+    algo_b: Callable[[Any, Sequence[int]], Sequence[int]]
+    data: Tuple[Any, Sequence[int]]
+    name_a: str = "algo_a"
+    name_b: str = "algo_b"

--- a/benchmarks/ab_testing/runner.py
+++ b/benchmarks/ab_testing/runner.py
@@ -1,0 +1,53 @@
+"""Execution utilities for running A/B algorithm comparisons."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import List
+
+from .config import ABTestConfig
+
+
+@dataclass
+class AlgorithmResult:
+    """Metrics collected for a single algorithm run."""
+
+    name: str
+    accuracy: float
+    duration: float
+    correctness: List[int]
+
+
+@dataclass
+class ABTestResult:
+    """Results for both algorithm variants."""
+
+    algo_a: AlgorithmResult
+    algo_b: AlgorithmResult
+
+
+def _evaluate(algo, X, y):
+    start = time.perf_counter()
+    preds = algo(X, y)
+    duration = time.perf_counter() - start
+    correctness = [int(p == t) for p, t in zip(preds, y)]
+    accuracy = sum(correctness) / len(correctness)
+    return AlgorithmResult(algo.__name__, accuracy, duration, correctness)
+
+
+def run_ab_test(config: ABTestConfig) -> ABTestResult:
+    """Run both algorithms in parallel and collect metrics."""
+
+    X, y = config.data
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        future_a = ex.submit(_evaluate, config.algo_a, X, y)
+        future_b = ex.submit(_evaluate, config.algo_b, X, y)
+        res_a = future_a.result()
+        res_b = future_b.result()
+
+    # Override names if provided in config
+    res_a.name = config.name_a
+    res_b.name = config.name_b
+    return ABTestResult(res_a, res_b)

--- a/benchmarks/ab_testing/sample_algorithms.py
+++ b/benchmarks/ab_testing/sample_algorithms.py
@@ -1,0 +1,23 @@
+"""Example algorithms for demonstrating the A/B testing utilities."""
+
+from __future__ import annotations
+
+from sklearn.dummy import DummyClassifier
+from sklearn.neighbors import KNeighborsClassifier
+from typing import Any, Sequence
+
+
+def algo_random(X: Any, y: Sequence[int]) -> Sequence[int]:
+    """Predict labels uniformly at random."""
+
+    model = DummyClassifier(strategy="uniform", random_state=0)
+    model.fit(X, y)
+    return model.predict(X)
+
+
+def algo_knn(X: Any, y: Sequence[int]) -> Sequence[int]:
+    """Simple k-nearest neighbours classifier."""
+
+    model = KNeighborsClassifier(n_neighbors=3)
+    model.fit(X, y)
+    return model.predict(X)

--- a/benchmarks/run_ab_test.py
+++ b/benchmarks/run_ab_test.py
@@ -1,0 +1,57 @@
+"""Command line interface for running A/B algorithm comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import sys
+from typing import Callable
+
+from sklearn.datasets import make_classification
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from benchmarks.ab_testing import (
+    ABTestConfig,
+    confidence_interval,
+    run_ab_test,
+    significance_test,
+)
+
+
+def _load_callable(path: str) -> Callable:
+    module_name, func_name = path.split(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, func_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run A/B algorithm test")
+    parser.add_argument("--algoA", required=True, help="module:function for algorithm A")
+    parser.add_argument("--algoB", required=True, help="module:function for algorithm B")
+    parser.add_argument("--size", type=int, default=200, help="dataset size")
+    args = parser.parse_args()
+
+    X, y = make_classification(
+        n_samples=args.size, n_features=20, n_informative=15, random_state=0
+    )
+
+    algo_a = _load_callable(args.algoA)
+    algo_b = _load_callable(args.algoB)
+    config = ABTestConfig(algo_a=algo_a, algo_b=algo_b, data=(X, y), name_a=args.algoA, name_b=args.algoB)
+
+    result = run_ab_test(config)
+    diff = [a - b for a, b in zip(result.algo_a.correctness, result.algo_b.correctness)]
+    ci_low, ci_high = confidence_interval(diff)
+    t_stat, p_val = significance_test(result.algo_a.correctness, result.algo_b.correctness)
+
+    print(f"{result.algo_a.name}: accuracy={result.algo_a.accuracy:.3f} time={result.algo_a.duration:.3f}s")
+    print(f"{result.algo_b.name}: accuracy={result.algo_b.accuracy:.3f} time={result.algo_b.duration:.3f}s")
+    print(f"Accuracy diff (A-B): {result.algo_a.accuracy - result.algo_b.accuracy:.3f}")
+    print(f"95% CI for diff: ({ci_low:.3f}, {ci_high:.3f})")
+    print(f"t-statistic={t_stat:.3f}, p-value={p_val:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/test_ab_testing.py
+++ b/benchmarks/tests/test_ab_testing.py
@@ -1,0 +1,20 @@
+"""Tests for the A/B testing utilities."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from sklearn.datasets import make_classification
+
+from benchmarks.ab_testing import ABTestConfig, run_ab_test, significance_test
+from benchmarks.ab_testing.sample_algorithms import algo_knn, algo_random
+
+
+def test_knn_beats_random() -> None:
+    X, y = make_classification(n_samples=200, n_features=20, n_informative=15, random_state=0)
+    config = ABTestConfig(algo_a=algo_random, algo_b=algo_knn, data=(X, y), name_a="random", name_b="knn")
+    result = run_ab_test(config)
+    assert result.algo_b.accuracy >= result.algo_a.accuracy
+    t_stat, p_val = significance_test(result.algo_a.correctness, result.algo_b.correctness)
+    assert p_val < 0.05


### PR DESCRIPTION
## Summary
- introduce `ab_testing` benchmark module with experiment config, parallel runner and statistical tools
- add CLI `run_ab_test.py` to compare two algorithms and compute confidence intervals & significance
- document how to integrate A/B tests in CI

## Testing
- `pytest benchmarks/tests -q`
- `python benchmarks/run_ab_test.py --algoA benchmarks.ab_testing.sample_algorithms:algo_random --algoB benchmarks.ab_testing.sample_algorithms:algo_knn --size 100`


------
https://chatgpt.com/codex/tasks/task_e_68c4f917954c832fadfc873ebd3bb7fb