### PR TITLE
Add sum logic to TemplateAlgorithm with tests and docs

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -48,6 +48,22 @@ algorithms/
 
 Use `template.py` as a starting point for new algorithm implementations.
 
+### Template Algorithm Example
+
+The provided `TemplateAlgorithm` demonstrates the expected interface. It
+expects a list of numbers and returns their sum:
+
+```python
+from algorithms.template import TemplateAlgorithm
+
+algo = TemplateAlgorithm()
+result = algo.execute([1, 2, 3])
+print(result)  # 6
+```
+
+Passing a non-list raises `TypeError`, and non-numeric elements raise
+`ValueError`.
+
 ## Data Structures
 
 Basic examples:

--- a/algorithms/template.py
+++ b/algorithms/template.py
@@ -7,13 +7,20 @@ class TemplateAlgorithm(Algorithm):
     """Example implementation demonstrating naming conventions."""
 
     def execute(self, data):
-        """Run the algorithm.
+        """Return the sum of a list of numbers.
 
         Args:
-            data: Input data for the algorithm.
+            data: List of numbers to process.
 
         Returns:
-            The result after processing ``data``.
+            int | float: Sum of the provided numbers.
+
+        Raises:
+            TypeError: If ``data`` is not a list.
+            ValueError: If any element is not numeric.
         """
-        # TODO: Implement algorithm logic
-        return data
+        if not isinstance(data, list):
+            raise TypeError("data must be a list")
+        if not all(isinstance(x, (int, float)) for x in data):
+            raise ValueError("all elements must be numeric")
+        return sum(data)

--- a/algorithms/tests/test_template_algorithm.py
+++ b/algorithms/tests/test_template_algorithm.py
@@ -1,0 +1,17 @@
+import pytest
+from algorithms.template import TemplateAlgorithm
+
+
+def test_template_algorithm_sum():
+    data = [1, 2, 3, 4]
+    assert TemplateAlgorithm().execute(data) == 10
+
+
+def test_template_algorithm_non_list_raises_type_error():
+    with pytest.raises(TypeError):
+        TemplateAlgorithm().execute("1234")
+
+
+def test_template_algorithm_non_numeric_raises_value_error():
+    with pytest.raises(ValueError):
+        TemplateAlgorithm().execute([1, "two", 3])


### PR DESCRIPTION
## Summary
- add simple summing logic with input validation to `TemplateAlgorithm`
- document `TemplateAlgorithm` usage and error cases in algorithms README
- add unit tests for normal and error scenarios

## Testing
- `PYTHONPATH=. pytest algorithms/tests/test_template_algorithm.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6686e75b0832fa3dd26508d4eebe1