### PR TITLE
feat: add realistic neural oscillations with coupling

### DIFF
--- a/modules/brain/oscillations.py
+++ b/modules/brain/oscillations.py
@@ -1,29 +1,120 @@
-class NeuralOscillations:
-    """Simulate neural oscillatory generators.
+import numpy as np
+from dataclasses import dataclass
+from typing import Optional
 
-    Provides simple placeholders for alpha, beta, gamma and theta wave
-    generators that could be used to model synchronous neural activity.
-    """
+
+@dataclass
+class Wave:
+    """Represents a bound oscillatory wave."""
+
+    region: str
+    frequency: float
+    phase: float
+    data: np.ndarray
+
+
+class NeuralOscillations:
+    """Simulate neural oscillatory generators with basic waveform support."""
 
     class AlphaGenerator:
-        def bind(self, region: str) -> str:
-            """Bind alpha oscillations to a region."""
-            return f"{region} bound to alpha waves"
+        def generate_wave(
+            self,
+            frequency: float = 10.0,
+            duration: float = 1.0,
+            phase: float = 0.0,
+            sample_rate: int = 1000,
+        ) -> np.ndarray:
+            t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+            return np.sin(2 * np.pi * frequency * t + phase)
+
+        def bind(
+            self,
+            region: str,
+            frequency: float = 10.0,
+            phase: float = 0.0,
+            duration: float = 1.0,
+            sample_rate: int = 1000,
+            lock_to: Optional[Wave] = None,
+        ) -> Wave:
+            if lock_to is not None:
+                phase = lock_to.phase
+            data = self.generate_wave(frequency, duration, phase, sample_rate)
+            return Wave(region, frequency, phase, data)
 
     class BetaGenerator:
-        def bind(self, region: str) -> str:
-            """Bind beta oscillations to a region."""
-            return f"{region} bound to beta waves"
+        def generate_wave(
+            self,
+            frequency: float = 20.0,
+            duration: float = 1.0,
+            phase: float = 0.0,
+            sample_rate: int = 1000,
+        ) -> np.ndarray:
+            t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+            return np.sin(2 * np.pi * frequency * t + phase)
+
+        def bind(
+            self,
+            region: str,
+            frequency: float = 20.0,
+            phase: float = 0.0,
+            duration: float = 1.0,
+            sample_rate: int = 1000,
+            lock_to: Optional[Wave] = None,
+        ) -> Wave:
+            if lock_to is not None:
+                phase = lock_to.phase
+            data = self.generate_wave(frequency, duration, phase, sample_rate)
+            return Wave(region, frequency, phase, data)
 
     class GammaGenerator:
-        def bind(self, region: str) -> str:
-            """Bind gamma oscillations to a region."""
-            return f"{region} synchronized via gamma waves"
+        def generate_wave(
+            self,
+            frequency: float = 40.0,
+            duration: float = 1.0,
+            phase: float = 0.0,
+            sample_rate: int = 1000,
+        ) -> np.ndarray:
+            t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+            return np.sin(2 * np.pi * frequency * t + phase)
+
+        def bind(
+            self,
+            region: str,
+            frequency: float = 40.0,
+            phase: float = 0.0,
+            duration: float = 1.0,
+            sample_rate: int = 1000,
+            lock_to: Optional[Wave] = None,
+        ) -> Wave:
+            if lock_to is not None:
+                phase = lock_to.phase
+            data = self.generate_wave(frequency, duration, phase, sample_rate)
+            return Wave(region, frequency, phase, data)
 
     class ThetaGenerator:
-        def bind(self, region: str) -> str:
-            """Bind theta oscillations to a region."""
-            return f"{region} bound to theta waves"
+        def generate_wave(
+            self,
+            frequency: float = 6.0,
+            duration: float = 1.0,
+            phase: float = 0.0,
+            sample_rate: int = 1000,
+        ) -> np.ndarray:
+            t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+            return np.sin(2 * np.pi * frequency * t + phase)
+
+        def bind(
+            self,
+            region: str,
+            frequency: float = 6.0,
+            phase: float = 0.0,
+            duration: float = 1.0,
+            sample_rate: int = 1000,
+            lock_to: Optional[Wave] = None,
+        ) -> Wave:
+            if lock_to is not None:
+                phase = lock_to.phase
+            data = self.generate_wave(frequency, duration, phase, sample_rate)
+            return Wave(region, frequency, phase, data)
 
     def __init__(self) -> None:
         self.alpha_waves = self.AlphaGenerator()
@@ -31,6 +122,38 @@ class NeuralOscillations:
         self.gamma_waves = self.GammaGenerator()
         self.theta_waves = self.ThetaGenerator()
 
-    def synchronize_regions(self, regions):
-        """Synchronize a list of regions using gamma oscillations."""
-        return [self.gamma_waves.bind(region) for region in regions]
+    def synchronize_regions(
+        self,
+        regions,
+        frequency: float = 40.0,
+        phase: float = 0.0,
+        duration: float = 1.0,
+        sample_rate: int = 1000,
+    ):
+        """Synchronize a list of regions using gamma oscillations with phase locking."""
+        if not regions:
+            return []
+        reference = self.gamma_waves.bind(
+            regions[0], frequency=frequency, phase=phase, duration=duration, sample_rate=sample_rate
+        )
+        bindings = [reference]
+        for region in regions[1:]:
+            bindings.append(
+                self.gamma_waves.bind(
+                    region,
+                    frequency=frequency,
+                    duration=duration,
+                    sample_rate=sample_rate,
+                    lock_to=reference,
+                )
+            )
+        return bindings
+
+    @staticmethod
+    def oscillatory_modulation(carrier_wave: np.ndarray, modulator_wave: np.ndarray) -> np.ndarray:
+        """Amplitude modulation of a carrier wave using a modulating wave."""
+        return carrier_wave * (1 + modulator_wave)
+
+    def cross_frequency_coupling(self, low_wave: np.ndarray, high_wave: np.ndarray) -> np.ndarray:
+        """Simple cross-frequency coupling via phase-amplitude modulation."""
+        return self.oscillatory_modulation(high_wave, low_wave)

--- a/tests/test_neural_oscillations.py
+++ b/tests/test_neural_oscillations.py
@@ -10,5 +10,23 @@ def test_synchronize_regions():
     oscillations = NeuralOscillations()
     regions = ["hippocampus", "cortex"]
     result = oscillations.synchronize_regions(regions)
-    expected = [f"{r} synchronized via gamma waves" for r in regions]
-    assert result == expected
+    assert [w.region for w in result] == regions
+    assert all(w.frequency == 40.0 for w in result)
+    assert len({w.phase for w in result}) == 1  # phase locked
+
+
+def test_phase_locking():
+    oscillations = NeuralOscillations()
+    wave1 = oscillations.alpha_waves.bind("r1", frequency=10.0, phase=0.5)
+    wave2 = oscillations.alpha_waves.bind("r2", frequency=10.0, lock_to=wave1)
+    assert wave2.phase == wave1.phase
+
+
+def test_cross_frequency_coupling_and_modulation():
+    oscillations = NeuralOscillations()
+    low = oscillations.theta_waves.generate_wave(frequency=6.0, duration=1.0, phase=0.0)
+    high = oscillations.gamma_waves.generate_wave(frequency=40.0, duration=1.0, phase=0.0)
+    coupled = oscillations.cross_frequency_coupling(low, high)
+    modulated = oscillations.oscillatory_modulation(high, low)
+    assert coupled.shape == low.shape == high.shape
+    assert modulated.shape == high.shape


### PR DESCRIPTION
## Summary
- generate realistic sine-wave oscillations for alpha, beta, gamma, and theta bands
- return bound wave objects with frequency/phase and support phase locking
- expose cross-frequency coupling and oscillatory modulation utilities

## Testing
- `python -m pytest tests/test_neural_oscillations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65ae1c940832f89cbfe33a2e06534