### PR TITLE
Add configurable NN architectures and trainer selection

### DIFF
--- a/backend/ml/__init__.py
+++ b/backend/ml/__init__.py
@@ -8,6 +8,7 @@ from typing import Dict
 from .backends import get_backend
 from .hf_models import load_bert, load_gpt, load_vit
 from .models import (
+    MLP,
     SequenceRNN,
     TransformerTextModel,
     VisionCNN,
@@ -38,6 +39,7 @@ class TrainingConfig:
     use_orthogonal: bool = False
     train_after_samples: int = 100
     checkpoint_dir: Path = Path("data") / "checkpoints"
+    model_type: str = "mlp"
     task_model_types: Dict[str, str] | None = None
 
 
@@ -51,6 +53,7 @@ __all__ = [
     "load_gpt",
     "load_bert",
     "load_vit",
+    "MLP",
     "TransformerTextModel",
     "VisionCNN",
     "SequenceRNN",

--- a/backend/ml/multitask_trainer.py
+++ b/backend/ml/multitask_trainer.py
@@ -14,7 +14,7 @@ try:  # Optional dependency for graph parsing
 except Exception:  # pragma: no cover - dependency may be missing at runtime
     nx = None  # type: ignore
 
-from . import DEFAULT_TRAINING_CONFIG, TrainingConfig
+from . import DEFAULT_TRAINING_CONFIG, TrainingConfig, get_model
 from .feature_extractor import (
     FeatureExtractor,
     GraphFeatureExtractor,
@@ -118,7 +118,12 @@ class MultiTaskTrainer:
             )
             y_test_t = torch.tensor(y_test, dtype=torch.float32).unsqueeze(1)
 
-            model = nn.Linear(X_train_t.shape[1], 1)
+            model_type = (
+                self.config.task_model_types.get(name)
+                if self.config.task_model_types
+                else self.config.model_type
+            )
+            model = get_model(model_type, input_dim=X_train_t.shape[1], output_dim=1)
             optimizer = optim.Adam(model.parameters(), lr=self.config.initial_lr)
             criterion = nn.MSELoss()
 

--- a/tests/test_nn_architectures.py
+++ b/tests/test_nn_architectures.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from backend.ml.models import get_model, MLP, VisionCNN, SequenceRNN
+
+
+def _train_step(model, x, y):
+    criterion = torch.nn.MSELoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    model.train()
+    before = [p.clone() for p in model.parameters()]
+    pred = model(x)
+    loss = criterion(pred, y)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+    changed = any(not torch.equal(b, a) for b, a in zip(before, model.parameters()))
+    with torch.no_grad():
+        final_loss = criterion(model(x), y).item()
+    return changed, final_loss
+
+
+def test_mlp_forward_and_train():
+    torch.manual_seed(0)
+    model = get_model("mlp", input_dim=4, hidden_dims=[8], output_dim=1)
+    x = torch.randn(2, 4)
+    y = torch.randn(2, 1)
+    out = model(x)
+    assert out.shape == (2, 1)
+    changed, _ = _train_step(model, x, y)
+    assert changed
+
+
+def test_cnn_forward_and_train():
+    torch.manual_seed(0)
+    model = get_model("cnn", num_classes=5)
+    x = torch.randn(2, 3, 32, 32)
+    y = torch.randn(2, 5)
+    out = model(x)
+    assert out.shape == (2, 5)
+    changed, _ = _train_step(model, x, y)
+    assert changed
+
+
+def test_rnn_forward_and_train():
+    torch.manual_seed(0)
+    model = get_model("rnn", input_size=6, hidden_size=4)
+    x = torch.randn(2, 3, 6)
+    y = torch.randn(2, 4)
+    out = model(x)
+    assert out.shape == (2, 4)
+    changed, _ = _train_step(model, x, y)
+    assert changed


### PR DESCRIPTION
## Summary
- introduce configurable MLP, CNN, and RNN models with factory helper
- allow TrainingConfig and trainers to instantiate architecture by type
- add unit tests exercising each architecture and config-driven selection

## Testing
- `pytest tests/test_nn_architectures.py tests/test_ml_training_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5440dfb68832f96473046480c76bc