### PR TITLE
Add self-supervised learning utilities and autoencoder tests

### DIFF
--- a/backend/ml/self_supervised/__init__.py
+++ b/backend/ml/self_supervised/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Self-supervised learning building blocks."""
+
+from .augmentations import AugmentationPipeline
+from .simclr import SimCLR
+from .moco import MoCo
+from .autoencoder import Autoencoder, reconstruction_loss
+from .vae import VariationalAutoencoder, kl_divergence
+from .mlm import prepare_mlm_inputs
+
+__all__ = [
+    "AugmentationPipeline",
+    "SimCLR",
+    "MoCo",
+    "Autoencoder",
+    "VariationalAutoencoder",
+    "reconstruction_loss",
+    "kl_divergence",
+    "prepare_mlm_inputs",
+]

--- a/backend/ml/self_supervised/augmentations.py
+++ b/backend/ml/self_supervised/augmentations.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Simple augmentation utilities for self-supervised learning."""
+
+from typing import Callable, Iterable
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+
+class AugmentationPipeline:
+    """A callable container for a sequence of augmentations."""
+
+    def __init__(self, augmentations: Iterable[Callable[["torch.Tensor"], "torch.Tensor"]] | None = None) -> None:
+        self.augmentations = list(augmentations or [])
+
+    def __call__(self, x: "torch.Tensor") -> "torch.Tensor":
+        for aug in self.augmentations:
+            x = aug(x)
+        return x
+
+    def add(self, augmentation: Callable[["torch.Tensor"], "torch.Tensor"]) -> None:
+        self.augmentations.append(augmentation)
+
+
+def random_horizontal_flip(p: float = 0.5) -> Callable[["torch.Tensor"], "torch.Tensor"]:
+    """Return an augmentation that randomly flips images horizontally."""
+
+    if torch is None:  # pragma: no cover - runtime dependency check
+        raise ImportError("torch is required for random_horizontal_flip")
+
+    def _augment(x: "torch.Tensor") -> "torch.Tensor":
+        if torch.rand(1) < p:
+            return torch.flip(x, dims=[-1])
+        return x
+
+    return _augment

--- a/backend/ml/self_supervised/autoencoder.py
+++ b/backend/ml/self_supervised/autoencoder.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Basic autoencoder module and reconstruction loss."""
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+
+class Autoencoder(nn.Module):
+    """Simple autoencoder container with separate encoder and decoder."""
+
+    def __init__(self, encoder: nn.Module, decoder: nn.Module) -> None:
+        if torch is None:  # pragma: no cover - runtime dependency check
+            raise ImportError("torch is required for Autoencoder")
+        super().__init__()
+        self.encoder = encoder
+        self.decoder = decoder
+
+    def forward(self, x: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
+        z = self.encoder(x)
+        return self.decoder(z)
+
+
+def reconstruction_loss(
+    original: "torch.Tensor", reconstruction: "torch.Tensor"
+) -> "torch.Tensor":
+    """Mean squared error reconstruction loss."""
+
+    if torch is None:  # pragma: no cover - runtime dependency check
+        raise ImportError("torch is required for reconstruction_loss")
+    loss_fn = nn.MSELoss()
+    return loss_fn(reconstruction, original)

--- a/backend/ml/self_supervised/mlm.py
+++ b/backend/ml/self_supervised/mlm.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Utilities for masked language model (MLM) pretraining."""
+
+from typing import Dict, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from transformers import PreTrainedTokenizerBase
+except Exception:  # pragma: no cover - transformers may be missing
+    PreTrainedTokenizerBase = object  # type: ignore
+
+
+def prepare_mlm_inputs(
+    tokenizer: PreTrainedTokenizerBase,
+    texts: Sequence[str],
+    mask_probability: float = 0.15,
+) -> Dict[str, "torch.Tensor"]:
+    """Tokenize ``texts`` and create MLM training inputs."""
+
+    if torch is None:  # pragma: no cover - runtime dependency check
+        raise ImportError("torch is required for prepare_mlm_inputs")
+
+    encoding = tokenizer(list(texts), return_tensors="pt", padding=True)
+    input_ids = encoding["input_ids"]
+    labels = input_ids.clone()
+    probability_matrix = torch.full(labels.shape, mask_probability)
+    special_tokens_mask = input_ids.eq(getattr(tokenizer, "pad_token_id", -100))
+    mask_indices = torch.bernoulli(probability_matrix).bool() & ~special_tokens_mask
+    input_ids[mask_indices] = getattr(tokenizer, "mask_token_id")
+    labels[~mask_indices] = -100
+    encoding["input_ids"] = input_ids
+    encoding["labels"] = labels
+    return encoding

--- a/backend/ml/self_supervised/moco.py
+++ b/backend/ml/self_supervised/moco.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Minimal Momentum Contrast (MoCo) implementation."""
+
+from typing import Callable
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch import nn
+    import torch.nn.functional as F
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+
+class MoCo(nn.Module):
+    """Simplified MoCo model with a queue and momentum encoder."""
+
+    def __init__(
+        self,
+        encoder_q: nn.Module,
+        encoder_k: nn.Module,
+        projection_head: nn.Module,
+        augmentations: Callable[["torch.Tensor"], "torch.Tensor"] | None = None,
+        queue_size: int = 1024,
+        momentum: float = 0.999,
+        temperature: float = 0.07,
+    ) -> None:
+        if torch is None:  # pragma: no cover - runtime dependency check
+            raise ImportError("torch is required for MoCo")
+        super().__init__()
+        self.encoder_q = encoder_q
+        self.encoder_k = encoder_k
+        self.projector = projection_head
+        self.augment = augmentations or (lambda x: x)
+        self.queue_size = queue_size
+        self.momentum = momentum
+        self.temperature = temperature
+
+        self.register_buffer("queue", torch.randn(projection_head.out_features, queue_size))
+        self.queue = F.normalize(self.queue, dim=0)
+        self.register_buffer("queue_ptr", torch.zeros(1, dtype=torch.long))
+
+    @torch.no_grad()
+    def _momentum_update_key_encoder(self) -> None:
+        for param_q, param_k in zip(self.encoder_q.parameters(), self.encoder_k.parameters()):
+            param_k.data = param_k.data * self.momentum + param_q.data * (1.0 - self.momentum)
+
+    @torch.no_grad()
+    def _dequeue_and_enqueue(self, keys: "torch.Tensor") -> None:
+        batch_size = keys.shape[0]
+        ptr = int(self.queue_ptr)
+        self.queue[:, ptr : ptr + batch_size] = keys.T
+        ptr = (ptr + batch_size) % self.queue_size
+        self.queue_ptr[0] = ptr
+
+    def forward(self, x: "torch.Tensor") -> tuple["torch.Tensor", "torch.Tensor"]:  # type: ignore[override]
+        q = self.augment(x)
+        k = self.augment(x)
+        q = F.normalize(self.projector(self.encoder_q(q)), dim=1)
+        with torch.no_grad():
+            self._momentum_update_key_encoder()
+            k = F.normalize(self.projector(self.encoder_k(k)), dim=1)
+        l_pos = torch.einsum("nc,nc->n", [q, k]).unsqueeze(-1)
+        l_neg = torch.einsum("nc,ck->nk", [q, self.queue.clone().detach()])
+        logits = torch.cat([l_pos, l_neg], dim=1) / self.temperature
+        labels = torch.zeros(logits.shape[0], dtype=torch.long, device=logits.device)
+        self._dequeue_and_enqueue(k)
+        return logits, labels

--- a/backend/ml/self_supervised/simclr.py
+++ b/backend/ml/self_supervised/simclr.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Minimal SimCLR implementation with pluggable augmentations."""
+
+from typing import Callable
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch import nn
+    import torch.nn.functional as F
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+class SimCLR(nn.Module):
+    """Contrastive learning model following the SimCLR framework."""
+
+    def __init__(
+        self,
+        encoder: nn.Module,
+        projection_head: nn.Module,
+        augmentations: Callable[["torch.Tensor"], "torch.Tensor"] | None = None,
+        temperature: float = 0.5,
+    ) -> None:
+        if torch is None:  # pragma: no cover - runtime dependency check
+            raise ImportError("torch is required for SimCLR")
+        super().__init__()
+        self.encoder = encoder
+        self.projection_head = projection_head
+        self.augment = augmentations or (lambda x: x)
+        self.temperature = temperature
+
+    def forward(self, x: "torch.Tensor") -> tuple["torch.Tensor", "torch.Tensor"]:  # type: ignore[override]
+        x_i = self.augment(x)
+        x_j = self.augment(x)
+        h_i = self.encoder(x_i)
+        h_j = self.encoder(x_j)
+        z_i = self.projection_head(h_i)
+        z_j = self.projection_head(h_j)
+        return z_i, z_j
+
+    def nt_xent_loss(
+        self, z_i: "torch.Tensor", z_j: "torch.Tensor"
+    ) -> "torch.Tensor":
+        """Compute the NT-Xent contrastive loss."""
+
+        if torch is None:  # pragma: no cover - runtime dependency check
+            raise ImportError("torch is required for SimCLR")
+
+        z = torch.cat([z_i, z_j], dim=0)
+        z = F.normalize(z, dim=1)
+        similarity = torch.matmul(z, z.T)
+        batch_size = z_i.size(0)
+        mask = torch.eye(2 * batch_size, device=z.device, dtype=torch.bool)
+        similarity = similarity.masked_fill(mask, float("-inf"))
+        logits = similarity / self.temperature
+        labels = torch.arange(batch_size, device=z.device)
+        labels = torch.cat([labels, labels], dim=0)
+        return F.cross_entropy(logits, labels)

--- a/backend/ml/self_supervised/vae.py
+++ b/backend/ml/self_supervised/vae.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Variational autoencoder utilities."""
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+
+from .autoencoder import reconstruction_loss
+
+
+class VariationalAutoencoder(nn.Module):
+    """Minimal variational autoencoder with linear layers."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, latent_dim: int) -> None:
+        if torch is None:  # pragma: no cover - runtime dependency check
+            raise ImportError("torch is required for VariationalAutoencoder")
+        super().__init__()
+        self.encoder = nn.Sequential(nn.Linear(input_dim, hidden_dim), nn.ReLU())
+        self.fc_mu = nn.Linear(hidden_dim, latent_dim)
+        self.fc_logvar = nn.Linear(hidden_dim, latent_dim)
+        self.decoder = nn.Sequential(nn.Linear(latent_dim, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, input_dim))
+
+    def reparameterize(self, mu: "torch.Tensor", logvar: "torch.Tensor") -> "torch.Tensor":
+        std = torch.exp(0.5 * logvar)
+        eps = torch.zeros_like(std)
+        return mu + eps * std
+
+    def forward(
+        self, x: "torch.Tensor"
+    ) -> tuple["torch.Tensor", "torch.Tensor", "torch.Tensor"]:  # type: ignore[override]
+        h = self.encoder(x)
+        mu = self.fc_mu(h)
+        logvar = self.fc_logvar(h)
+        z = self.reparameterize(mu, logvar)
+        recon = self.decoder(z)
+        return recon, mu, logvar
+
+
+def kl_divergence(mu: "torch.Tensor", logvar: "torch.Tensor") -> "torch.Tensor":
+    """KL divergence between a normal distribution and N(0, I)."""
+
+    if torch is None:  # pragma: no cover - runtime dependency check
+        raise ImportError("torch is required for kl_divergence")
+    return -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp(), dim=1).mean()

--- a/backend/tests/test_self_supervised_autoencoders.py
+++ b/backend/tests/test_self_supervised_autoencoders.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend.ml.self_supervised.autoencoder import Autoencoder, reconstruction_loss
+from backend.ml.self_supervised.vae import VariationalAutoencoder
+
+try:
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - skip tests if torch missing
+    pytest.skip("torch is required for self-supervised tests", allow_module_level=True)
+
+
+def test_autoencoder_reconstruction_loss() -> None:
+    model = Autoencoder(nn.Identity(), nn.Identity())
+    x = torch.randn(2, 3)
+    recon = model(x)
+    loss = reconstruction_loss(x, recon)
+    assert loss.item() == pytest.approx(0.0)
+
+
+def test_variational_autoencoder_reconstruction_loss() -> None:
+    class IdentityVAE(VariationalAutoencoder):
+        def __init__(self, dim: int) -> None:
+            super().__init__(dim, dim, dim)
+            self.encoder = nn.Identity()
+            self.fc_mu = nn.Identity()
+            self.fc_logvar = nn.Identity()
+            self.decoder = nn.Identity()
+
+        def reparameterize(self, mu: "torch.Tensor", logvar: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
+            return mu
+
+    x = torch.randn(2, 4)
+    model = IdentityVAE(4)
+    recon, mu, logvar = model(x)
+    loss = reconstruction_loss(x, recon)
+    assert loss.item() == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- implement SimCLR and MoCo with pluggable augmentations
- add masked language modeling pretraining utilities
- add autoencoder and variational autoencoder modules with tests for reconstruction loss

## Testing
- `pytest backend/tests/test_self_supervised_autoencoders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5526ccb08832fa606510ee05899f7