### PR TITLE
feat: add multimodal attention and clip extractor

### DIFF
--- a/backend/ml/feature_extractor.py
+++ b/backend/ml/feature_extractor.py
@@ -1,10 +1,17 @@
 """Utilities for converting raw log lines into numerical feature vectors."""
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Iterable, List, Optional, Tuple
 
 from sklearn.feature_extraction.text import TfidfVectorizer
 import joblib
+import torch
+from PIL import Image
+
+try:
+    import open_clip
+except Exception:  # pragma: no cover - dependency may be missing at runtime
+    open_clip = None
 
 
 class FeatureExtractor:
@@ -35,3 +42,39 @@ class FeatureExtractor:
         instance = cls()
         instance.vectorizer = joblib.load(path)
         return instance
+
+
+class CLIPFeatureExtractor:
+    """Wrapper around a pretrained CLIP model for multimodal features."""
+
+    def __init__(
+        self,
+        model_name: str = "ViT-B-32",
+        pretrained: str = "laion2b_s34b_b79k",
+        device: Optional[str] = None,
+    ) -> None:
+        if open_clip is None:
+            raise ImportError("open_clip package is required for CLIPFeatureExtractor")
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model, _, self.preprocess = open_clip.create_model_and_transforms(
+            model_name, pretrained=pretrained
+        )
+        self.tokenizer = open_clip.get_tokenizer(model_name)
+        self.model.to(self.device).eval()
+
+    def extract_image_features(self, image: Image.Image) -> torch.Tensor:
+        image = self.preprocess(image).unsqueeze(0).to(self.device)
+        with torch.no_grad():
+            feats = self.model.encode_image(image)
+        return feats.squeeze(0)
+
+    def extract_text_features(self, text: str) -> torch.Tensor:
+        tokens = self.tokenizer([text]).to(self.device)
+        with torch.no_grad():
+            feats = self.model.encode_text(tokens)
+        return feats.squeeze(0)
+
+    def extract(self, image: Image.Image, text: str) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return both image and text feature vectors for ``image`` and ``text``."""
+
+        return self.extract_image_features(image), self.extract_text_features(text)

--- a/backend/world_model/vision.py
+++ b/backend/world_model/vision.py
@@ -12,6 +12,37 @@ retrieve them later.
 
 from typing import Any, Dict, Optional
 
+import torch
+from torch import nn
+
+
+class CrossModalAttention(nn.Module):
+    """Simple cross-modal attention module.
+
+    The module attends between visual and textual features and produces a
+    unified representation by averaging bidirectional attention outputs.
+    """
+
+    def __init__(self, embed_dim: int, num_heads: int = 8) -> None:
+        if embed_dim % num_heads != 0:
+            num_heads = 1
+        super().__init__()
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+
+    def forward(self, vision_feat: torch.Tensor, text_feat: torch.Tensor) -> torch.Tensor:
+        if vision_feat.dim() == 1:
+            vision_feat = vision_feat.unsqueeze(0).unsqueeze(0)
+        elif vision_feat.dim() == 2:
+            vision_feat = vision_feat.unsqueeze(0)
+        if text_feat.dim() == 1:
+            text_feat = text_feat.unsqueeze(0).unsqueeze(0)
+        elif text_feat.dim() == 2:
+            text_feat = text_feat.unsqueeze(0)
+        text_attended, _ = self.attn(text_feat, vision_feat, vision_feat)
+        vision_attended, _ = self.attn(vision_feat, text_feat, text_feat)
+        unified = (text_attended.mean(dim=1) + vision_attended.mean(dim=1)) / 2
+        return unified.squeeze(0)
+
 
 class VisionStore:
     """In-memory storage for visual observations."""
@@ -20,6 +51,9 @@ class VisionStore:
         self._images: Dict[str, Any] = {}
         self._features: Dict[str, Any] = {}
         self._vit_features: Dict[str, Any] = {}
+        self._text: Dict[str, Any] = {}
+        self._unified: Dict[str, Any] = {}
+        self._attn: Optional[CrossModalAttention] = None
 
     def ingest(
         self,
@@ -27,8 +61,9 @@ class VisionStore:
         image: Optional[Any] = None,
         features: Optional[Any] = None,
         vit_features: Optional[Any] = None,
-    ) -> None:
-        """Store an observation for ``agent_id``.
+        text: Optional[Any] = None,
+    ) -> Optional[torch.Tensor]:
+        """Store an observation for ``agent_id`` and optionally compute fusion.
 
         Parameters
         ----------
@@ -43,6 +78,8 @@ class VisionStore:
         vit_features:
             Feature representation produced by a Vision Transformer (ViT)
             model.
+        text:
+            Optional textual embedding aligned with the visual input.
         """
 
         if image is not None:
@@ -51,6 +88,20 @@ class VisionStore:
             self._features[agent_id] = features
         if vit_features is not None:
             self._vit_features[agent_id] = vit_features
+        if text is not None:
+            self._text[agent_id] = text
+
+        unified: Optional[torch.Tensor] = None
+        vision_feat = features if features is not None else vit_features
+        if text is not None and vision_feat is not None:
+            vision_tensor = torch.as_tensor(vision_feat)
+            text_tensor = torch.as_tensor(text)
+            if self._attn is None:
+                self._attn = CrossModalAttention(vision_tensor.shape[-1])
+            unified = self._attn(vision_tensor, text_tensor)
+            self._unified[agent_id] = unified
+
+        return unified
 
     def get(self, agent_id: str) -> Dict[str, Any]:
         """Return the latest observation for ``agent_id``."""
@@ -59,20 +110,30 @@ class VisionStore:
             "image": self._images.get(agent_id),
             "features": self._features.get(agent_id),
             "vit_features": self._vit_features.get(agent_id),
+            "text": self._text.get(agent_id),
+            "unified": self._unified.get(agent_id),
         }
 
     def all(self) -> Dict[str, Dict[str, Any]]:
         """Return a snapshot of all stored observations."""
 
-        keys = set(self._images) | set(self._features) | set(self._vit_features)
+        keys = (
+            set(self._images)
+            | set(self._features)
+            | set(self._vit_features)
+            | set(self._text)
+            | set(self._unified)
+        )
         return {
             agent: {
                 "image": self._images.get(agent),
                 "features": self._features.get(agent),
                 "vit_features": self._vit_features.get(agent),
+                "text": self._text.get(agent),
+                "unified": self._unified.get(agent),
             }
             for agent in keys
         }
 
 
-__all__ = ["VisionStore"]
+__all__ = ["VisionStore", "CrossModalAttention"]


### PR DESCRIPTION
## Summary
- add CrossModalAttention to blend vision and language features into unified embedding
- expose CLIPFeatureExtractor wrapper for multimodal feature extraction
- store unified representations in world model for downstream inference

## Testing
- `pytest backend/world_model/tests/test_vision_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68c539a198c0832f86c68e413eaf33ab