### PR TITLE
feat: add quantum decision, entanglement and memory utilities

### DIFF
--- a/docs/quantum_cognition_features.md
+++ b/docs/quantum_cognition_features.md
@@ -1,0 +1,38 @@
+# Quantum cognition features
+
+This document demonstrates the lightweight quantum cognition helpers used for
+unit testing.  They do **not** aim to be physically accurate simulations but
+provide minimal behaviour for experiments.
+
+## Quantum decision making
+
+```python
+from modules.brain.quantum.quantum_cognition import QuantumCognition
+
+qc = QuantumCognition()
+choice, probs = qc.make_decision({
+    "A": [0.5, 0.5],
+    "B": [0.5, -0.5],
+})
+# choice == "A", destructive interference removes option B
+```
+
+## Concept entanglement with decoherence
+
+```python
+from modules.brain.quantum.quantum_cognition import EntanglementNetwork
+
+network = EntanglementNetwork()
+density = network.entangle_concepts("cat", "hat", decoherence=0.3)
+```
+
+## Quantum memory
+
+```python
+from modules.brain.quantum.quantum_cognition import QuantumMemory, SuperpositionState
+
+memory = QuantumMemory()
+memory.store("A", SuperpositionState({"0": 1}))
+memory.store("B", SuperpositionState({"1": 1}))
+combined = memory.superposition({"A": 1/2**0.5, "B": 1/2**0.5})
+```

--- a/modules/brain/quantum/quantum_cognition.py
+++ b/modules/brain/quantum/quantum_cognition.py
@@ -12,17 +12,20 @@ SuperpositionState
     Stores complex amplitudes for basis states and exposes utilities to
     obtain probabilities or a density matrix representation.
 EntanglementNetwork
-    Produces a small set of predefined entangled states used by the tests.
+    Produces a small set of predefined entangled states used by the tests and
+    exposes :meth:`entangle_concepts` for simple decoherence simulations.
+QuantumMemory
+    Minimal in-memory store allowing superposition based retrieval.
 QuantumCognition
-    High level interface exposing :meth:`evaluate_probabilities` which can
-    operate on either :class:`SuperpositionState` instances or density
-    matrices.
+    High level interface exposing :meth:`evaluate_probabilities` and
+    :meth:`make_decision` which can operate on either
+    :class:`SuperpositionState` instances or density matrices.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 import math
-from typing import Dict, Union
+from typing import Dict, Iterable, Mapping, Union
 
 import numpy as np
 
@@ -67,6 +70,59 @@ class EntanglementNetwork:
         # Include the full two-qubit computational basis with zero amplitudes
         return SuperpositionState({"00": amp, "01": 0, "10": 0, "11": amp})
 
+    def entangle_concepts(
+        self, concept_a: str, concept_b: str, decoherence: float = 0.0
+    ) -> np.ndarray:
+        """Return density matrix for two entangled *concepts*.
+
+        Parameters
+        ----------
+        concept_a, concept_b:
+            Names of the concepts being entangled.  The names are currently
+            only informational but mirror a potential semantic mapping.
+        decoherence:
+            Value in ``[0, 1]`` representing how much the off-diagonal terms
+            of the Bell state's density matrix are damped.  ``0`` corresponds
+            to a pure Bell pair while ``1`` yields a fully decohered mixed
+            state.
+        """
+
+        density = self.create_bell_pair().density_matrix()
+        if decoherence:
+            density = density.copy()
+            factor = 1 - decoherence
+            density[0, 3] *= factor
+            density[3, 0] *= factor
+        return density
+
+
+@dataclass
+class QuantumMemory:
+    """Simple storage for :class:`SuperpositionState` objects.
+
+    The memory can retrieve classical states or superpositions across stored
+    entries by supplying amplitude weights.
+    """
+
+    storage: Dict[str, SuperpositionState]
+
+    def __init__(self) -> None:
+        self.storage = {}
+
+    def store(self, key: str, state: SuperpositionState) -> None:
+        self.storage[key] = state
+
+    def retrieve(self, key: str) -> SuperpositionState:
+        return self.storage[key]
+
+    def superposition(self, weights: Mapping[str, complex]) -> SuperpositionState:
+        combined: Dict[str, complex] = {}
+        for key, amp in weights.items():
+            state = self.storage[key]
+            for basis, value in state.amplitudes.items():
+                combined[basis] = combined.get(basis, 0) + amp * value
+        return SuperpositionState(combined)
+
 
 class QuantumCognition:
     """High level interface for evaluating quantum cognitive states."""
@@ -95,5 +151,33 @@ class QuantumCognition:
         labels = [format(i, f"0{num_qubits}b") for i in range(size)]
         return {label: float(diag[i]) for i, label in enumerate(labels)}
 
+    def make_decision(
+        self,
+        options: Mapping[str, Iterable[complex]],
+        rng: np.random.Generator | None = None,
+    ) -> tuple[str, Dict[str, float]]:
+        """Perform a quantum-style decision over *options*.
 
-__all__ = ["SuperpositionState", "EntanglementNetwork", "QuantumCognition"]
+        ``options`` maps each label to a collection of amplitudes which are
+        summed to produce interference effects.  The squared magnitudes of
+        the resulting amplitudes yield the decision probabilities.  The
+        selected option and the probability distribution are returned.
+        """
+
+        amps = {label: sum(values) for label, values in options.items()}
+        norm = math.sqrt(sum(abs(a) ** 2 for a in amps.values()))
+        if not np.isclose(norm, 1):
+            amps = {k: v / norm for k, v in amps.items()}
+        labels = list(amps.keys())
+        probs = [float(abs(a) ** 2) for a in amps.values()]
+        generator = rng or np.random.default_rng()
+        choice = generator.choice(labels, p=probs)
+        return choice, {label: prob for label, prob in zip(labels, probs)}
+
+
+__all__ = [
+    "SuperpositionState",
+    "EntanglementNetwork",
+    "QuantumMemory",
+    "QuantumCognition",
+]

--- a/tests/quantum/test_quantum_cognition.py
+++ b/tests/quantum/test_quantum_cognition.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".
 
 from modules.brain.quantum.quantum_cognition import (
     EntanglementNetwork,
+    QuantumMemory,
     QuantumCognition,
     SuperpositionState,
 )
@@ -33,3 +34,36 @@ def test_entangled_density_matrix_probabilities():
     assert probs["11"] == pytest.approx(0.5, rel=1e-6)
     assert probs["01"] == pytest.approx(0.0, abs=1e-6)
     assert probs["10"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_make_decision_interference():
+    qc = QuantumCognition()
+    choice, probs = qc.make_decision(
+        {
+            "A": [0.5, 0.5],
+            "B": [0.5, -0.5],
+        }
+    )
+    assert choice == "A"
+    assert probs["A"] == pytest.approx(1.0, abs=1e-6)
+    assert probs["B"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_entangle_concepts_decoherence():
+    network = EntanglementNetwork()
+    density = network.entangle_concepts("cat", "hat", decoherence=0.5)
+    qc = QuantumCognition()
+    probs = qc.evaluate_probabilities(density)
+    assert probs["00"] == pytest.approx(0.5, rel=1e-6)
+    assert density[0, 3] == pytest.approx(0.25, rel=1e-6)
+
+
+def test_quantum_memory_superposition():
+    memory = QuantumMemory()
+    memory.store("A", SuperpositionState({"0": 1}))
+    memory.store("B", SuperpositionState({"1": 1}))
+    combined = memory.superposition({"A": 1 / np.sqrt(2), "B": 1 / np.sqrt(2)})
+    qc = QuantumCognition()
+    probs = qc.evaluate_probabilities(combined)
+    assert probs["0"] == pytest.approx(0.5, rel=1e-6)
+    assert probs["1"] == pytest.approx(0.5, rel=1e-6)


### PR DESCRIPTION
## Summary
- add `make_decision` for amplitude-based quantum decision making
- allow concept entanglement with optional decoherence simulation
- introduce simple quantum memory and accompanying documentation

## Testing
- `pytest tests/quantum/test_quantum_cognition.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c65aec5e74832fb971724d3a0f28f6