### PR TITLE
Add cerebellum module and integrate with motor cortex

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -1,5 +1,6 @@
 from .sensory_cortex import VisualCortex, AuditoryCortex, SomatosensoryCortex
 from .motor_cortex import MotorCortex
+from .cerebellum import Cerebellum
 from .limbic import LimbicSystem
 
 __all__ = [
@@ -7,5 +8,6 @@ __all__ = [
     "AuditoryCortex",
     "SomatosensoryCortex",
     "MotorCortex",
+    "Cerebellum",
     "LimbicSystem",
 ]

--- a/modules/brain/cerebellum.py
+++ b/modules/brain/cerebellum.py
@@ -1,0 +1,36 @@
+class PurkinjeNetwork:
+    """Network of Purkinje cells for refining motor signals."""
+
+    def refine(self, signal: str) -> str:
+        """Refine incoming signals from granule network."""
+        return f"{signal} refined"
+
+
+class GranuleNetwork:
+    """Network of granule cells preprocessing inputs."""
+
+    def process(self, input_signal: str) -> str:
+        """Process incoming sensory or motor inputs."""
+        return f"processed {input_signal}"
+
+
+class Cerebellum:
+    """Simplified cerebellum coordinating motor control and learning."""
+
+    def __init__(self):
+        self.purkinje = PurkinjeNetwork()
+        self.granule = GranuleNetwork()
+
+    def fine_tune(self, motor_command: str) -> str:
+        """Refine motor commands for smoother execution."""
+        processed = self.granule.process(motor_command)
+        return self.purkinje.refine(processed)
+
+    def motor_learning(self, error_signal: str) -> str:
+        """Placeholder for motor learning based on error signals."""
+        return f"learned from {error_signal}"
+
+    def balance_control(self, sensory_input: str) -> str:
+        """Placeholder for balance control using sensory feedback."""
+        processed = self.granule.process(sensory_input)
+        return f"balance adjusted with {processed}"

--- a/modules/brain/motor_cortex.py
+++ b/modules/brain/motor_cortex.py
@@ -43,3 +43,9 @@ class MotorCortex:
         if self.cerebellum:
             command = self.cerebellum.fine_tune(command)
         return self.primary_motor.execute(command)
+
+    def train(self, error_signal: str) -> str:
+        """Adjust motor output based on feedback using the cerebellum."""
+        if self.cerebellum:
+            return self.cerebellum.motor_learning(error_signal)
+        return f"no cerebellum to learn from {error_signal}"

--- a/tests/test_cerebellum_integration.py
+++ b/tests/test_cerebellum_integration.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.brain import MotorCortex, Cerebellum
+
+
+def test_cerebellum_training_integration():
+    cerebellum = Cerebellum()
+    cortex = MotorCortex(cerebellum=cerebellum)
+    result = cortex.train("overshoot")
+    assert "learned" in result and "overshoot" in result
+    executed = cortex.execute_action("move")
+    assert "refined" in executed
+
+
+def test_balance_control_placeholder():
+    cerebellum = Cerebellum()
+    response = cerebellum.balance_control("tilt")
+    assert "balance adjusted" in response and "tilt" in response


### PR DESCRIPTION
## Summary
- implement cerebellum with Purkinje and Granule networks
- expose motor learning and balance control placeholders
- integrate cerebellum training interface with motor cortex and add tests

## Testing
- `pytest tests/test_motor_cortex.py tests/test_cerebellum_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68c61df2706c832f8826a5c39cf0f7d7