### PR TITLE
feat: add neuromorphic whole brain processing

### DIFF
--- a/tests/brain/test_whole_brain_neuromorphic.py
+++ b/tests/brain/test_whole_brain_neuromorphic.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.brain import WholeBrainSimulation
+
+
+def test_whole_brain_neuromorphic_cycle():
+    brain = WholeBrainSimulation(neuromorphic=True)
+    input_data = {
+        "image": [0.9, 0.1],
+        "sound": [0.5],
+        "touch": [0.3, 0.7],
+        "text": "good",
+        "is_salient": True,
+    }
+    action = brain.process_cycle(input_data)
+    assert "executed" in action
+    assert brain.last_perception["vision"]["spike_counts"] == [1, 1]
+    assert brain.last_perception["audio"]["spike_counts"] == [1]
+    assert brain.last_perception["touch"]["spike_counts"] == [1, 1]


### PR DESCRIPTION
## Summary
- add optional neuromorphic mode to WholeBrainSimulation using latency encoding and a spiking neural network
- record spike-based perception features and expose last_perception
- test full perception→decision→action flow in neuromorphic mode

## Testing
- `pytest tests/brain/test_whole_brain_neuromorphic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c632e39ba4832f8d135ed8d59b408f