### PR TITLE
feat: add refractory period and adaptive thresholds

### DIFF
--- a/tests/neuromorphic/test_spiking_network.py
+++ b/tests/neuromorphic/test_spiking_network.py
@@ -15,3 +15,34 @@ def test_spike_generation():
     spikes = network.run(inputs)
     expected = [(0, [0]), (1, [1]), (2, [0]), (3, [1])]
     assert spikes == expected
+
+
+def test_refractory_behavior():
+    neurons = SpikingNeuralNetwork.LeakyIntegrateFireNeurons(
+        n_neurons=1, decay=1.0, threshold=1.0, reset=0.0, refractory_period=2
+    )
+
+    assert neurons.step([1.1]) == [1]
+    assert neurons.step([1.1]) == [0]
+    assert neurons.step([1.1]) == [0]
+    assert neurons.step([1.1]) == [1]
+
+
+def test_dynamic_threshold_adaptation():
+    neurons = SpikingNeuralNetwork.LeakyIntegrateFireNeurons(
+        n_neurons=1,
+        decay=0.9,
+        threshold=1.0,
+        reset=0.0,
+        dynamic_threshold=0.5,
+    )
+
+    # Initial spike raises threshold
+    assert neurons.step([1.1]) == [1]
+    # Elevated threshold suppresses subsequent spike
+    assert neurons.step([1.1]) == [0]
+    # Allow adaptive threshold to decay
+    for _ in range(20):
+        neurons.step([0.0])
+    # Same input can trigger spike again after adaptation decays
+    assert neurons.step([1.1]) == [1]


### PR DESCRIPTION
## Summary
- extend LeakyIntegrateFireNeurons with refractory periods, dynamic thresholds, and noise injection
- update neuron stepping to handle refractory state and threshold adaptation
- add tests covering refractory behavior and threshold adaptation

## Testing
- `pytest tests/neuromorphic/test_spiking_network.py -q`
- `pytest tests/neuromorphic -q`


------
https://chatgpt.com/codex/tasks/task_e_68c628ba0140832f8ee26dd0f96765d2