### PR TITLE
Add optimization module with parameter tuning and persistence

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -1,0 +1,22 @@
+# Optimization Module
+
+The optimization module records every algorithm run and recommends improved
+parameters for future runs. It keeps a CSV file of historic parameter choices
+and their resulting performance, enabling simple automatic tuning without manual
+trial and error.
+
+## Usage
+
+```python
+from modules.optimization import log_run, optimize_params
+
+search_space = {"lr": [0.01, 0.1, 1.0], "batch": [16, 32, 64]}
+params = optimize_params("my_algo", search_space)
+# run your algorithm with ``params`` and compute a performance score
+metrics = {"score": 0.8}
+log_run("my_algo", params, metrics)
+```
+
+The first call samples random parameters from the provided search space. After
+several runs the best performing configuration is returned, saving time otherwise
+spent on manual tuning.

--- a/modules/README.md
+++ b/modules/README.md
@@ -12,3 +12,11 @@ pip install -r requirements.txt
 ```
 
 This installs only the packages required by the modules under this directory.
+
+## Optimization
+
+The ``optimization`` module provides lightweight parameter tuning utilities. It
+records the parameters and metrics of each algorithm run to a CSV file and can
+recommend improved parameters for future runs.
+
+See [docs/optimization.md](../docs/optimization.md) for usage details.

--- a/modules/optimization/__init__.py
+++ b/modules/optimization/__init__.py
@@ -1,0 +1,15 @@
+"""Lightweight parameter optimization utilities.
+
+This module provides functions to persist algorithm run parameters and metrics
+and to recommend parameters for future runs based on historical performance.
+"""
+
+from .optimizer import optimize_params, log_run
+from .storage import load_history, DEFAULT_HISTORY_FILE
+
+__all__ = [
+    "optimize_params",
+    "log_run",
+    "load_history",
+    "DEFAULT_HISTORY_FILE",
+]

--- a/modules/optimization/example.py
+++ b/modules/optimization/example.py
@@ -1,0 +1,21 @@
+"""Example usage of the optimization module."""
+from __future__ import annotations
+
+from modules.optimization import log_run, optimize_params
+
+
+def dummy_algorithm(x: int, y: int) -> float:
+    """A placeholder objective function returning a score."""
+    return 1.0 / (abs(x - 3) + 1) + y / 100
+
+
+def main() -> None:
+    search_space = {"x": [1, 2, 3, 4], "y": [10, 20, 30]}
+    params = optimize_params("dummy", search_space)
+    score = dummy_algorithm(**params)
+    log_run("dummy", params, {"score": score})
+    print("run with", params, "-> score", score)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/optimization/optimizer.py
+++ b/modules/optimization/optimizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Dict, Any, Iterable
+
+from .storage import load_history, DEFAULT_HISTORY_FILE
+
+
+def optimize_params(
+    algorithm: str,
+    search_space: Dict[str, Iterable],
+    metric: str = "score",
+    history_file: Path = DEFAULT_HISTORY_FILE,
+) -> Dict[str, Any]:
+    """Return recommended parameters for ``algorithm``.
+
+    Parameters are chosen by looking at past runs stored in ``history_file``. If
+    runs for the given algorithm exist, the parameters with the highest value for
+    the provided ``metric`` are returned. Otherwise a random sample from the
+    provided ``search_space`` is used as a starting point.
+    """
+    best_params = None
+    best_score = None
+    for record in load_history(history_file):
+        if record["algorithm"] != algorithm:
+            continue
+        score = record["metrics"].get(metric)
+        if score is None:
+            continue
+        if best_score is None or score > best_score:
+            best_score = score
+            best_params = record["params"]
+
+    if best_params is not None:
+        return best_params
+
+    # Fallback to random selection
+    return {name: random.choice(list(values)) for name, values in search_space.items()}
+
+
+def log_run(
+    algorithm: str,
+    params: Dict[str, Any],
+    metrics: Dict[str, Any],
+    history_file: Path = DEFAULT_HISTORY_FILE,
+) -> None:
+    """Public wrapper for appending history."""
+    from .storage import append_history
+
+    append_history(algorithm, params, metrics, history_file)

--- a/modules/optimization/storage.py
+++ b/modules/optimization/storage.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Any, Iterable, Iterator
+
+# Default location for the history database
+DEFAULT_HISTORY_FILE = Path(__file__).with_name("history.csv")
+
+
+def append_history(
+    algorithm: str,
+    params: Dict[str, Any],
+    metrics: Dict[str, Any],
+    history_file: Path = DEFAULT_HISTORY_FILE,
+) -> None:
+    """Append a single run to the persistent history file.
+
+    The history is stored as CSV with JSON-encoded parameter and metric
+    dictionaries. Each row contains the algorithm name, parameters used and the
+    resulting metrics.
+    """
+    fieldnames = ["algorithm", "params", "metrics"]
+    exists = history_file.exists()
+    with history_file.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(
+            {
+                "algorithm": algorithm,
+                "params": json.dumps(params),
+                "metrics": json.dumps(metrics),
+            }
+        )
+
+
+def load_history(history_file: Path = DEFAULT_HISTORY_FILE) -> Iterator[Dict[str, Any]]:
+    """Load all historic runs from the given file."""
+    if not history_file.exists():
+        return iter([])
+
+    with history_file.open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = [
+            {
+                "algorithm": row["algorithm"],
+                "params": json.loads(row["params"]),
+                "metrics": json.loads(row["metrics"]),
+            }
+            for row in reader
+        ]
+    return iter(rows)

--- a/modules/tests/test_optimization.py
+++ b/modules/tests/test_optimization.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from optimization import log_run, optimize_params
+
+
+def test_optimization_flow_and_persistence(tmp_path):
+    history = tmp_path / "history.csv"
+    search_space = {"x": [1, 2, 3], "y": [10, 20]}
+
+    log_run("algo", {"x": 1, "y": 10}, {"score": 0.5}, history)
+    log_run("algo", {"x": 2, "y": 20}, {"score": 0.8}, history)
+
+    params = optimize_params("algo", search_space, history_file=history)
+    assert params == {"x": 2, "y": 20}
+
+    with history.open() as f:
+        lines = f.readlines()
+    assert len(lines) == 3  # header + two entries
+
+    # When requesting params for new algorithm it samples from search space
+    new_params = optimize_params("new_algo", search_space, history_file=history)
+    assert new_params["x"] in search_space["x"]
+    assert new_params["y"] in search_space["y"]


### PR DESCRIPTION
## Summary
- add `modules/optimization` for persisting algorithm parameters and metrics
- recommend parameters based on historical runs via `optimize_params`
- document optimization workflow and add example usage
- include tests validating persistence and recommendation logic

## Testing
- `pytest modules/tests/test_optimization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f92ceee4832f99d1ad54e6bee4ac