### PR TITLE
Add data pipeline, streaming ingestion, and active learning sampler

### DIFF
--- a/backend/ml/active_sampler.py
+++ b/backend/ml/active_sampler.py
@@ -1,0 +1,44 @@
+"""Active learning samplers for prioritising informative samples.
+
+The sampler ranks samples either by model uncertainty or diversity in feature
+space. It is intended to be lightweight and independent from any specific
+model implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+
+@dataclass
+class ActiveLearningSampler:
+    """Select samples using uncertainty or diversity based heuristics."""
+
+    strategy: str = "uncertainty"
+
+    def score_uncertainty(self, probs: Sequence[Sequence[float]]) -> np.ndarray:
+        """Return uncertainty scores given class probability distributions."""
+        arr = np.asarray(probs)
+        return 1.0 - arr.max(axis=1)
+
+    def score_diversity(self, features: Sequence[Sequence[float]]) -> np.ndarray:
+        """Return diversity scores based on distance from the feature centroid."""
+        feats = np.asarray(features)
+        centroid = feats.mean(axis=0)
+        return np.linalg.norm(feats - centroid, axis=1)
+
+    def select(self, *, probs: Sequence[Sequence[float]] | None = None,
+               features: Sequence[Sequence[float]] | None = None,
+               k: int = 1) -> np.ndarray:
+        """Return indices of the ``k`` most informative samples."""
+        if self.strategy == "uncertainty" and probs is not None:
+            scores = self.score_uncertainty(probs)
+        elif features is not None:
+            scores = self.score_diversity(features)
+        else:
+            raise ValueError("Insufficient data provided for sampling")
+        idx = np.argsort(scores)[::-1][:k]
+        return idx

--- a/backend/ml/data_pipeline.py
+++ b/backend/ml/data_pipeline.py
@@ -1,0 +1,79 @@
+"""Utilities for preparing data prior to model retraining.
+
+This module provides a small ``DataPipeline`` class that performs simple
+augmentation and synthetic sample generation for both text and image data.
+The aim is to offer hook points for richer pipelines while keeping the
+implementation lightweight and dependency free.
+
+Example
+-------
+>>> import pandas as pd
+>>> from backend.ml.data_pipeline import DataPipeline
+>>> df = pd.DataFrame({"input": ["hello world"]})
+>>> DataPipeline().process(df)
+          input
+0   hello world
+1   world hello
+2  hello world [synthetic]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Iterable, List
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class DataPipeline:
+    """Apply basic augmentation and synthesis to datasets.
+
+    Text augmentation shuffles token order while image augmentation performs a
+    horizontal flip. Synthetic samples are created by appending a marker for
+    text or generating random noise for images. These operations are purposely
+    simple but demonstrate where more sophisticated logic can be inserted.
+    """
+
+    def augment_text(self, text: str) -> str:
+        tokens = text.split()
+        random.shuffle(tokens)
+        return " ".join(tokens)
+
+    def synthesize_text(self, text: str) -> str:
+        return f"{text} [synthetic]"
+
+    def augment_image(self, image: np.ndarray) -> np.ndarray:
+        return np.fliplr(image)
+
+    def synthesize_image(self, shape: tuple[int, int, int]) -> np.ndarray:
+        return np.random.rand(*shape)
+
+    def process(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return a new dataframe with augmented and synthetic samples.
+
+        The pipeline looks for ``input`` (text) and ``image`` columns. For each
+        record two additional rows are produced: one augmented and one
+        synthetic. Other columns are copied verbatim.
+        """
+
+        rows: List[pd.Series] = []
+        for _, row in df.iterrows():
+            rows.append(row)
+            if "input" in row and isinstance(row["input"], str):
+                aug = row.copy()
+                aug["input"] = self.augment_text(row["input"])
+                rows.append(aug)
+                syn = row.copy()
+                syn["input"] = self.synthesize_text(row["input"])
+                rows.append(syn)
+            if "image" in row and isinstance(row["image"], np.ndarray):
+                aug_img = row.copy()
+                aug_img["image"] = self.augment_image(row["image"])
+                rows.append(aug_img)
+                syn_img = row.copy()
+                syn_img["image"] = self.synthesize_image(row["image"].shape)
+                rows.append(syn_img)
+        return pd.DataFrame(rows)

--- a/backend/ml/retraining_pipeline.py
+++ b/backend/ml/retraining_pipeline.py
@@ -19,6 +19,7 @@ from typing import Dict
 
 import pandas as pd
 from events import create_event_bus, publish
+from .data_pipeline import DataPipeline
 
 DATA_DIR = Path("data")
 DATASET = DATA_DIR / "dataset.csv"
@@ -221,6 +222,12 @@ def main() -> bool:
     if not DATASET.exists():
         print("No dataset available for training")
         return True
+
+    # Expand the dataset using the data pipeline before training.
+    df = pd.read_csv(DATASET)
+    pipeline = DataPipeline()
+    df = pipeline.process(df)
+    df.to_csv(DATASET, index=False)
 
     version = datetime.utcnow().strftime("v%Y%m%d%H%M%S")
     metrics_file, metric_name = train_and_evaluate(version, args.model)

--- a/backend/runner/__init__.py
+++ b/backend/runner/__init__.py
@@ -1,0 +1,5 @@
+"""Runner utilities for training and online learning."""
+
+from .streaming import StreamingDataIngestor
+
+__all__ = ["StreamingDataIngestor"]

--- a/backend/runner/streaming.py
+++ b/backend/runner/streaming.py
@@ -1,0 +1,54 @@
+"""Utilities for streaming data ingestion using an event queue.
+
+The :class:`StreamingDataIngestor` subscribes to an event bus topic and
+buffers incoming events in a local queue. A consumer can periodically drain
+this queue and feed the resulting samples into an online learning routine.
+
+The ingestor optionally accepts an active learning sampler which can be used
+to prioritise which samples from the queue are returned.
+"""
+
+from __future__ import annotations
+
+from queue import Empty, Queue
+from typing import Any, Callable, Dict, List
+
+from events import EventBus, create_event_bus
+from backend.ml.active_sampler import ActiveLearningSampler
+
+
+class StreamingDataIngestor:
+    """Subscribe to events and expose them as a stream of training samples."""
+
+    def __init__(
+        self,
+        bus: EventBus | None = None,
+        *,
+        topic: str = "training.sample",
+        sampler: ActiveLearningSampler | None = None,
+    ) -> None:
+        self.bus = bus or create_event_bus("inmemory")
+        self.topic = topic
+        self.queue: Queue[Dict[str, Any]] = Queue()
+        self.bus.subscribe(topic, self.queue.put)
+        self.sampler = sampler
+
+    def drain(self) -> List[Dict[str, Any]]:
+        """Return all queued events, optionally prioritised by the sampler."""
+        batch: List[Dict[str, Any]] = []
+        while True:
+            try:
+                batch.append(self.queue.get_nowait())
+            except Empty:
+                break
+        if self.sampler and batch:
+            features = [e.get("features") for e in batch]
+            k = len(batch)
+            idx = self.sampler.select(features=features, k=k)
+            batch = [batch[i] for i in idx]
+        return batch
+
+    def stream(self, handler: Callable[[Dict[str, Any]], None]) -> None:
+        """Process all queued events using ``handler``."""
+        for event in self.drain():
+            handler(event)

--- a/docs/active_learning_sampler.md
+++ b/docs/active_learning_sampler.md
@@ -1,0 +1,30 @@
+# Active Learning Sampler
+
+The `backend/ml/active_sampler.py` module provides a tiny helper for selecting
+which new samples should be labelled or used for training. Two strategies are
+implemented:
+
+* **Uncertainty** – chooses samples where the model has low confidence.
+* **Diversity** – chooses samples that are far from the feature centroid.
+
+## Basic Usage
+
+```python
+from backend.ml.active_sampler import ActiveLearningSampler
+import numpy as np
+
+sampler = ActiveLearningSampler(strategy="uncertainty")
+probs = np.array([[0.6, 0.4], [0.9, 0.1]])
+indices = sampler.select(probs=probs, k=1)
+# -> array([0]) selects the least certain sample
+```
+
+The sampler can be combined with the streaming ingestor in
+`backend/runner/streaming.py` to prioritise which events from the queue are
+processed:
+
+```python
+from backend.runner import StreamingDataIngestor
+ingestor = StreamingDataIngestor(sampler=sampler)
+ingestor.stream(lambda e: train_on_sample(e))
+```

--- a/docs/retraining_pipeline.md
+++ b/docs/retraining_pipeline.md
@@ -1,10 +1,13 @@
 # Retraining Pipeline
 
 The `ml/retraining_pipeline.py` module automates model updates using new log
-entries.
+entries. It now integrates a lightweight data pipeline for augmentation and
+supports online learning via an event queue.
 
 1. **Accumulate logs** – new logs are stored in `data/new_logs.csv` and are
-   appended to the aggregated dataset `data/dataset.csv`.
+   appended to the aggregated dataset `data/dataset.csv`. Before training the
+   dataset passes through `ml/data_pipeline.py` where optional text and image
+   augmentation/synthesis expands the data available for learning.
 2. **Retrain and evaluate** – the dataset is used to train a fresh model.
    Classic models are trained via `ml/train_models.py` while LLMs use
    `ml/fine_tune_llm.py` when calling the pipeline with `--model llm`. The
@@ -13,6 +16,10 @@ entries.
 3. **Deploy on improvement** – if the new model achieves a lower metric, it
    replaces the existing model in `artifacts/current/`. Older versions remain in
    `artifacts/<version>/` and can be restored manually to roll back.
+4. **Online ingestion (optional)** – `backend/runner/streaming.py` exposes a
+   queue based interface for feeding new samples from an event bus directly into
+   an online learning loop. It can be coupled with the active learning sampler
+   in `ml/active_sampler.py` to prioritise the most informative events.
 
 To execute the pipeline periodically, use the provided `retrain_cron.sh` script
 in a cron job or workflow. The script forwards all arguments to the Python


### PR DESCRIPTION
## Summary
- add data_pipeline with simple text and image augmentation and integrate with retraining
- introduce StreamingDataIngestor for event queue based online learning
- provide ActiveLearningSampler and document its usage

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68c5557666ec832f9ee9a392746b23c6