### PR TITLE
Add heap sort algorithm with comprehensive tests

### DIFF
--- a/algorithms/sorting/advanced/heap_sort.py
+++ b/algorithms/sorting/advanced/heap_sort.py
@@ -1,0 +1,54 @@
+"""堆排序算法实现。"""
+from ...base import Algorithm
+from typing import List, Any
+
+
+class HeapSort(Algorithm):
+    """使用堆排序算法对列表进行排序。
+
+    堆排序通过构建最大堆，将最大元素逐个移到数组末尾，从而实现排序。
+    设置 ``reverse=True`` 可返回降序结果。
+    """
+
+    def __init__(self, reverse: bool = False) -> None:
+        self.reverse = reverse
+
+    def execute(self, data: List[Any]) -> List[Any]:
+        """返回数据的排序副本。
+
+        参数:
+            data: 待排序的数据列表
+
+        返回:
+            List[Any]: 排序后的数据副本
+
+        时间复杂度: O(n log n)
+        空间复杂度: O(1)
+        """
+        arr = data.copy()  # 创建数据副本，避免修改原数组
+        n = len(arr)
+        # 建堆
+        for i in range(n // 2 - 1, -1, -1):
+            self._heapify(arr, n, i)
+        # 逐个将堆顶元素移到末尾
+        for i in range(n - 1, 0, -1):
+            arr[i], arr[0] = arr[0], arr[i]
+            self._heapify(arr, i, 0)
+        if self.reverse:
+            arr.reverse()
+        return arr
+
+    def _heapify(self, arr: List[Any], n: int, i: int) -> None:
+        """维护以 ``i`` 为根的最大堆性质。"""
+        largest = i
+        left = 2 * i + 1
+        right = 2 * i + 2
+
+        if left < n and arr[left] > arr[largest]:
+            largest = left
+        if right < n and arr[right] > arr[largest]:
+            largest = right
+
+        if largest != i:
+            arr[i], arr[largest] = arr[largest], arr[i]
+            self._heapify(arr, n, largest)

--- a/algorithms/tests/test_heap_sort.py
+++ b/algorithms/tests/test_heap_sort.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from algorithms.sorting.advanced.heap_sort import HeapSort
+
+
+def test_heap_sort_basic():
+    data = [5, 1, 4, 2, 8]
+    original = list(data)
+    assert HeapSort().execute(data) == sorted(data)
+    assert data == original
+
+
+def test_heap_sort_descending():
+    data = [5, 1, 4, 2, 8]
+    assert HeapSort(reverse=True).execute(data) == sorted(data, reverse=True)
+
+
+def test_heap_sort_empty_and_single():
+    sorter = HeapSort()
+    assert sorter.execute([]) == []
+    assert sorter.execute([1]) == [1]

--- a/algorithms/tests/test_sorting.py
+++ b/algorithms/tests/test_sorting.py
@@ -1,11 +1,16 @@
+import os
+import sys
 import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from algorithms.sorting.basic.bubble_sort import BubbleSort
 from algorithms.sorting.basic.quick_sort import QuickSort
 from algorithms.sorting.advanced.merge_sort import MergeSort
+from algorithms.sorting.advanced.heap_sort import HeapSort
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort(), HeapSort()])
 def test_sorting_basic(algorithm):
     data = [5, 1, 4, 2, 8]
     original = list(data)
@@ -13,13 +18,13 @@ def test_sorting_basic(algorithm):
     assert data == original
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort(), HeapSort()])
 def test_sorting_empty_and_single(algorithm):
     assert algorithm.execute([]) == []
     assert algorithm.execute([1]) == [1]
 
 
-@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort()])
+@pytest.mark.parametrize("algorithm", [BubbleSort(), QuickSort(), MergeSort(), HeapSort()])
 def test_sorting_type_error(algorithm):
     with pytest.raises(TypeError):
         algorithm.execute([1, "a"])


### PR DESCRIPTION
## Summary
- implement HeapSort algorithm with optional descending order
- include heap sort in common sorting tests
- add dedicated heap sort tests for ascending, descending, and edge cases

## Testing
- `pytest algorithms/tests/test_sorting.py algorithms/tests/test_heap_sort.py`

------
https://chatgpt.com/codex/tasks/task_e_68c533d338a0832f8acabd9309e4e071