### PR TITLE
Add Kruskal-based minimum spanning tree algorithm

### DIFF
--- a/algorithms/graph/advanced/mst.py
+++ b/algorithms/graph/advanced/mst.py
@@ -1,0 +1,77 @@
+"""Minimum Spanning Tree algorithm using Kruskal's method."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ...base import Algorithm
+
+
+class KruskalMST(Algorithm):
+    """基于 Kruskal 算法的最小生成树实现。
+
+    该算法接受一个无向图的邻接表表示，返回生成树的边集合及总权重。
+    如果图不连通，则抛出 ``ValueError``。
+    """
+
+    def execute(
+        self, graph: Dict[Any, List[Tuple[Any, float]]]
+    ) -> Tuple[List[Tuple[Any, Any, float]], float]:
+        """计算图的最小生成树。
+
+        参数:
+            graph: 图的邻接表，键为节点，值为邻接节点与权重的列表。
+
+        返回:
+            Tuple[List[Tuple[Any, Any, float]], float]:
+                - 生成树的边集合，每条边表示为 ``(u, v, weight)``。
+                - 生成树的总权重。
+
+        异常:
+            ValueError: 如果图不是连通的。
+        """
+        # 收集所有边，避免重复 (u,v) 与 (v,u)
+        seen = set()
+        edges: List[Tuple[Any, Any, float]] = []
+        for u, neighbors in graph.items():
+            for v, weight in neighbors:
+                edge = (u, v) if (u, v) not in seen and (v, u) not in seen else None
+                if edge:
+                    seen.add(edge)
+                    edges.append((u, v, weight))
+
+        # 按权重排序
+        edges.sort(key=lambda e: e[2])
+
+        parent = {node: node for node in graph}
+        rank = {node: 0 for node in graph}
+
+        def find(x: Any) -> Any:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        def union(x: Any, y: Any) -> bool:
+            rx, ry = find(x), find(y)
+            if rx == ry:
+                return False
+            if rank[rx] < rank[ry]:
+                parent[rx] = ry
+            elif rank[rx] > rank[ry]:
+                parent[ry] = rx
+            else:
+                parent[ry] = rx
+                rank[rx] += 1
+            return True
+
+        mst_edges: List[Tuple[Any, Any, float]] = []
+        total_weight = 0.0
+        for u, v, w in edges:
+            if union(u, v):
+                mst_edges.append((u, v, w))
+                total_weight += w
+
+        if len(mst_edges) != len(graph) - 1:
+            raise ValueError("Graph is not connected")
+
+        return mst_edges, total_weight

--- a/algorithms/tests/test_mst.py
+++ b/algorithms/tests/test_mst.py
@@ -1,0 +1,67 @@
+"""Tests for the Kruskal Minimum Spanning Tree algorithm."""
+from typing import Dict, List, Tuple
+
+import pytest
+
+from algorithms.graph.advanced.mst import KruskalMST
+
+
+def _build_connected_graph() -> Dict[str, List[Tuple[str, float]]]:
+    return {
+        "A": [("B", 1), ("C", 5)],
+        "B": [("A", 1), ("C", 4), ("D", 2)],
+        "C": [("A", 5), ("B", 4), ("D", 1)],
+        "D": [("B", 2), ("C", 1)],
+    }
+
+
+def _build_negative_graph() -> Dict[str, List[Tuple[str, float]]]:
+    return {
+        "A": [("B", -1), ("C", 4)],
+        "B": [("A", -1), ("C", 2), ("D", 3)],
+        "C": [("A", 4), ("B", 2), ("D", -2)],
+        "D": [("B", 3), ("C", -2)],
+    }
+
+
+def _build_disconnected_graph() -> Dict[str, List[Tuple[str, float]]]:
+    return {
+        "A": [("B", 1)],
+        "B": [("A", 1)],
+        "C": [],
+    }
+
+
+def test_kruskal_mst_connected_graph() -> None:
+    graph = _build_connected_graph()
+    algo = KruskalMST()
+    edges, total = algo.execute(graph)
+
+    expected_edges = {
+        frozenset({"A", "B"}),
+        frozenset({"C", "D"}),
+        frozenset({"B", "D"}),
+    }
+    assert {frozenset({u, v}) for u, v, _ in edges} == expected_edges
+    assert total == 4
+
+
+def test_kruskal_mst_negative_weights() -> None:
+    graph = _build_negative_graph()
+    algo = KruskalMST()
+    edges, total = algo.execute(graph)
+
+    expected_edges = {
+        frozenset({"C", "D"}),
+        frozenset({"A", "B"}),
+        frozenset({"B", "C"}),
+    }
+    assert {frozenset({u, v}) for u, v, _ in edges} == expected_edges
+    assert total == -1
+
+
+def test_kruskal_mst_disconnected_graph() -> None:
+    graph = _build_disconnected_graph()
+    algo = KruskalMST()
+    with pytest.raises(ValueError):
+        algo.execute(graph)


### PR DESCRIPTION
## Summary
- implement Kruskal minimum spanning tree algorithm returning edges and total weight
- add tests for connected graph, negative weights, and disconnected graphs

## Testing
- `PYTHONPATH=. pytest algorithms/tests/test_mst.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5357e28ac832fb122be6a4b05e7b0