### PR TITLE
Add neural oscillations module and synchronization tests

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -2,6 +2,7 @@ from .sensory_cortex import VisualCortex, AuditoryCortex, SomatosensoryCortex
 from .motor_cortex import MotorCortex
 from .cerebellum import Cerebellum
 from .limbic import LimbicSystem
+from .oscillations import NeuralOscillations
 
 __all__ = [
     "VisualCortex",
@@ -10,4 +11,5 @@ __all__ = [
     "MotorCortex",
     "Cerebellum",
     "LimbicSystem",
+    "NeuralOscillations",
 ]

--- a/modules/brain/oscillations.py
+++ b/modules/brain/oscillations.py
@@ -1,0 +1,36 @@
+class NeuralOscillations:
+    """Simulate neural oscillatory generators.
+
+    Provides simple placeholders for alpha, beta, gamma and theta wave
+    generators that could be used to model synchronous neural activity.
+    """
+
+    class AlphaGenerator:
+        def bind(self, region: str) -> str:
+            """Bind alpha oscillations to a region."""
+            return f"{region} bound to alpha waves"
+
+    class BetaGenerator:
+        def bind(self, region: str) -> str:
+            """Bind beta oscillations to a region."""
+            return f"{region} bound to beta waves"
+
+    class GammaGenerator:
+        def bind(self, region: str) -> str:
+            """Bind gamma oscillations to a region."""
+            return f"{region} synchronized via gamma waves"
+
+    class ThetaGenerator:
+        def bind(self, region: str) -> str:
+            """Bind theta oscillations to a region."""
+            return f"{region} bound to theta waves"
+
+    def __init__(self) -> None:
+        self.alpha_waves = self.AlphaGenerator()
+        self.beta_waves = self.BetaGenerator()
+        self.gamma_waves = self.GammaGenerator()
+        self.theta_waves = self.ThetaGenerator()
+
+    def synchronize_regions(self, regions):
+        """Synchronize a list of regions using gamma oscillations."""
+        return [self.gamma_waves.bind(region) for region in regions]

--- a/tests/test_neural_oscillations.py
+++ b/tests/test_neural_oscillations.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.brain import NeuralOscillations
+
+
+def test_synchronize_regions():
+    oscillations = NeuralOscillations()
+    regions = ["hippocampus", "cortex"]
+    result = oscillations.synchronize_regions(regions)
+    expected = [f"{r} synchronized via gamma waves" for r in regions]
+    assert result == expected


### PR DESCRIPTION
## Summary
- add `NeuralOscillations` with alpha, beta, gamma, and theta generators
- expose new oscillation module in brain package
- test gamma wave synchronization across brain regions

## Testing
- `pytest tests/test_neural_oscillations.py`

------
https://chatgpt.com/codex/tasks/task_e_68c61ed1fe24832fa23d8105b9650131