### PR TITLE
Add evaluation metrics, explanation logging and dashboard alerts

### DIFF
--- a/backend/analysis/interpretability.py
+++ b/backend/analysis/interpretability.py
@@ -9,12 +9,16 @@ import os
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from monitoring.storage import TimeSeriesStorage
+
 
 @dataclass
 class InterpretabilityAnalyzer:
-    """Collects metrics and failure cases for interpretability analysis."""
+    """Collects metrics, failure cases and explanations for analysis."""
 
     failure_cases: List[Dict[str, object]] = field(default_factory=list)
+    explanations: List[str] = field(default_factory=list)
+    storage: TimeSeriesStorage | None = None
 
     def generate_learning_curve(self, metrics: List[float], path: str) -> str:
         """Save a learning curve plot for the provided metric values."""
@@ -37,6 +41,12 @@ class InterpretabilityAnalyzer:
             "output": output,
             "expected": expected,
         })
+
+    def log_explanation(self, text: str) -> None:
+        """Record an explanation and persist it via storage if available."""
+        self.explanations.append(text)
+        if self.storage is not None:
+            self.storage.store("analysis.explanations", {"text": text})
 
     def export_failure_cases(self, path: str) -> str:
         """Write failure cases to a CSV file."""

--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -9,6 +9,7 @@ from .reflection import Reflection
 from .global_workspace import GlobalWorkspace, global_workspace
 from .brain_state import create_app as create_brain_app, record_memory_hit
 from .multi_metric_monitor import MultiMetricMonitor
+from .evaluation import EvaluationMetrics
 
 __all__ = [
     "TimeSeriesStorage",
@@ -24,4 +25,5 @@ __all__ = [
     "create_brain_app",
     "record_memory_hit",
     "MultiMetricMonitor",
+    "EvaluationMetrics",
 ]

--- a/backend/monitoring/alerting.py
+++ b/backend/monitoring/alerting.py
@@ -1,0 +1,37 @@
+"""Simple alerting rules for evaluation metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class AlertRule:
+    metric: str
+    threshold: float
+    op: str = "lt"  # "lt" means trigger when metric < threshold, "gt" when >
+    message: str | None = None
+
+
+def evaluate_alerts(metrics: Dict[str, float], rules: List[AlertRule]) -> List[Dict[str, object]]:
+    """Return list of alerts for metrics breaching *rules*."""
+    alerts: List[Dict[str, object]] = []
+    for rule in rules:
+        value = metrics.get(rule.metric)
+        if value is None:
+            continue
+        triggered = False
+        if rule.op == "lt" and value < rule.threshold:
+            triggered = True
+        elif rule.op == "gt" and value > rule.threshold:
+            triggered = True
+        if triggered:
+            alerts.append(
+                {
+                    "metric": rule.metric,
+                    "value": value,
+                    "message": rule.message or f"{rule.metric} {value} breached {rule.threshold}",
+                }
+            )
+    return alerts

--- a/backend/monitoring/evaluation.py
+++ b/backend/monitoring/evaluation.py
@@ -1,0 +1,65 @@
+"""Multi-metric evaluation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class EvaluationMetrics:
+    """Tracks classification and performance metrics."""
+
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    tn: int = 0
+    latencies: List[float] = field(default_factory=list)
+    group_positive: Dict[str, int] = field(default_factory=dict)
+    group_total: Dict[str, int] = field(default_factory=dict)
+
+    def record(self, prediction: bool, truth: bool, latency: float, group: str) -> None:
+        """Record a single prediction outcome."""
+        if prediction and truth:
+            self.tp += 1
+        elif prediction and not truth:
+            self.fp += 1
+        elif not prediction and truth:
+            self.fn += 1
+        else:
+            self.tn += 1
+
+        self.latencies.append(latency)
+        self.group_total[group] = self.group_total.get(group, 0) + 1
+        if prediction:
+            self.group_positive[group] = self.group_positive.get(group, 0) + 1
+
+    # metric helpers -----------------------------------------------------
+    def precision(self) -> float:
+        denom = self.tp + self.fp
+        return self.tp / denom if denom else 0.0
+
+    def recall(self) -> float:
+        denom = self.tp + self.fn
+        return self.tp / denom if denom else 0.0
+
+    def latency(self) -> float:
+        return sum(self.latencies) / len(self.latencies) if self.latencies else 0.0
+
+    def fairness(self) -> float:
+        """Return absolute difference in positive rates across groups."""
+        rates: List[float] = []
+        for g, total in self.group_total.items():
+            pos = self.group_positive.get(g, 0)
+            rates.append(pos / total if total else 0.0)
+        if not rates:
+            return 0.0
+        return max(rates) - min(rates)
+
+    def summary(self) -> Dict[str, float]:
+        return {
+            "precision": self.precision(),
+            "recall": self.recall(),
+            "latency": self.latency(),
+            "fairness": self.fairness(),
+        }

--- a/backend/tests/test_alerting.py
+++ b/backend/tests/test_alerting.py
@@ -1,0 +1,24 @@
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+sys.modules.setdefault("events", types.SimpleNamespace(EventBus=object))
+monitoring_dir = Path(__file__).resolve().parent.parent / "monitoring"
+pkg = types.ModuleType("monitoring")
+pkg.__path__ = [str(monitoring_dir)]
+sys.modules["monitoring"] = pkg
+
+alerting = importlib.import_module("monitoring.alerting")
+AlertRule = alerting.AlertRule
+evaluate_alerts = alerting.evaluate_alerts
+
+
+def test_alert_triggered() -> None:
+    metrics = {"precision": 0.5, "recall": 0.7}
+    rules = [AlertRule(metric="precision", threshold=0.8, op="lt", message="low precision")]
+    alerts = evaluate_alerts(metrics, rules)
+    assert alerts and alerts[0]["metric"] == "precision"

--- a/backend/tests/test_interpretability.py
+++ b/backend/tests/test_interpretability.py
@@ -1,14 +1,34 @@
 from pathlib import Path
 import os
 import sys
+import importlib.util
+import types
+from pathlib import Path
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from analysis.interpretability import InterpretabilityAnalyzer
+sys.modules.setdefault("events", types.SimpleNamespace(EventBus=object))
+
+monitoring_dir = Path(__file__).resolve().parent.parent / "monitoring"
+spec_storage = importlib.util.spec_from_file_location("monitoring.storage", monitoring_dir / "storage.py")
+storage_mod = importlib.util.module_from_spec(spec_storage)
+sys.modules["monitoring.storage"] = storage_mod
+spec_storage.loader.exec_module(storage_mod)  # type: ignore
+sys.modules["monitoring"] = types.ModuleType("monitoring")
+sys.modules["monitoring"].storage = storage_mod
+TimeSeriesStorage = storage_mod.TimeSeriesStorage
+
+analysis_dir = Path(__file__).resolve().parent.parent / "analysis"
+spec_analysis = importlib.util.spec_from_file_location("analysis.interpretability", analysis_dir / "interpretability.py")
+analysis_mod = importlib.util.module_from_spec(spec_analysis)
+sys.modules["analysis.interpretability"] = analysis_mod
+spec_analysis.loader.exec_module(analysis_mod)  # type: ignore
+InterpretabilityAnalyzer = analysis_mod.InterpretabilityAnalyzer
 
 
 def test_interpretability_tools(tmp_path: Path) -> None:
-    analyzer = InterpretabilityAnalyzer()
+    storage = TimeSeriesStorage(tmp_path / "interp.db")
+    analyzer = InterpretabilityAnalyzer(storage=storage)
     curve_path = tmp_path / "curve.png"
     analyzer.generate_learning_curve([0.1, 0.2, 0.3], str(curve_path))
     assert curve_path.exists()
@@ -17,3 +37,7 @@ def test_interpretability_tools(tmp_path: Path) -> None:
     report_path = tmp_path / "failures.csv"
     analyzer.export_failure_cases(str(report_path))
     assert report_path.exists()
+
+    analyzer.log_explanation("test explanation")
+    stored = storage.events("analysis.explanations")
+    assert stored and stored[0]["text"] == "test explanation"

--- a/backend/tests/test_monitoring_api.py
+++ b/backend/tests/test_monitoring_api.py
@@ -1,0 +1,51 @@
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+sys.modules.setdefault("events", types.SimpleNamespace(EventBus=object))
+
+monitoring_dir = Path(__file__).resolve().parent.parent / "monitoring"
+monitoring_pkg = types.ModuleType("monitoring")
+monitoring_pkg.__path__ = [str(monitoring_dir)]
+sys.modules["monitoring"] = monitoring_pkg
+
+analysis_dir = Path(__file__).resolve().parent.parent / "analysis"
+analysis_pkg = types.ModuleType("analysis")
+analysis_pkg.__path__ = [str(analysis_dir)]
+sys.modules["analysis"] = analysis_pkg
+
+api = importlib.import_module("monitoring.api")
+create_app = api.create_app
+
+evaluation = importlib.import_module("monitoring.evaluation")
+EvaluationMetrics = evaluation.EvaluationMetrics
+
+storage_mod = importlib.import_module("monitoring.storage")
+TimeSeriesStorage = storage_mod.TimeSeriesStorage
+
+analysis_mod = importlib.import_module("analysis.interpretability")
+InterpretabilityAnalyzer = analysis_mod.InterpretabilityAnalyzer
+
+from fastapi.testclient import TestClient
+
+
+def test_dashboard_endpoints(tmp_path: Path) -> None:
+    storage = TimeSeriesStorage(tmp_path / "mon.db")
+    eval_metrics = EvaluationMetrics()
+    eval_metrics.record(True, True, 0.1, "a")
+    eval_metrics.record(False, True, 0.2, "b")
+    analyzer = InterpretabilityAnalyzer(storage=storage)
+    analyzer.log_explanation("because")
+
+    app = create_app(storage=storage, evaluation=eval_metrics)
+    client = TestClient(app)
+
+    r = client.get("/metrics/evaluation")
+    assert r.status_code == 200
+
+    r2 = client.get("/metrics/explanations")
+    assert r2.status_code == 200

--- a/frontend/streamlit_dashboard.py
+++ b/frontend/streamlit_dashboard.py
@@ -1,0 +1,23 @@
+"""Simple Streamlit dashboard for metrics and explanations."""
+
+import os
+import requests
+import streamlit as st
+
+API_URL = os.environ.get("METRICS_API_URL", "http://localhost:8000")
+
+st.title("Monitoring Dashboard")
+
+# metrics
+metrics = requests.get(f"{API_URL}/metrics/evaluation").json()
+col1, col2, col3, col4 = st.columns(4)
+col1.metric("Precision", f"{metrics.get('precision', 0):.2f}")
+col2.metric("Recall", f"{metrics.get('recall', 0):.2f}")
+col3.metric("Latency", f"{metrics.get('latency', 0):.2f}")
+col4.metric("Fairness", f"{metrics.get('fairness', 0):.2f}")
+
+# explanations
+st.header("Explanations")
+expl = requests.get(f"{API_URL}/metrics/explanations").json()
+for e in expl:
+    st.write(e.get("text"))


### PR DESCRIPTION
## Summary
- add `EvaluationMetrics` utility and expose evaluation/explanation endpoints
- log interpretability explanations and surface them in a Streamlit dashboard
- provide alerting rules and unit tests for metrics and dashboard API

## Testing
- `pytest backend/tests/test_alerting.py backend/tests/test_monitoring_api.py backend/tests/test_interpretability.py backend/tests/test_multi_metric_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5556f661c832fb14c29363ad27298