### PR TITLE
Add selection sort algorithm and tests

### DIFF
--- a/algorithms/sorting/basic/selection_sort.py
+++ b/algorithms/sorting/basic/selection_sort.py
@@ -1,0 +1,39 @@
+"""选择排序算法实现。"""
+from ...utils import swap
+from ...base import Algorithm
+from typing import List, Any
+
+
+class SelectionSort(Algorithm):
+    """使用选择排序算法对列表进行排序。
+
+    选择排序通过在未排序部分中寻找最小元素，
+    将其交换到当前排序位置，逐步构建有序序列。
+    """
+
+    def execute(self, data: List[Any]) -> List[Any]:
+        """返回数据的排序副本。
+
+        参数:
+            data: 待排序的数据列表
+
+        返回:
+            List[Any]: 排序后的数据副本
+
+        时间复杂度: O(n^2) - 需要进行 n*(n-1)/2 次比较
+        空间复杂度: O(1) - 只需要常数额外空间
+        """
+        arr = data.copy()  # 创建数据副本，避免修改原数组
+        n = len(arr)
+
+        for i in range(n):
+            # 假设当前索引 i 处的元素为最小值
+            min_index = i
+            # 在未排序部分中寻找更小的元素
+            for j in range(i + 1, n):
+                if arr[j] < arr[min_index]:
+                    min_index = j
+            # 将找到的最小元素交换到当前位置
+            if min_index != i:
+                swap(arr, i, min_index)
+        return arr

--- a/algorithms/tests/test_selection_sort.py
+++ b/algorithms/tests/test_selection_sort.py
@@ -1,0 +1,22 @@
+from algorithms.sorting.basic.selection_sort import SelectionSort
+
+
+def test_selection_sort_sorted():
+    data = [1, 2, 3, 4, 5]
+    original = list(data)
+    assert SelectionSort().execute(data) == [1, 2, 3, 4, 5]
+    assert data == original
+
+
+def test_selection_sort_reverse():
+    data = [5, 4, 3, 2, 1]
+    original = list(data)
+    assert SelectionSort().execute(data) == [1, 2, 3, 4, 5]
+    assert data == original
+
+
+def test_selection_sort_duplicates():
+    data = [3, 1, 2, 3, 1]
+    original = list(data)
+    assert SelectionSort().execute(data) == [1, 1, 2, 3, 3]
+    assert data == original

--- a/algorithms/tests/test_sorting.py
+++ b/algorithms/tests/test_sorting.py
@@ -2,10 +2,11 @@ import pytest
 
 from algorithms.sorting.basic.bubble_sort import BubbleSort
 from algorithms.sorting.basic.quick_sort import QuickSort
+from algorithms.sorting.basic.selection_sort import SelectionSort
 from algorithms.sorting.advanced.merge_sort import MergeSort
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), SelectionSort(), MergeSort()])
 def test_sorting_basic(algorithm):
     data = [5, 1, 4, 2, 8]
     original = list(data)
@@ -13,13 +14,13 @@ def test_sorting_basic(algorithm):
     assert data == original
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), SelectionSort(), MergeSort()])
 def test_sorting_empty_and_single(algorithm):
     assert algorithm.execute([]) == []
     assert algorithm.execute([1]) == [1]
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), SelectionSort(), MergeSort()])
 def test_sorting_type_error(algorithm):
     with pytest.raises(TypeError):
         algorithm.execute([1, "a"])


### PR DESCRIPTION
## Summary
- add selection sort implementation to basic sorting algorithms
- cover selection sort with dedicated tests for sorted, reversed, and duplicate lists
- include selection sort in existing generic sorting test suite

## Testing
- `PYTHONPATH=$PWD pytest algorithms/tests/test_selection_sort.py algorithms/tests/test_sorting.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', 'sklearn', etc.; 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c533da0818832f9b942f8e51961bce