### PR TITLE
Add Dijkstra algorithm for weighted graphs

### DIFF
--- a/algorithms/graph/advanced/dijkstra.py
+++ b/algorithms/graph/advanced/dijkstra.py
@@ -1,0 +1,49 @@
+"""Dijkstra shortest path algorithm using a priority queue."""
+from __future__ import annotations
+
+import heapq
+from typing import Any, Dict, List, Tuple
+
+from ...base import Algorithm
+
+
+class Dijkstra(Algorithm):
+    """单源最短路径的 Dijkstra 算法实现。
+
+    该算法使用优先队列（最小堆）处理带权无向图，
+    计算源点到图中各节点的最短距离。如果某个节点不可达，
+    则其距离为 ``float('inf')``。
+    """
+
+    def execute(
+        self, graph: Dict[Any, List[Tuple[Any, float]]], start: Any
+    ) -> Dict[Any, float]:
+        """计算源点到其他所有节点的最短距离。
+
+        参数:
+            graph: 图的邻接表表示，键为节点，值为邻居及权重的列表。
+            start: 源点。
+
+        返回:
+            Dict[Any, float]: 源点到每个节点的最短距离映射。
+        """
+        # 初始化距离字典，所有节点距离设为正无穷
+        distances: Dict[Any, float] = {node: float("inf") for node in graph}
+        distances[start] = 0.0
+
+        # 最小堆，存储待处理的节点及其当前已知的最短距离
+        pq: List[Tuple[float, Any]] = [(0.0, start)]
+
+        while pq:
+            current_dist, node = heapq.heappop(pq)
+            if current_dist > distances[node]:
+                continue
+
+            # 遍历邻居节点，尝试更新距离
+            for neighbor, weight in graph.get(node, []):
+                new_dist = current_dist + weight
+                if new_dist < distances.get(neighbor, float("inf")):
+                    distances[neighbor] = new_dist
+                    heapq.heappush(pq, (new_dist, neighbor))
+
+        return distances

--- a/algorithms/tests/test_dijkstra.py
+++ b/algorithms/tests/test_dijkstra.py
@@ -1,0 +1,35 @@
+"""Tests for the Dijkstra shortest path algorithm."""
+from typing import Dict, List, Tuple
+import math
+
+from algorithms.graph.advanced.dijkstra import Dijkstra
+
+
+def _build_graph() -> Dict[str, List[Tuple[str, float]]]:
+    """Create a sample weighted undirected graph for testing."""
+    return {
+        "A": [("B", 1), ("C", 4)],
+        "B": [("A", 1), ("C", 2), ("D", 5)],
+        "C": [("A", 4), ("B", 2)],
+        "D": [("B", 5)],
+        "E": [],  # unreachable node
+    }
+
+
+def test_dijkstra_shortest_paths() -> None:
+    graph = _build_graph()
+    algo = Dijkstra()
+    distances = algo.execute(graph, "A")
+
+    assert distances["A"] == 0
+    assert distances["B"] == 1
+    assert distances["C"] == 3  # via A -> B -> C
+    assert distances["D"] == 6  # via A -> B -> D
+
+
+def test_dijkstra_unreachable_node() -> None:
+    graph = _build_graph()
+    algo = Dijkstra()
+    distances = algo.execute(graph, "A")
+
+    assert math.isinf(distances["E"])


### PR DESCRIPTION
## Summary
- implement priority-queue based Dijkstra for weighted undirected graphs
- cover shortest paths and unreachable nodes with dedicated tests

## Testing
- `PYTHONPATH=. pytest algorithms/tests/test_dijkstra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c533d5adb0832fb7c221103d10fd00