### PR TITLE
Add sensory cortex module with basic cortices

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -1,0 +1,7 @@
+from .sensory_cortex import VisualCortex, AuditoryCortex, SomatosensoryCortex
+
+__all__ = [
+    "VisualCortex",
+    "AuditoryCortex",
+    "SomatosensoryCortex",
+]

--- a/modules/brain/sensory_cortex.py
+++ b/modules/brain/sensory_cortex.py
@@ -1,0 +1,97 @@
+class EdgeDetector:
+    """Simple edge detection placeholder."""
+
+    def detect(self, image):
+        return ["edge"]
+
+
+class V1:
+    def __init__(self):
+        self.edge_detector = EdgeDetector()
+
+    def process(self, image):
+        return self.edge_detector.detect(image)
+
+
+class V2:
+    def process(self, image):
+        return ["form"]
+
+
+class V4:
+    def process(self, image):
+        return ["color"]
+
+
+class MT:
+    def process(self, image):
+        return ["motion"]
+
+
+class VisualCortex:
+    """Visual cortex with hierarchical processing areas."""
+
+    def __init__(self):
+        self.v1 = V1()
+        self.v2 = V2()
+        self.v4 = V4()
+        self.mt = MT()
+
+    def process(self, image):
+        return {
+            "edges": self.v1.process(image),
+            "form": self.v2.process(image),
+            "color": self.v4.process(image),
+            "motion": self.mt.process(image),
+        }
+
+
+class FrequencyAnalyzer:
+    """Placeholder frequency analyzer for auditory signals."""
+
+    def analyze(self, sound):
+        return ["frequency"]
+
+
+class A1:
+    def __init__(self):
+        self.analyzer = FrequencyAnalyzer()
+
+    def process(self, sound):
+        return self.analyzer.analyze(sound)
+
+
+class A2:
+    def process(self, sound):
+        return ["interpretation"]
+
+
+class AuditoryCortex:
+    """Auditory cortex with primary and secondary areas."""
+
+    def __init__(self):
+        self.a1 = A1()
+        self.a2 = A2()
+
+    def process(self, sound):
+        return {
+            "frequencies": self.a1.process(sound),
+            "interpretation": self.a2.process(sound),
+        }
+
+
+class TouchProcessor:
+    """Placeholder somatosensory processor."""
+
+    def process(self, stimulus):
+        return ["touch"]
+
+
+class SomatosensoryCortex:
+    """Somatosensory cortex for processing tactile information."""
+
+    def __init__(self):
+        self.processor = TouchProcessor()
+
+    def process(self, stimulus):
+        return self.processor.process(stimulus)

--- a/tests/test_sensory_cortex.py
+++ b/tests/test_sensory_cortex.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.brain import VisualCortex, AuditoryCortex, SomatosensoryCortex
+
+
+def test_visual_cortex():
+    cortex = VisualCortex()
+    result = cortex.process("image data")
+    assert "edges" in result and "color" in result
+
+
+def test_auditory_cortex():
+    cortex = AuditoryCortex()
+    result = cortex.process("audio data")
+    assert "frequencies" in result and "interpretation" in result
+
+
+def test_somatosensory_cortex():
+    cortex = SomatosensoryCortex()
+    result = cortex.process("stimulus")
+    assert result == ["touch"]


### PR DESCRIPTION
## Summary
- add sensory_cortex module implementing Visual, Auditory, and Somatosensory cortex placeholders
- expose new cortex classes in brain package
- test cortex classes process sample inputs

## Testing
- `pytest tests/test_sensory_cortex.py`

------
https://chatgpt.com/codex/tasks/task_e_68c61baed250832f980cc093c05008d4