### PR TITLE
Add Kuramoto and Wilson-Cowan neural oscillation models

### DIFF
--- a/modules/brain/oscillations.py
+++ b/modules/brain/oscillations.py
@@ -1,6 +1,82 @@
 import numpy as np
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
+
+
+@dataclass
+class KuramotoModel:
+    """Simple Kuramoto phase synchronization model."""
+
+    def simulate(
+        self,
+        natural_frequencies: Sequence[float],
+        coupling_strength: float,
+        initial_phases: Sequence[float],
+        duration: float,
+        sample_rate: int,
+    ) -> np.ndarray:
+        dt = 1.0 / sample_rate
+        steps = int(duration * sample_rate)
+        omega = np.array(natural_frequencies)
+        phases = np.zeros((steps, len(omega)))
+        phases[0] = np.array(initial_phases)
+        for t in range(1, steps):
+            theta = phases[t - 1]
+            theta_diff = theta[None, :] - theta[:, None]
+            coupling = np.sum(np.sin(theta_diff), axis=1)
+            dtheta = omega + (coupling_strength / len(omega)) * coupling
+            phases[t] = theta + dtheta * dt
+        return phases
+
+
+@dataclass
+class WilsonCowanModel:
+    """Wilson-Cowan excitatory-inhibitory population model."""
+
+    a_e: float = 1.0
+    a_i: float = 1.0
+    theta_e: float = 0.0
+    theta_i: float = 0.0
+    tau_e: float = 0.02
+    tau_i: float = 0.02
+    w_ee: float = 10.0
+    w_ei: float = 10.0
+    w_ie: float = 10.0
+    w_ii: float = 10.0
+
+    def _sigmoid(self, x: np.ndarray, a: float, theta: float) -> np.ndarray:
+        return 1.0 / (1.0 + np.exp(-a * (x - theta)))
+
+    def simulate(
+        self,
+        duration: float = 1.0,
+        dt: float = 0.001,
+        P_e: float = 0.0,
+        P_i: float = 0.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        steps = int(duration / dt)
+        E = np.zeros(steps)
+        I = np.zeros(steps)
+        for t in range(1, steps):
+            dE = (
+                -E[t - 1]
+                + self._sigmoid(
+                    self.w_ee * E[t - 1] - self.w_ei * I[t - 1] + P_e,
+                    self.a_e,
+                    self.theta_e,
+                )
+            ) / self.tau_e
+            dI = (
+                -I[t - 1]
+                + self._sigmoid(
+                    self.w_ie * E[t - 1] - self.w_ii * I[t - 1] + P_i,
+                    self.a_i,
+                    self.theta_i,
+                )
+            ) / self.tau_i
+            E[t] = E[t - 1] + dt * dE
+            I[t] = I[t - 1] + dt * dI
+        return E, I
 
 
 @dataclass
@@ -121,6 +197,32 @@ class NeuralOscillations:
         self.beta_waves = self.BetaGenerator()
         self.gamma_waves = self.GammaGenerator()
         self.theta_waves = self.ThetaGenerator()
+        self.kuramoto = KuramotoModel()
+        self.wilson_cowan = WilsonCowanModel()
+
+    def generate_realistic_oscillations(
+        self,
+        num_oscillators: int = 2,
+        duration: float = 1.0,
+        sample_rate: int = 1000,
+        coupling_strength: float = 1.0,
+    ) -> np.ndarray:
+        """Generate synchronized oscillations using Wilson-Cowan and Kuramoto models."""
+        dt = 1.0 / sample_rate
+        E, I = self.wilson_cowan.simulate(duration=duration, dt=dt, P_e=1.25, P_i=0.5)
+        base_wave = E - I
+        natural_freqs = np.linspace(30.0, 50.0, num_oscillators) * 2 * np.pi
+        initial_phases = np.linspace(0, np.pi, num_oscillators)
+        phases = self.kuramoto.simulate(
+            natural_freqs,
+            coupling_strength,
+            initial_phases,
+            duration,
+            sample_rate,
+        )
+        return np.array([
+            base_wave * np.sin(phases[:, i]) for i in range(num_oscillators)
+        ])
 
     def synchronize_regions(
         self,
@@ -154,6 +256,26 @@ class NeuralOscillations:
         """Amplitude modulation of a carrier wave using a modulating wave."""
         return carrier_wave * (1 + modulator_wave)
 
-    def cross_frequency_coupling(self, low_wave: np.ndarray, high_wave: np.ndarray) -> np.ndarray:
-        """Simple cross-frequency coupling via phase-amplitude modulation."""
-        return self.oscillatory_modulation(high_wave, low_wave)
+    def cross_frequency_coupling(
+        self,
+        low_freq: float,
+        high_freq: float,
+        duration: float = 1.0,
+        sample_rate: int = 1000,
+        coupling_strength: float = 1.0,
+    ) -> np.ndarray:
+        """Cross-frequency coupling via Wilson-Cowan amplitude and Kuramoto phase dynamics."""
+        dt = 1.0 / sample_rate
+        E_low, I_low = self.wilson_cowan.simulate(duration=duration, dt=dt, P_e=1.25, P_i=0.5)
+        low_amp = E_low - I_low
+        natural_freqs = [2 * np.pi * low_freq, 2 * np.pi * high_freq]
+        phases = self.kuramoto.simulate(
+            natural_freqs,
+            coupling_strength,
+            [0.0, np.pi / 2],
+            duration,
+            sample_rate,
+        )
+        low_signal = low_amp * np.sin(phases[:, 0])
+        high_signal = np.sin(phases[:, 1])
+        return self.oscillatory_modulation(high_signal, low_signal)

--- a/modules/tests/test_brain_oscillations.py
+++ b/modules/tests/test_brain_oscillations.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.oscillations import KuramotoModel, NeuralOscillations
+
+
+def test_kuramoto_synchronization():
+    model = KuramotoModel()
+    natural_freqs = [2 * np.pi * 1.0, 2 * np.pi * 1.1, 2 * np.pi * 0.9]
+    phases = model.simulate(
+        natural_freqs,
+        coupling_strength=10.0,
+        initial_phases=[0.0, 1.0, 2.0],
+        duration=1.0,
+        sample_rate=1000,
+    )
+    final = phases[-1]
+    initial_spread = 2.0 - 0.0
+    final_spread = np.max(final) - np.min(final)
+    assert final_spread < initial_spread
+
+
+def test_generate_realistic_oscillations():
+    osc = NeuralOscillations()
+    waves = osc.generate_realistic_oscillations(
+        num_oscillators=3, duration=0.5, sample_rate=1000, coupling_strength=5.0
+    )
+    assert waves.shape[0] == 3
+    corr = np.corrcoef(waves)
+    assert corr[0, 1] > 0 and corr[1, 2] > 0
+
+
+def test_cross_frequency_coupling():
+    osc = NeuralOscillations()
+    duration = 0.5
+    sample_rate = 1000
+    result = osc.cross_frequency_coupling(
+        low_freq=5.0,
+        high_freq=40.0,
+        duration=duration,
+        sample_rate=sample_rate,
+        coupling_strength=5.0,
+    )
+    dt = 1.0 / sample_rate
+    E_low, I_low = osc.wilson_cowan.simulate(duration=duration, dt=dt, P_e=1.25, P_i=0.5)
+    low_amp = E_low - I_low
+    phases = osc.kuramoto.simulate(
+        [2 * np.pi * 5.0, 2 * np.pi * 40.0],
+        5.0,
+        [0.0, np.pi / 2],
+        duration,
+        sample_rate,
+    )
+    low_signal = low_amp * np.sin(phases[:, 0])
+    high_signal = np.sin(phases[:, 1])
+    expected = osc.oscillatory_modulation(high_signal, low_signal)
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
## Summary
- add KuramotoModel and WilsonCowanModel to simulate phase synchronization and excitatory-inhibitory dynamics
- expose generate_realistic_oscillations and cross_frequency_coupling in NeuralOscillations using these models
- test synchronization and cross-frequency coupling behaviors

## Testing
- `pytest modules/tests/test_brain_oscillations.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6689128d0832f8f5388fd87656881