### PR TITLE
Add symbolic reasoning with causal and counterfactual hooks

### DIFF
--- a/backend/reasoning/__init__.py
+++ b/backend/reasoning/__init__.py
@@ -3,8 +3,15 @@
 from .multi_hop import MultiHopAssociator
 from .planner import ReasoningPlanner
 from .solvers import NeuroSymbolicSolver, RuleProbabilisticSolver
-from .interfaces import KnowledgeSource, Solver
+from .interfaces import (
+    KnowledgeSource,
+    Solver,
+    CausalReasoner,
+    CounterfactualReasoner,
+)
 from .decision_engine import ActionPlan, DecisionEngine
+from .symbolic import SymbolicReasoner
+from .causal import KnowledgeGraphCausalReasoner, CounterfactualGraphReasoner
 
 __all__ = [
     "MultiHopAssociator",
@@ -13,6 +20,11 @@ __all__ = [
     "NeuroSymbolicSolver",
     "KnowledgeSource",
     "Solver",
+    "CausalReasoner",
+    "CounterfactualReasoner",
     "ActionPlan",
     "DecisionEngine",
+    "SymbolicReasoner",
+    "KnowledgeGraphCausalReasoner",
+    "CounterfactualGraphReasoner",
 ]

--- a/backend/reasoning/causal.py
+++ b/backend/reasoning/causal.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Causal and counterfactual reasoning helpers."""
+
+from typing import Iterable, Tuple
+
+from .multi_hop import MultiHopAssociator
+from .interfaces import CausalReasoner, CounterfactualReasoner
+
+
+class KnowledgeGraphCausalReasoner(CausalReasoner):
+    """Check causal relationships using a knowledge graph."""
+
+    def __init__(self, graph: dict[str, Iterable[str]]):
+        self.associator = MultiHopAssociator(graph)
+
+    def check_causality(self, cause: str, effect: str) -> Tuple[bool, Iterable[str]]:
+        path = self.associator.find_path(cause, effect)
+        return bool(path), path
+
+
+class CounterfactualGraphReasoner(CounterfactualReasoner):
+    """Simple counterfactual reasoning based on causal paths."""
+
+    def __init__(self, causal_reasoner: KnowledgeGraphCausalReasoner):
+        self.causal_reasoner = causal_reasoner
+
+    def evaluate_counterfactual(self, cause: str, effect: str) -> str:
+        exists, path = self.causal_reasoner.check_causality(cause, effect)
+        if not exists:
+            return f"{cause} has no causal effect on {effect}."
+        chain = " -> ".join(path)
+        return f"Without {cause}, {effect} would not occur via {chain}."
+

--- a/backend/reasoning/interfaces.py
+++ b/backend/reasoning/interfaces.py
@@ -17,3 +17,17 @@ class Solver(Protocol):
 
     def infer(self, statement: str, evidence: Iterable[str]) -> Tuple[str, float]:
         """Return a conclusion and its associated probability/confidence."""
+
+
+class CausalReasoner(Protocol):
+    """Infer causal relationships between events or concepts."""
+
+    def check_causality(self, cause: str, effect: str) -> Tuple[bool, Iterable[str]]:
+        """Return whether ``cause`` leads to ``effect`` and the supporting path."""
+
+
+class CounterfactualReasoner(Protocol):
+    """Evaluate the outcome of alternative scenarios."""
+
+    def evaluate_counterfactual(self, cause: str, effect: str) -> str:
+        """Return an explanation of ``effect`` if ``cause`` were different."""

--- a/backend/reasoning/symbolic.py
+++ b/backend/reasoning/symbolic.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Symbolic reasoning with chain-of-thought generation."""
+
+from typing import Iterable, List, Tuple
+
+from .decision_engine import ActionPlan, DecisionEngine
+from .multi_hop import MultiHopAssociator
+from .causal import KnowledgeGraphCausalReasoner, CounterfactualGraphReasoner
+
+
+class SymbolicReasoner:
+    """Perform symbolic reasoning over a knowledge graph."""
+
+    def __init__(
+        self,
+        graph: dict[str, Iterable[str]],
+        decision_engine: DecisionEngine | None = None,
+    ):
+        self.graph = graph
+        self.associator = MultiHopAssociator(graph)
+        self.decision_engine = decision_engine or DecisionEngine()
+        self.causal = KnowledgeGraphCausalReasoner(graph)
+        self.counterfactual = CounterfactualGraphReasoner(self.causal)
+
+    def chain_of_thought(self, start: str, goal: str) -> List[str]:
+        """Generate intermediate reasoning steps from ``start`` to ``goal``."""
+
+        path = self.associator.find_path(start, goal)
+        return [f"{path[i]} -> {path[i + 1]}" for i in range(len(path) - 1)]
+
+    def reason(self, start: str, goal: str) -> Tuple[str, List[str]]:
+        """Return the conclusion and chain-of-thought."""
+
+        steps = self.chain_of_thought(start, goal)
+        conclusion = goal if steps else start
+        if steps:
+            plans = [ActionPlan(action=s, utility=1.0, cost=0.0, rationale=s) for s in steps]
+            # Decision engine evaluates the steps; we ignore the choice but keep integration
+            self.decision_engine.select_optimal_action(plans)
+        return conclusion, steps
+
+    def explain_causality(self, cause: str, effect: str) -> Tuple[bool, Iterable[str]]:
+        """Expose causal links between ``cause`` and ``effect``."""
+
+        return self.causal.check_causality(cause, effect)
+
+    def evaluate_counterfactual(self, cause: str, effect: str) -> str:
+        """Provide a counterfactual explanation for ``effect`` if ``cause`` changes."""
+
+        return self.counterfactual.evaluate_counterfactual(cause, effect)
+


### PR DESCRIPTION
## Summary
- add symbolic reasoner built on decision engine and multi-hop search
- introduce causal and counterfactual reasoning helpers using knowledge graphs
- expose new reasoning interfaces and exports

## Testing
- `pytest tests/test_reasoning_planner.py tests/test_neuro_symbolic_solver.py tests/test_knowledge_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53da672e8832f99b8cbd46f7936df