### PR TITLE
feat: add spiking backend support

### DIFF
--- a/modules/brain/motor_cortex.py
+++ b/modules/brain/motor_cortex.py
@@ -22,12 +22,13 @@ class SupplementaryMotor:
 class MotorCortex:
     """Motor cortex integrating multiple motor-related areas."""
 
-    def __init__(self, basal_ganglia=None, cerebellum=None):
+    def __init__(self, basal_ganglia=None, cerebellum=None, spiking_backend=None):
         self.primary_motor = PrimaryMotor()
         self.premotor_area = PreMotorArea()
         self.supplementary_motor = SupplementaryMotor()
         self.basal_ganglia = basal_ganglia
         self.cerebellum = cerebellum
+        self.spiking_backend = spiking_backend
 
     def plan_movement(self, intention: str) -> str:
         """Plan a movement based on an intention."""
@@ -37,8 +38,14 @@ class MotorCortex:
             plan = self.basal_ganglia.modulate(plan)
         return plan
 
-    def execute_action(self, motor_command: str) -> str:
-        """Execute a motor command, optionally refined by the cerebellum."""
+    def execute_action(self, motor_command: str):
+        """Execute a motor command, optionally using a spiking backend."""
+        if self.spiking_backend and isinstance(motor_command, (list, tuple)):
+            spikes = self.spiking_backend.run(motor_command)
+            self.spiking_backend.synapses.adapt(
+                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+            )
+            return spikes
         command = motor_command
         if self.cerebellum:
             command = self.cerebellum.fine_tune(command)

--- a/modules/brain/sensory_cortex.py
+++ b/modules/brain/sensory_cortex.py
@@ -31,13 +31,20 @@ class MT:
 class VisualCortex:
     """Visual cortex with hierarchical processing areas."""
 
-    def __init__(self):
+    def __init__(self, spiking_backend=None):
         self.v1 = V1()
         self.v2 = V2()
         self.v4 = V4()
         self.mt = MT()
+        self.spiking_backend = spiking_backend
 
     def process(self, image):
+        if self.spiking_backend:
+            spikes = self.spiking_backend.run(image)
+            self.spiking_backend.synapses.adapt(
+                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+            )
+            return spikes
         return {
             "edges": self.v1.process(image),
             "form": self.v2.process(image),
@@ -69,11 +76,18 @@ class A2:
 class AuditoryCortex:
     """Auditory cortex with primary and secondary areas."""
 
-    def __init__(self):
+    def __init__(self, spiking_backend=None):
         self.a1 = A1()
         self.a2 = A2()
+        self.spiking_backend = spiking_backend
 
     def process(self, sound):
+        if self.spiking_backend:
+            spikes = self.spiking_backend.run(sound)
+            self.spiking_backend.synapses.adapt(
+                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+            )
+            return spikes
         return {
             "frequencies": self.a1.process(sound),
             "interpretation": self.a2.process(sound),
@@ -90,8 +104,15 @@ class TouchProcessor:
 class SomatosensoryCortex:
     """Somatosensory cortex for processing tactile information."""
 
-    def __init__(self):
+    def __init__(self, spiking_backend=None):
         self.processor = TouchProcessor()
+        self.spiking_backend = spiking_backend
 
     def process(self, stimulus):
+        if self.spiking_backend:
+            spikes = self.spiking_backend.run(stimulus)
+            self.spiking_backend.synapses.adapt(
+                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+            )
+            return spikes
         return self.processor.process(stimulus)

--- a/tests/test_motor_cortex.py
+++ b/tests/test_motor_cortex.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from modules.brain import MotorCortex
+from modules.brain.neuromorphic.spiking_network import SpikingNeuralNetwork
 
 
 class StubBasalGanglia:
@@ -22,3 +23,11 @@ def test_motor_cortex_plan_execute():
     assert "modulated" in plan
     result = cortex.execute_action(plan)
     assert "executed" in result and "tuned" in result
+
+
+def test_motor_cortex_spiking_backend():
+    snn = SpikingNeuralNetwork(2, weights=[[0.0, 1.0], [0.0, 0.0]])
+    initial = snn.synapses.weights[0][1]
+    cortex = MotorCortex(spiking_backend=snn)
+    cortex.execute_action([[1, 0], [0, 1]])
+    assert snn.synapses.weights[0][1] != initial

--- a/tests/test_sensory_cortex.py
+++ b/tests/test_sensory_cortex.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from modules.brain import VisualCortex, AuditoryCortex, SomatosensoryCortex
+from modules.brain.neuromorphic.spiking_network import SpikingNeuralNetwork
 
 
 def test_visual_cortex():
@@ -22,3 +23,11 @@ def test_somatosensory_cortex():
     cortex = SomatosensoryCortex()
     result = cortex.process("stimulus")
     assert result == ["touch"]
+
+
+def test_visual_cortex_spiking_backend():
+    snn = SpikingNeuralNetwork(2, weights=[[0.0, 1.0], [0.0, 0.0]])
+    initial = snn.synapses.weights[0][1]
+    cortex = VisualCortex(spiking_backend=snn)
+    cortex.process([[1, 0], [0, 1]])
+    assert snn.synapses.weights[0][1] != initial


### PR DESCRIPTION
## Summary
- allow sensory and motor cortex modules to accept optional spiking backend
- integrate event-driven processing and STDP adaptation via DynamicSynapses
- add tests exercising perception and action with spiking backend

## Testing
- `pytest tests/test_sensory_cortex.py tests/test_motor_cortex.py -q`
- `pytest -q` *(fails: No module named 'algorithms')*


------
https://chatgpt.com/codex/tasks/task_e_68c635827fac832f9b594d5233d00140