### PR TITLE
Add consciousness model with salience-based broadcast

### DIFF
--- a/modules/brain/consciousness.py
+++ b/modules/brain/consciousness.py
@@ -1,0 +1,88 @@
+"""Simplified consciousness model components.
+
+This module implements a tiny collection of classes that mimic
+fundamental pieces of a cognitive architecture.  They are intentionally
+light‑weight and only provide behaviour required by the unit tests:
+
+``GlobalWorkspace``
+    Records broadcasts of salient information.
+``AttentionController``
+    Evaluates whether a piece of information is salient.
+``FeatureBinding``
+    Placeholder that returns the information unchanged.
+``ConsciousnessModel``
+    Integrates the above components and exposes ``conscious_access``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Dict
+
+
+class GlobalWorkspace:
+    """Minimal global workspace storing broadcasted messages."""
+
+    def __init__(self) -> None:
+        self.broadcasts: List[Any] = []
+
+    def broadcast(self, information: Any) -> None:
+        """Store *information* as having been broadcast."""
+        self.broadcasts.append(information)
+
+
+class AttentionController:
+    """Determine whether information is salient."""
+
+    def is_salient(self, information: Dict[str, Any]) -> bool:
+        """Return ``True`` if the ``information`` is marked salient."""
+        return bool(information.get("is_salient"))
+
+
+class FeatureBinding:
+    """Bind features of the information together.
+
+    For this simplified model the binding operation simply returns the
+    information unchanged.  The class exists to show how additional
+    processing stages might be chained in a more complete system.
+    """
+
+    def bind(self, information: Dict[str, Any]) -> Dict[str, Any]:
+        return information
+
+
+@dataclass
+class ConsciousnessModel:
+    """Toy model combining workspace, attention and feature binding."""
+
+    workspace: GlobalWorkspace = field(default_factory=GlobalWorkspace)
+    attention: AttentionController = field(default_factory=AttentionController)
+    binding: FeatureBinding = field(default_factory=FeatureBinding)
+
+    def conscious_access(self, information: Dict[str, Any]) -> bool:
+        """Process ``information`` and broadcast if it is salient.
+
+        Parameters
+        ----------
+        information:
+            Dictionary that should contain an ``"is_salient"`` boolean flag
+            alongside any payload under other keys.
+
+        Returns
+        -------
+        bool
+            ``True`` if the information was broadcast, otherwise ``False``.
+        """
+
+        bound = self.binding.bind(information)
+        if self.attention.is_salient(bound):
+            self.workspace.broadcast(bound)
+            return True
+        return False
+
+
+__all__ = [
+    "GlobalWorkspace",
+    "AttentionController",
+    "FeatureBinding",
+    "ConsciousnessModel",
+]

--- a/modules/tests/test_consciousness_model.py
+++ b/modules/tests/test_consciousness_model.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.consciousness import ConsciousnessModel
+
+
+def test_conscious_access_handles_salience() -> None:
+    model = ConsciousnessModel()
+
+    salient = {"data": "important", "is_salient": True}
+    non_salient = {"data": "trivial", "is_salient": False}
+
+    assert model.conscious_access(salient) is True
+    assert model.workspace.broadcasts == [salient]
+
+    assert model.conscious_access(non_salient) is False
+    # Broadcast log should remain unchanged after non-salient information
+    assert model.workspace.broadcasts == [salient]


### PR DESCRIPTION
## Summary
- implement simple consciousness model with global workspace, attention controller, and feature binding
- broadcast salient information through `conscious_access`
- add test covering salient vs non-salient information

## Testing
- `pytest modules/tests/test_consciousness_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68c61fe096b0832f9d1d47cc6f7ca280