### PR TITLE
Implement plugin loading from paths and add tests

### DIFF
--- a/backend/autogpt/autogpt/core/plugin/simple.py
+++ b/backend/autogpt/autogpt/core/plugin/simple.py
@@ -1,4 +1,8 @@
 from importlib import import_module
+import importlib.util
+from pathlib import Path
+import tempfile
+import zipfile
 from typing import TYPE_CHECKING
 
 from autogpt.core.plugin.base import (
@@ -13,6 +17,16 @@ if TYPE_CHECKING:
 
 
 class SimplePluginService(PluginService):
+    """Simple plugin service implementation.
+
+    This service provides minimal functionality for loading plugin classes from
+    either the local workspace or from installed python packages.
+    """
+
+    # Default search locations
+    WORKSPACE_PLUGIN_DIR = Path(__file__).resolve().parents[3] / "plugins"
+    CORE_PLUGIN_PACKAGE = "autogpt.plugins"
+    EXTERNAL_PLUGIN_PACKAGE = "auto_gpt_plugins"
     @staticmethod
     def get_plugin(plugin_location: dict | PluginLocation) -> "PluginType":
         """Get a plugin from a plugin location."""
@@ -37,10 +51,51 @@ class SimplePluginService(PluginService):
     ####################################
     @staticmethod
     def load_from_file_path(plugin_route: PluginStorageRoute) -> "PluginType":
-        """Load a plugin from a file path."""
-        # TODO: Define an on disk storage format and implement this.
-        #   Can pull from existing zip file loading implementation
-        raise NotImplementedError("Loading from file path is not implemented.")
+        """Load a plugin from a file, directory, or zip archive.
+
+        The file path may point to a Python file, a directory containing an
+        ``__init__.py`` (i.e. a package), or a ``.zip`` archive with python
+        sources. The first class defined in the module will be returned.
+        """
+
+        path = Path(plugin_route)
+        if not path.exists():
+            raise FileNotFoundError(f"Plugin path '{plugin_route}' does not exist")
+
+        if path.is_file() and path.suffix == ".zip":
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with zipfile.ZipFile(path) as zf:
+                    zf.extractall(tmpdir)
+                module_path = next(Path(tmpdir).rglob("*.py"), None)
+                if module_path is None:
+                    raise ImportError("No python modules found in plugin archive")
+                spec = importlib.util.spec_from_file_location(
+                    module_path.stem, module_path
+                )
+                module = importlib.util.module_from_spec(spec)
+                assert spec.loader is not None
+                spec.loader.exec_module(module)
+        elif path.is_dir():
+            init_file = path / "__init__.py"
+            if not init_file.exists():
+                raise FileNotFoundError(
+                    f"Plugin directory '{plugin_route}' missing __init__.py"
+                )
+            spec = importlib.util.spec_from_file_location(path.name, init_file)
+            module = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            spec.loader.exec_module(module)
+        else:
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            module = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            spec.loader.exec_module(module)
+
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if isinstance(obj, type):
+                return obj
+        raise ImportError("No class found in plugin module")
 
     @staticmethod
     def load_from_import_path(plugin_route: PluginStorageRoute) -> "PluginType":
@@ -52,12 +107,42 @@ class SimplePluginService(PluginService):
     def resolve_name_to_path(
         plugin_route: PluginStorageRoute, path_type: str
     ) -> PluginStorageRoute:
-        """Resolve a plugin name to a plugin path."""
-        # TODO: Implement a discovery system for finding plugins by name from known
-        #   storage locations. E.g. if we know that path_type is a file path, we can
-        #   search the workspace for it. If it's an import path, we can check the core
-        #   system and the auto_gpt_plugins package.
-        raise NotImplementedError("Resolving plugin name to path is not implemented.")
+        """Resolve a plugin name to a storage route.
+
+        This searches, in order, the workspace directory, the built-in AutoGPT
+        plugin package, and the optional ``auto_gpt_plugins`` package.
+        """
+
+        name = plugin_route
+
+        # Workspace search
+        workspace = SimplePluginService.WORKSPACE_PLUGIN_DIR
+        candidates = [
+            workspace / name,
+            workspace / f"{name}.py",
+            workspace / f"{name}.zip",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+
+        # Core plugin package
+        core_module = f"{SimplePluginService.CORE_PLUGIN_PACKAGE}.{name}"
+        try:
+            if importlib.util.find_spec(core_module):
+                return core_module
+        except ModuleNotFoundError:
+            pass
+
+        # External plugin package
+        ext_module = f"{SimplePluginService.EXTERNAL_PLUGIN_PACKAGE}.{name}"
+        try:
+            if importlib.util.find_spec(ext_module):
+                return ext_module
+        except ModuleNotFoundError:
+            pass
+
+        raise FileNotFoundError(f"Plugin '{name}' not found")
 
     #####################################
     # High-level storage format loaders #

--- a/tests/backend/autogpt/autogpt/core/plugin/test_simple.py
+++ b/tests/backend/autogpt/autogpt/core/plugin/test_simple.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.getcwd(), "backend", "autogpt"))
+from autogpt.core.plugin.simple import SimplePluginService
+
+
+def _write_plugin(path: Path, class_name: str = "MyPlugin") -> None:
+    path.write_text(f"class {class_name}:\n    pass\n")
+
+
+def test_load_from_file_path_py(tmp_path):
+    plugin_file = tmp_path / "my_plugin.py"
+    _write_plugin(plugin_file, "MyPlugin")
+    plugin_cls = SimplePluginService.load_from_file_path(str(plugin_file))
+    assert plugin_cls.__name__ == "MyPlugin"
+
+
+def test_load_from_file_path_zip(tmp_path):
+    source = tmp_path / "plug.py"
+    _write_plugin(source, "ZipPlugin")
+    zip_path = tmp_path / "plugin.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(source, arcname="plug.py")
+    plugin_cls = SimplePluginService.load_from_file_path(str(zip_path))
+    assert plugin_cls.__name__ == "ZipPlugin"
+
+
+def test_load_from_file_path_directory(tmp_path):
+    pkg = tmp_path / "dirplug"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("class DirPlugin:\n    pass\n")
+    plugin_cls = SimplePluginService.load_from_file_path(str(pkg))
+    assert plugin_cls.__name__ == "DirPlugin"
+
+
+def test_resolve_name_to_path_workspace(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    plugin_file = workspace / "my_plugin.py"
+    _write_plugin(plugin_file)
+    monkeypatch.setattr(SimplePluginService, "WORKSPACE_PLUGIN_DIR", workspace)
+    path = SimplePluginService.resolve_name_to_path("my_plugin", "file")
+    assert path == str(plugin_file)
+
+
+def test_resolve_name_to_path_core(tmp_path, monkeypatch):
+    root = tmp_path / "my_core" / "plugins"
+    root.mkdir(parents=True)
+    (root.parent / "__init__.py").write_text("")
+    (root / "__init__.py").write_text("")
+    (root / "dummycore.py").write_text("")
+    sys.path.insert(0, str(tmp_path))
+    monkeypatch.setattr(SimplePluginService, "CORE_PLUGIN_PACKAGE", "my_core.plugins")
+    try:
+        path = SimplePluginService.resolve_name_to_path("dummycore", "import")
+        assert path == "my_core.plugins.dummycore"
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_resolve_name_to_path_auto_package(tmp_path):
+    pkg_root = tmp_path / "auto_gpt_plugins"
+    pkg_root.mkdir()
+    (pkg_root / "__init__.py").write_text("")
+    (pkg_root / "dummy.py").write_text("")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        path = SimplePluginService.resolve_name_to_path("dummy", "import")
+        assert path == "auto_gpt_plugins.dummy"
+    finally:
+        sys.path.remove(str(tmp_path))


### PR DESCRIPTION
## Summary
- support loading plugin classes from python files, directories, or zip archives
- resolve plugin names across workspace, core package, and external auto_gpt_plugins
- add comprehensive unit tests for simple plugin service

## Testing
- `pytest tests/backend/autogpt/autogpt/core/plugin/test_simple.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66391a12c832fb6547438cb4235af