### PR TITLE
feat: add multi-head global workspace attention

### DIFF
--- a/backend/monitoring/brain_state.py
+++ b/backend/monitoring/brain_state.py
@@ -9,6 +9,7 @@ be used by memory backends to keep track of retrieval operations.
 """
 
 from fastapi import FastAPI
+from typing import List
 
 from .global_workspace import GlobalWorkspace, global_workspace
 
@@ -60,10 +61,10 @@ def create_app(workspace: GlobalWorkspace | None = None) -> FastAPI:
         }
 
     @app.post("/brain/attention/{module}")
-    def set_attention(module: str, weight: float) -> dict[str, object]:
-        """Set attention ``weight`` for ``module``."""
+    def set_attention(module: str, weights: List[float]) -> dict[str, object]:
+        """Set attention ``weights`` for ``module``."""
 
-        workspace._attention[module] = float(weight)
+        workspace._attention[module] = [float(w) for w in weights]
         return {"module": module, "attention": workspace._attention[module]}
 
     return app

--- a/backend/monitoring/global_workspace.py
+++ b/backend/monitoring/global_workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Shared global workspace for broadcasting state between modules."""
 
-from typing import Any, Dict, Callable, List
+from typing import Any, Dict, Callable, List, Sequence, Tuple, Optional
 
 
 class GlobalWorkspace:
@@ -11,40 +11,133 @@ class GlobalWorkspace:
     def __init__(self) -> None:
         self._modules: Dict[str, Any] = {}
         self._state: Dict[str, Any] = {}
-        self._attention: Dict[str, float] = {}
+        # Store per-module multi-head attention weights
+        self._attention: Dict[str, List[float]] = {}
         self._state_subs: Dict[str, List[Callable[[Any], None]]] = {}
+        # (module_a, module_b) -> cross-attention fusion hook
+        self._cross_attn: Dict[Tuple[str, str], Callable[[Any, Any, Optional[List[float]], Optional[List[float]]], Tuple[Any, Optional[List[float]]]]] = {}
 
     # ------------------------------------------------------------------
     def register_module(self, name: str, module: Any) -> None:
         """Register *module* under *name* in the workspace."""
         self._modules[name] = module
 
-    def broadcast(self, sender: str, state: Any, attention: float | None = None) -> None:
-        """Broadcast *state* and optional *attention* from *sender* to all other modules."""
+    def broadcast(
+        self,
+        sender: str,
+        state: Any,
+        attention: Optional[Sequence[float] | float] = None,
+        *,
+        strategy: str = "full",
+        targets: Optional[List[str]] = None,
+        k: Optional[int] = None,
+        _allow_cross: bool = True,
+    ) -> None:
+        """Broadcast *state* from *sender* according to *strategy*.
+
+        Parameters
+        ----------
+        sender:
+            Name of the broadcasting module.
+        state:
+            Arbitrary payload to share.
+        attention:
+            Optional attention vector. A scalar will be promoted to a
+            single-element list.
+        strategy:
+            ``"full"`` (default) broadcasts to all modules, ``"local"`` only to
+            provided ``targets`` and ``"sparse"`` routes to the top ``k`` modules
+            ranked by their current attention weights.
+        targets:
+            Optional explicit list of recipient modules. Required for
+            ``strategy="local"``.
+        k:
+            Number of modules to target when ``strategy="sparse"``.
+        _allow_cross:
+            Internal flag to prevent recursive cross attention broadcasting.
+        """
+
         self._state[sender] = state
+
+        att_list: Optional[List[float]] = None
         if attention is not None:
-            self._attention[sender] = float(attention)
-        for name, module in self._modules.items():
-            if name == sender:
-                continue
+            if isinstance(attention, Sequence) and not isinstance(attention, (str, bytes)):
+                att_list = [float(a) for a in attention]
+            else:
+                att_list = [float(attention)]
+            self._attention[sender] = att_list
+
+        # Determine recipients
+        recipients = [name for name in self._modules if name != sender]
+        if strategy == "local":
+            if targets is None:
+                raise ValueError("targets must be provided for local strategy")
+            recipients = [n for n in targets if n in self._modules and n != sender]
+        elif strategy == "sparse":
+            if k is None:
+                raise ValueError("k must be provided for sparse strategy")
+            scores = {
+                n: sum(self._attention.get(n, [])) for n in recipients
+            }
+            recipients = [n for n, _ in sorted(scores.items(), key=lambda i: i[1], reverse=True)[:k]]
+        elif targets is not None:
+            recipients = [n for n in targets if n in self._modules and n != sender]
+
+        for name in recipients:
+            module = self._modules[name]
             handler = getattr(module, "receive_broadcast", None)
             if callable(handler):
-                handler(sender, state, attention)
+                handler(sender, state, att_list)
+
         for handler in self._state_subs.get(sender, []):
             handler(state)
+
+        if _allow_cross:
+            self._trigger_cross_attention(sender)
 
     def subscribe_state(self, name: str, handler: Callable[[Any], None]) -> None:
         """Invoke *handler* whenever *name* publishes new state."""
 
         self._state_subs.setdefault(name, []).append(handler)
 
+    def register_cross_attention(
+        self,
+        module_a: str,
+        module_b: str,
+        handler: Callable[[Any, Any, Optional[List[float]], Optional[List[float]]], Tuple[Any, Optional[List[float]]]],
+    ) -> None:
+        """Register a cross-attention fusion hook between two modules.
+
+        When both modules have published state, *handler* is invoked with
+        ``(state_a, state_b, attn_a, attn_b)`` and should return a tuple of
+        ``(fused_state, fused_attention)`` which is then broadcast under the
+        sender name ``"module_a|module_b"``.
+        """
+
+        key = tuple(sorted((module_a, module_b)))
+        self._cross_attn[key] = handler
+
+    def _trigger_cross_attention(self, sender: str) -> None:
+        for (a, b), handler in self._cross_attn.items():
+            if sender not in (a, b):
+                continue
+            other = b if sender == a else a
+            if other not in self._state:
+                continue
+            state_a = self._state[a]
+            state_b = self._state[b]
+            att_a = self._attention.get(a)
+            att_b = self._attention.get(b)
+            fused_state, fused_attn = handler(state_a, state_b, att_a, att_b)
+            self.broadcast(f"{a}|{b}", fused_state, fused_attn, _allow_cross=False)
+
     # ------------------------------------------------------------------
     def state(self, name: str) -> Any:
         """Return the last state published by *name*."""
         return self._state.get(name)
 
-    def attention(self, name: str) -> float | None:
-        """Return the last attention weight published by *name*."""
+    def attention(self, name: str) -> Optional[List[float]]:
+        """Return the last attention vector published by *name*."""
         return self._attention.get(name)
 
 

--- a/modules/tests/test_global_workspace.py
+++ b/modules/tests/test_global_workspace.py
@@ -19,10 +19,10 @@ def test_broadcast_propagates_state() -> None:
     b = DummyModule()
     gw.register_module("a", a)
     gw.register_module("b", b)
-    gw.broadcast("a", {"value": 1}, 0.5)
-    assert b.received == [("a", {"value": 1}, 0.5)]
+    gw.broadcast("a", {"value": 1}, [0.5, 0.5])
+    assert b.received == [("a", {"value": 1}, [0.5, 0.5])]
     assert gw.state("a") == {"value": 1}
-    assert gw.attention("a") == 0.5
+    assert gw.attention("a") == [0.5, 0.5]
 
 
 def test_subscribe_state_receives_updates() -> None:
@@ -31,3 +31,58 @@ def test_subscribe_state_receives_updates() -> None:
     gw.subscribe_state("self_model", lambda s: received.append(s))
     gw.broadcast("self_model", {"agent": "a", "summary": "hi"})
     assert received == [{"agent": "a", "summary": "hi"}]
+
+
+def test_cross_attention_fuses_states() -> None:
+    gw = GlobalWorkspace()
+    text = DummyModule()
+    vision = DummyModule()
+    obs = DummyModule()
+    gw.register_module("text", text)
+    gw.register_module("vision", vision)
+    gw.register_module("obs", obs)
+
+    def fuse(t_state, v_state, t_att, v_att):
+        fused = {"text": t_state["t"], "vision": v_state["v"]}
+        return fused, [0.5, 0.5]
+
+    gw.register_cross_attention("text", "vision", fuse)
+
+    gw.broadcast("text", {"t": "hello"}, [1.0, 0.0])
+    obs.received.clear()
+    gw.broadcast("vision", {"v": "img"}, [0.0, 1.0])
+
+    assert any(
+        msg[0] == "text|vision" and msg[1] == {"text": "hello", "vision": "img"}
+        for msg in obs.received
+    )
+
+
+def test_sparse_attention_routes_to_high_attention_modules() -> None:
+    gw = GlobalWorkspace()
+    a = DummyModule()
+    b = DummyModule()
+    c = DummyModule()
+    gw.register_module("a", a)
+    gw.register_module("b", b)
+    gw.register_module("c", c)
+    gw.broadcast("b", {}, [0.9])
+    gw.broadcast("c", {}, [0.1])
+    b.received.clear()
+    c.received.clear()
+    gw.broadcast("a", {"data": 1}, [0.5], strategy="sparse", k=1)
+    assert b.received == [("a", {"data": 1}, [0.5])]
+    assert c.received == []
+
+
+def test_local_attention_targets_specified_modules() -> None:
+    gw = GlobalWorkspace()
+    a = DummyModule()
+    b = DummyModule()
+    c = DummyModule()
+    gw.register_module("a", a)
+    gw.register_module("b", b)
+    gw.register_module("c", c)
+    gw.broadcast("a", {"data": 2}, [0.3], strategy="local", targets=["b"])
+    assert b.received == [("a", {"data": 2}, [0.3])]
+    assert c.received == []


### PR DESCRIPTION
## Summary
- extend global workspace with multi-head attention vectors and optional sparse/local routing strategies
- add cross-attention hooks for multimodal state fusion
- expose vector attention in brain metrics API and add comprehensive tests

## Testing
- `pytest modules/tests/test_global_workspace.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5541bc74c832f84cbe5cb9950c8a7