### PR TITLE
Add second-order gradient option to MAML

### DIFF
--- a/backend/ml/meta_learning/maml.py
+++ b/backend/ml/meta_learning/maml.py
@@ -37,7 +37,22 @@ def load_task(path: str | Path, test_size: float = 0.5, random_state: int = 42) 
 
 
 class MAML:
-    """Minimal implementation of Model-Agnostic Meta-Learning."""
+    """Minimal implementation of Model-Agnostic Meta-Learning.
+
+    Parameters
+    ----------
+    input_dim:
+        Dimensionality of the linear model.
+    inner_lr:
+        Learning rate used for task-specific adaptation.
+    meta_lr:
+        Learning rate used for the meta-update.
+    adapt_steps:
+        Number of gradient steps taken during adaptation.
+    second_order:
+        If ``True``, compute second-order gradients for the meta-update.
+        When ``False``, the algorithm reduces to first-order MAML.
+    """
 
     def __init__(
         self,
@@ -45,40 +60,80 @@ class MAML:
         inner_lr: float = 0.01,
         meta_lr: float = 0.001,
         adapt_steps: int = 1,
+        second_order: bool = False,
     ) -> None:
         self.weights = np.zeros(input_dim)
         self.inner_lr = inner_lr
         self.meta_lr = meta_lr
         self.adapt_steps = adapt_steps
+        self.second_order = second_order
 
     def _loss_and_grad(
-        self, w: np.ndarray, X: np.ndarray, y: np.ndarray
-    ) -> tuple[float, np.ndarray]:
+        self,
+        w: np.ndarray,
+        X: np.ndarray,
+        y: np.ndarray,
+        compute_hessian: bool = False,
+    ) -> tuple[float, np.ndarray] | tuple[float, np.ndarray, np.ndarray]:
         preds = X @ w
         diff = preds - y
         loss = float(np.mean(diff ** 2))
         grad = 2 * X.T @ diff / len(X)
+        if compute_hessian:
+            hess = 2 * X.T @ X / len(X)
+            return loss, grad, hess
         return loss, grad
 
-    def adapt(self, task: TaskData) -> np.ndarray:
-        """Adapt the model to a single task and return the adapted weights."""
+    def adapt(self, task: TaskData) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        """Adapt the model to ``task``.
+
+        Returns
+        -------
+        np.ndarray | tuple[np.ndarray, np.ndarray]
+            The adapted weights. If ``second_order`` is enabled, also return the
+            Jacobian of the adapted weights with respect to the initial weights.
+        """
+
         w = self.weights.copy()
+        if self.second_order:
+            jac = np.eye(len(self.weights))
+            for _ in range(self.adapt_steps):
+                _, grad, hess = self._loss_and_grad(
+                    w, task.support_x, task.support_y, compute_hessian=True
+                )
+                w -= self.inner_lr * grad
+                jac = jac @ (np.eye(len(self.weights)) - self.inner_lr * hess)
+            return w, jac
+
         for _ in range(self.adapt_steps):
             _, grad = self._loss_and_grad(w, task.support_x, task.support_y)
             w -= self.inner_lr * grad
         return w
 
     def meta_train(self, tasks: List[TaskData], epochs: int = 1) -> List[float]:
-        """Run meta-training across all ``tasks`` for ``epochs`` iterations."""
+        """Run meta-training across all ``tasks`` for ``epochs`` iterations.
+
+        Uses first- or second-order updates depending on ``second_order``.
+        """
         history: List[float] = []
         for _ in range(epochs):
             meta_grad = np.zeros_like(self.weights)
             epoch_loss = 0.0
             for task in tasks:
-                adapted = self.adapt(task)
-                loss, grad = self._loss_and_grad(adapted, task.query_x, task.query_y)
-                epoch_loss += loss
-                meta_grad += grad
+                if self.second_order:
+                    adapted, jac = self.adapt(task)
+                    loss, grad = self._loss_and_grad(
+                        adapted, task.query_x, task.query_y
+                    )
+                    epoch_loss += loss
+                    meta_grad += jac.T @ grad
+                else:
+                    adapted = self.adapt(task)
+                    loss, grad = self._loss_and_grad(
+                        adapted, task.query_x, task.query_y
+                    )
+                    epoch_loss += loss
+                    meta_grad += grad
             self.weights -= self.meta_lr * meta_grad / len(tasks)
             history.append(epoch_loss / len(tasks))
         return history

--- a/tests/test_maml.py
+++ b/tests/test_maml.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.ml.meta_learning.maml import MAML, TaskData
+
+def _toy_task():
+    return TaskData(
+        support_x=np.array([[1.0], [2.0]]),
+        support_y=np.array([2.0, 4.0]),
+        query_x=np.array([[3.0], [4.0]]),
+        query_y=np.array([6.0, 8.0]),
+    )
+
+def test_second_order_matches_manual_computation():
+    task = _toy_task()
+    maml = MAML(input_dim=1, inner_lr=0.1, meta_lr=1.0, adapt_steps=1, second_order=True)
+    initial = maml.weights.copy()
+    maml.meta_train([task], epochs=1)
+    updated = maml.weights.copy()
+
+    Xs, ys = task.support_x, task.support_y
+    Xq, yq = task.query_x, task.query_y
+
+    grad_s = 2 * Xs.T @ (Xs @ initial - ys) / len(Xs)
+    H_s = 2 * Xs.T @ Xs / len(Xs)
+    w_prime = initial - maml.inner_lr * grad_s
+    grad_q = 2 * Xq.T @ (Xq @ w_prime - yq) / len(Xq)
+    expected_grad = (np.eye(1) - maml.inner_lr * H_s) @ grad_q
+    expected = initial - maml.meta_lr * expected_grad
+
+    assert np.allclose(updated, expected)
+
+def test_second_order_differs_from_first_order():
+    task = _toy_task()
+    maml_first = MAML(input_dim=1, inner_lr=0.1, meta_lr=1.0, adapt_steps=1, second_order=False)
+    maml_second = MAML(input_dim=1, inner_lr=0.1, meta_lr=1.0, adapt_steps=1, second_order=True)
+    maml_first.meta_train([task], epochs=1)
+    maml_second.meta_train([task], epochs=1)
+    assert not np.allclose(maml_first.weights, maml_second.weights)


### PR DESCRIPTION
## Summary
- add optional second-order gradient support with Hessian-based Jacobian propagation in MAML
- allow toggling first- vs second-order updates via `second_order` flag
- test second-order path on toy regression task

## Testing
- `pytest tests/test_maml.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c548643a9c832f8d645d60fb14e2b5