### PR TITLE
Add motor cortex module with planning and execution flow

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -1,7 +1,9 @@
 from .sensory_cortex import VisualCortex, AuditoryCortex, SomatosensoryCortex
+from .motor_cortex import MotorCortex
 
 __all__ = [
     "VisualCortex",
     "AuditoryCortex",
     "SomatosensoryCortex",
+    "MotorCortex",
 ]

--- a/modules/brain/motor_cortex.py
+++ b/modules/brain/motor_cortex.py
@@ -1,0 +1,45 @@
+class PrimaryMotor:
+    """Primary motor cortex responsible for executing motor commands."""
+
+    def execute(self, motor_command: str) -> str:
+        return f"executed {motor_command}"
+
+
+class PreMotorArea:
+    """Pre-motor area that plans movements based on intention."""
+
+    def plan(self, intention: str) -> str:
+        return f"plan for {intention}"
+
+
+class SupplementaryMotor:
+    """Supplementary motor area that coordinates complex movements."""
+
+    def organize(self, plan: str) -> str:
+        return f"organized {plan}"
+
+
+class MotorCortex:
+    """Motor cortex integrating multiple motor-related areas."""
+
+    def __init__(self, basal_ganglia=None, cerebellum=None):
+        self.primary_motor = PrimaryMotor()
+        self.premotor_area = PreMotorArea()
+        self.supplementary_motor = SupplementaryMotor()
+        self.basal_ganglia = basal_ganglia
+        self.cerebellum = cerebellum
+
+    def plan_movement(self, intention: str) -> str:
+        """Plan a movement based on an intention."""
+        plan = self.premotor_area.plan(intention)
+        plan = self.supplementary_motor.organize(plan)
+        if self.basal_ganglia:
+            plan = self.basal_ganglia.modulate(plan)
+        return plan
+
+    def execute_action(self, motor_command: str) -> str:
+        """Execute a motor command, optionally refined by the cerebellum."""
+        command = motor_command
+        if self.cerebellum:
+            command = self.cerebellum.fine_tune(command)
+        return self.primary_motor.execute(command)

--- a/tests/test_motor_cortex.py
+++ b/tests/test_motor_cortex.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.brain import MotorCortex
+
+
+class StubBasalGanglia:
+    def modulate(self, plan: str) -> str:
+        return plan + " modulated"
+
+
+class StubCerebellum:
+    def fine_tune(self, command: str) -> str:
+        return command + " tuned"
+
+
+def test_motor_cortex_plan_execute():
+    cortex = MotorCortex(basal_ganglia=StubBasalGanglia(), cerebellum=StubCerebellum())
+    plan = cortex.plan_movement("wave")
+    assert "modulated" in plan
+    result = cortex.execute_action(plan)
+    assert "executed" in result and "tuned" in result


### PR DESCRIPTION
## Summary
- implement motor cortex with primary, pre-motor, and supplementary areas
- add plan_movement and execute_action logic with optional BasalGanglia/Cerebellum hooks
- test planning-to-execution workflow

## Testing
- `pytest tests/test_motor_cortex.py tests/test_sensory_cortex.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c61c4c5710832f9bbf9192ac2dcaf7