### PR TITLE
feat: enhance knowledge graph with reasoning and distillation

### DIFF
--- a/backend/autogpt/autogpt/core/knowledge_graph/__init__.py
+++ b/backend/autogpt/autogpt/core/knowledge_graph/__init__.py
@@ -2,6 +2,7 @@
 
 from .ontology import EntityType, RelationType
 from .graph_store import GraphStore, get_graph_store, query_graph
+from .reasoner import infer_potential_relations
 
 __all__ = [
     "EntityType",
@@ -9,4 +10,5 @@ __all__ = [
     "GraphStore",
     "get_graph_store",
     "query_graph",
+    "infer_potential_relations",
 ]

--- a/backend/autogpt/autogpt/core/knowledge_graph/reasoner.py
+++ b/backend/autogpt/autogpt/core/knowledge_graph/reasoner.py
@@ -1,0 +1,34 @@
+"""Simple commonsense reasoning utilities for the knowledge graph."""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from .graph_store import GraphStore, get_graph_store
+from .ontology import RelationType
+
+
+def infer_potential_relations(
+    graph: GraphStore | None = None,
+) -> List[Tuple[str, str, str]]:
+    """Infer potential relations via two-hop paths.
+
+    For each path A -> B -> C where no direct edge A -> C exists, suggest a
+    potential relation between A and C. The returned tuples contain the source,
+    target and the relation sequence discovered.
+    """
+
+    graph = graph or get_graph_store()
+    data = graph.query()
+    edges = data["edges"]
+    adjacency: Dict[str, List[Tuple[str, RelationType]]] = {}
+    for edge in edges:
+        adjacency.setdefault(edge.source, []).append((edge.target, edge.type))
+
+    suggestions: List[Tuple[str, str, str]] = []
+    for a, neighbors in adjacency.items():
+        for mid, rel1 in neighbors:
+            for c, rel2 in adjacency.get(mid, []):
+                if any(e.source == a and e.target == c for e in edges):
+                    continue
+                suggestions.append((a, c, f"{rel1.value}->{rel2.value}"))
+    return suggestions

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,71 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend.autogpt.autogpt.core.knowledge_graph.graph_store import GraphStore
+from backend.autogpt.autogpt.core.knowledge_graph.ontology import (
+    EntityType,
+    RelationType,
+)
+from backend.autogpt.autogpt.core.knowledge_graph.reasoner import (
+    infer_potential_relations,
+)
+from modules.common import ConceptNode
+
+import types
+
+capability_module = types.ModuleType("capability")
+librarian_module = types.ModuleType("capability.librarian")
+
+
+class Librarian:
+    def search(self, *args, **kwargs):
+        return []
+
+
+librarian_module.Librarian = Librarian
+capability_module.librarian = librarian_module
+sys.modules["capability"] = capability_module
+sys.modules["capability.librarian"] = librarian_module
+
+from backend.concept_alignment import ConceptAligner  # noqa: E402
+
+
+def test_dynamic_graph_and_version():
+    store = GraphStore()
+    store.add_node("a", EntityType.SKILL)
+    store.add_node("b", EntityType.TASK)
+    store.add_edge("a", "b", RelationType.RELATED_TO)
+    version = store.get_version()
+    snapshot = store.get_snapshot()
+    assert len(snapshot["nodes"]) == 2
+    assert version > 0
+    store.remove_node("b")
+    assert len(store.query()["nodes"]) == 1
+    assert store.get_version() == version + 1
+
+
+def test_infer_potential_relations():
+    store = GraphStore()
+    store.add_node("a", EntityType.SKILL)
+    store.add_node("b", EntityType.TASK)
+    store.add_node("c", EntityType.SKILL)
+    store.add_edge("a", "b", RelationType.RELATED_TO)
+    store.add_edge("b", "c", RelationType.RELATED_TO)
+    suggestions = infer_potential_relations(store)
+    assert ("a", "c", "related_to->related_to") in suggestions
+
+
+def test_concept_alignment_distill_and_transfer():
+    entities = {
+        "x": ConceptNode(id="x", label="X", modalities={"text": [1.0, 0.0]})
+    }
+    aligner = ConceptAligner(Librarian(), entities)
+    external = {
+        "y": ConceptNode(id="y", label="Y", modalities={"text": [1.0, 0.0]})
+    }
+    aligner.distill_from_graph(external)
+    assert "y" in aligner.entities
+    nodes = [ConceptNode(id="z", label="Z", modalities={"text": [1.0, 0.0]})]
+    enriched = aligner.transfer_knowledge(nodes)
+    assert enriched[0].metadata.get("related_concepts") is not None


### PR DESCRIPTION
## Summary
- support node/edge removal, versioning, and snapshots in graph store
- add knowledge distillation & transfer utilities in concept alignment
- introduce reasoning helper to infer potential relations from the graph

## Testing
- `ruff check backend/autogpt/autogpt/core/knowledge_graph/graph_store.py backend/concept_alignment.py backend/autogpt/autogpt/core/knowledge_graph/reasoner.py backend/autogpt/autogpt/core/knowledge_graph/__init__.py tests/test_knowledge_graph.py`
- `pytest tests/test_knowledge_graph.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'algorithms', 'sklearn', 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c53b024c8c832fa35a4de57b26cf74