### PR TITLE
feat(events): introduce AsyncEventBus with coroutine handlers

### DIFF
--- a/backend/capability/runtime_loader.py
+++ b/backend/capability/runtime_loader.py
@@ -32,7 +32,7 @@ class RuntimeModuleManager:
     # ------------------------------------------------------------------
     # Event handlers
     # ------------------------------------------------------------------
-    def _on_request(self, event: Dict[str, Any]) -> None:
+    async def _on_request(self, event: Dict[str, Any]) -> None:
         name = event.get("module")
         if not isinstance(name, str):
             return
@@ -40,7 +40,7 @@ class RuntimeModuleManager:
         if self._bus:
             self._bus.publish("module.loaded", {"module": name})
 
-    def _on_release(self, event: Dict[str, Any]) -> None:
+    async def _on_release(self, event: Dict[str, Any]) -> None:
         name = event.get("module")
         if not isinstance(name, str):
             return

--- a/backend/execution/coordinator.py
+++ b/backend/execution/coordinator.py
@@ -29,7 +29,7 @@ class AgentCoordinator:
         event = TaskDispatchEvent(task_id=task_id, payload=payload, assigned_to=agent_id)
         self._bus.publish("task.dispatch", event.to_dict())
 
-    def _on_status(self, event: Dict[str, Any]) -> None:
+    async def _on_status(self, event: Dict[str, Any]) -> None:
         status = event.get("status")
         if status == TaskStatus.COMPLETED.value:
             self._bus.publish("coordinator.task_completed", event)

--- a/backend/execution/manager.py
+++ b/backend/execution/manager.py
@@ -98,7 +98,7 @@ class AgentLifecycleManager:
             "agent.state", {"agent": name, "state": state.value, "time": time.time()}
         )
 
-    def _on_heartbeat(self, event: Dict[str, Any]) -> None:
+    async def _on_heartbeat(self, event: Dict[str, Any]) -> None:
         name = event.get("agent")
         if not name:
             return
@@ -276,7 +276,7 @@ class AgentLifecycleManager:
         )
 
     # ------------------------------------------------------------------
-    def _on_resource_event(self, event: Dict[str, float]) -> None:
+    async def _on_resource_event(self, event: Dict[str, float]) -> None:
         name = event.get("agent")
         if name not in self._resources:
             return

--- a/backend/founder_agent/analytics.py
+++ b/backend/founder_agent/analytics.py
@@ -16,7 +16,7 @@ class Analytics:
             lambda: deque(maxlen=window)
         )
 
-    def handle_event(self, event: Dict[str, float]) -> None:
+    async def handle_event(self, event: Dict[str, float]) -> None:
         """Process incoming metric event."""
         for key, value in event.items():
             if isinstance(value, (int, float)):

--- a/backend/ml/retraining_pipeline.py
+++ b/backend/ml/retraining_pipeline.py
@@ -43,7 +43,7 @@ HISTORY_FIELDS = [
     "status",
 ]
 
-event_bus = create_event_bus("inmemory")
+event_bus = create_event_bus()
 
 # Additional metrics considered during deployment comparison. ``direction``
 # specifies whether higher values are better ("higher") or lower values are

--- a/backend/monitoring/metrics_collector.py
+++ b/backend/monitoring/metrics_collector.py
@@ -25,10 +25,10 @@ class MetricsCollector:
         )
 
     # ------------------------------------------------------------------
-    def _store_lifecycle(self, event: dict) -> None:
+    async def _store_lifecycle(self, event: dict) -> None:
         self.storage.store("agent.lifecycle", event)
 
-    def _store_resource(self, event: dict) -> None:
+    async def _store_resource(self, event: dict) -> None:
         self.storage.store("agent.resource", event)
 
     # ------------------------------------------------------------------

--- a/backend/monitoring/storage.py
+++ b/backend/monitoring/storage.py
@@ -60,7 +60,10 @@ class TimeSeriesStorage:
     def subscribe_to(self, bus: EventBus, topics: Iterable[str]) -> None:
         """Subscribe to *topics* on *bus* and persist events."""
         for topic in topics:
-            cancel = bus.subscribe(topic, lambda e, t=topic: self.store(t, e))
+            async def _store(event: Dict[str, Any], t: str = topic) -> None:
+                self.store(t, event)
+
+            cancel = bus.subscribe(topic, _store)
             self._subscriptions.append(cancel)
 
     # ------------------------------------------------------------------

--- a/backend/runner/streaming.py
+++ b/backend/runner/streaming.py
@@ -27,10 +27,14 @@ class StreamingDataIngestor:
         topic: str = "training.sample",
         sampler: ActiveLearningSampler | None = None,
     ) -> None:
-        self.bus = bus or create_event_bus("inmemory")
+        self.bus = bus or create_event_bus()
         self.topic = topic
         self.queue: Queue[Dict[str, Any]] = Queue()
-        self.bus.subscribe(topic, self.queue.put)
+
+        async def _enqueue(event: Dict[str, Any]) -> None:
+            self.queue.put(event)
+
+        self.bus.subscribe(topic, _enqueue)
         self.sampler = sampler
 
     def drain(self) -> List[Dict[str, Any]]:

--- a/modules/events/client.py
+++ b/modules/events/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict
 
 from . import EventBus
 
@@ -21,11 +21,11 @@ class EventClient:
         self._bus.publish(topic, event)
 
     def subscribe(
-        self, topic: str, handler: Callable[[Dict[str, Any]], None]
+        self, topic: str, handler: Callable[[Dict[str, Any]], Awaitable[None]]
     ) -> Callable[[], None]:
         return self._bus.subscribe(topic, handler)
 
     def unsubscribe(
-        self, topic: str, handler: Callable[[Dict[str, Any]], None]
+        self, topic: str, handler: Callable[[Dict[str, Any]], Awaitable[None]]
     ) -> None:
         self._bus.unsubscribe(topic, handler)


### PR DESCRIPTION
## Summary
- add AsyncEventBus using `asyncio.Queue` and `create_task`
- make subscription handlers coroutine-based and manage subscribers with `asyncio.Lock`
- default to AsyncEventBus while keeping threaded InMemoryEventBus as fallback

## Testing
- `pytest` *(fails: 67 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c65ae46274832f8dca43c1c523a93e