### PR TITLE
Make VisionCNN input size agnostic

### DIFF
--- a/backend/ml/models.py
+++ b/backend/ml/models.py
@@ -38,7 +38,14 @@ class TransformerTextModel(nn.Module):
 
 
 class VisionCNN(nn.Module):
-    """Simple convolutional network for vision tasks."""
+    """Simple convolutional network for vision tasks.
+
+    The model now supports arbitrary input spatial dimensions. An
+    ``AdaptiveAvgPool2d`` layer ensures the convolutional feature map is
+    pooled to ``1x1`` so the classifier always receives a fixed-size input.
+    The constructor signature remains unchanged for backward compatibility,
+    and images of any size can be passed during the forward pass.
+    """
 
     def __init__(self, num_classes: int = 10) -> None:
         if torch is None:  # pragma: no cover - runtime dependency check
@@ -51,8 +58,9 @@ class VisionCNN(nn.Module):
             nn.Conv2d(32, 64, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(2),
+            nn.AdaptiveAvgPool2d((1, 1)),
         )
-        self.classifier = nn.Linear(64 * 8 * 8, num_classes)
+        self.classifier = nn.Linear(64, num_classes)
 
     def forward(self, x: "torch.Tensor") -> "torch.Tensor":  # type: ignore[override]
         x = self.features(x)

--- a/tests/test_nn_architectures.py
+++ b/tests/test_nn_architectures.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import torch
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from backend.ml.models import get_model, MLP, VisionCNN, SequenceRNN
@@ -43,6 +44,16 @@ def test_cnn_forward_and_train():
     assert out.shape == (2, 5)
     changed, _ = _train_step(model, x, y)
     assert changed
+
+
+@pytest.mark.parametrize("size", [32, 64, 28])
+def test_cnn_forward_varied_input_sizes(size):
+    """VisionCNN should handle different image sizes."""
+    torch.manual_seed(0)
+    model = get_model("cnn", num_classes=5)
+    x = torch.randn(2, 3, size, size)
+    out = model(x)
+    assert out.shape == (2, 5)
 
 
 def test_rnn_forward_and_train():


### PR DESCRIPTION
## Summary
- allow VisionCNN to handle arbitrary image sizes via AdaptiveAvgPool2d
- document flexible input size and maintain backward-compatible constructor
- test CNN forward pass with multiple input dimensions

## Testing
- `pytest tests/test_nn_architectures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55e715c04832fbbb267f6bbc2c329