### PR TITLE
refactor: centralize session handling

### DIFF
--- a/backend/forge/forge/sdk/db_test.py
+++ b/backend/forge/forge/sdk/db_test.py
@@ -216,7 +216,7 @@ async def test_create_and_get_step():
     db_name = "sqlite:///test_db.sqlite3"
     agent_db = AgentDB(db_name)
     task = await agent_db.create_task("task_input")
-    step_input = StepInput(type="python/code")
+    step_input = {"type": "python/code"}
     request = StepRequestBody(input="test_input debug", additional_input=step_input)
     step = await agent_db.create_step(task.task_id, request)
     step = await agent_db.get_step(task.task_id, step.step_id)
@@ -229,7 +229,7 @@ async def test_updating_step():
     db_name = "sqlite:///test_db.sqlite3"
     agent_db = AgentDB(db_name)
     created_task = await agent_db.create_task("task_input")
-    step_input = StepInput(type="python/code")
+    step_input = {"type": "python/code"}
     request = StepRequestBody(input="test_input debug", additional_input=step_input)
     created_step = await agent_db.create_step(created_task.task_id, request)
     await agent_db.update_step(created_task.task_id, created_step.step_id, "completed")
@@ -255,7 +255,7 @@ async def test_get_artifact():
 
     # Given: A task and its corresponding artifact
     task = await db.create_task("test_input debug")
-    step_input = StepInput(type="python/code")
+    step_input = {"type": "python/code"}
     requst = StepRequestBody(input="test_input debug", additional_input=step_input)
 
     step = await db.create_step(task.task_id, requst)
@@ -306,7 +306,7 @@ async def test_list_steps():
     db_name = "sqlite:///test_db.sqlite3"
     db = AgentDB(db_name)
 
-    step_input = StepInput(type="python/code")
+    step_input = {"type": "python/code"}
     requst = StepRequestBody(input="test_input debug", additional_input=step_input)
 
     # Given: A task and multiple steps for that task


### PR DESCRIPTION
## Summary
- add `_execute_with_session` helper to manage DB sessions and exceptions
- refactor task/step/artifact CRUD to use shared session logic
- align tests with new DB API

## Testing
- `pytest tests/test_forge_sdk_db.py backend/forge/forge/sdk/db_test.py tests/test_forge_sdk_agent_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c583851364832fb1620b7279c84b74