### PR TITLE
Add neural security guards and tests

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -4,6 +4,7 @@ from .cerebellum import Cerebellum
 from .limbic import LimbicSystem
 from .oscillations import NeuralOscillations
 from .whole_brain import WholeBrainSimulation
+from .security import NeuralSecurityGuard
 
 __all__ = [
     "VisualCortex",
@@ -14,4 +15,5 @@ __all__ = [
     "LimbicSystem",
     "NeuralOscillations",
     "WholeBrainSimulation",
+    "NeuralSecurityGuard",
 ]

--- a/modules/brain/security.py
+++ b/modules/brain/security.py
@@ -1,0 +1,192 @@
+"""Basic security utilities for neural modules.
+
+This module provides minimalistic detectors and guards to simulate
+security mechanisms within neural components. The implementations are
+intentionally lightweight so that they remain easy to unit test while
+still demonstrating core concepts like adversarial input detection,
+backdoor scanning and memory integrity checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+import copy
+
+
+# ---------------------------------------------------------------------------
+# Adversarial input detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdversarialInputDetector:
+    """Detects and sanitises adversarial numeric patterns.
+
+    Any numeric value whose magnitude exceeds ``threshold`` is treated as
+    adversarial.  Sanitisation simply clips offending values to the
+    allowed range.
+    """
+
+    threshold: float = 10.0
+
+    def detect(self, data: Any) -> bool:
+        """Return ``True`` if adversarial content is found."""
+        found = False
+
+        def _check(value: Any) -> None:
+            nonlocal found
+            if isinstance(value, (int, float)):
+                if abs(value) > self.threshold:
+                    found = True
+            elif isinstance(value, (list, tuple)):
+                for v in value:
+                    _check(v)
+            elif isinstance(value, dict):
+                for v in value.values():
+                    _check(v)
+
+        _check(data)
+        return found
+
+    def sanitize(self, data: Any) -> Any:
+        """Clip numeric values to the accepted range."""
+
+        def _sanitize(value: Any) -> Any:
+            if isinstance(value, (int, float)):
+                if value > self.threshold:
+                    return self.threshold
+                if value < -self.threshold:
+                    return -self.threshold
+                return value
+            if isinstance(value, list):
+                return [_sanitize(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(_sanitize(v) for v in value)
+            if isinstance(value, dict):
+                return {k: _sanitize(v) for k, v in value.items()}
+            return value
+
+        return _sanitize(data)
+
+
+# ---------------------------------------------------------------------------
+# Backdoor trigger scanning
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BackdoorScanner:
+    """Detects simple backdoor trigger strings.
+
+    The scanner looks for a configured ``trigger_token`` within any string
+    value and removes it during cleaning.
+    """
+
+    trigger_token: str = "trigger"
+
+    def scan(self, data: Any) -> bool:
+        found = False
+
+        def _check(value: Any) -> None:
+            nonlocal found
+            if isinstance(value, str) and self.trigger_token in value:
+                found = True
+            elif isinstance(value, (list, tuple)):
+                for v in value:
+                    _check(v)
+            elif isinstance(value, dict):
+                for v in value.values():
+                    _check(v)
+
+        _check(data)
+        return found
+
+    def clean(self, data: Any) -> Any:
+        def _clean(value: Any) -> Any:
+            if isinstance(value, str):
+                return value.replace(self.trigger_token, "")
+            if isinstance(value, list):
+                return [_clean(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(_clean(v) for v in value)
+            if isinstance(value, dict):
+                return {k: _clean(v) for k, v in value.items()}
+            return value
+
+        return _clean(data)
+
+
+# ---------------------------------------------------------------------------
+# Memory integrity checking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MemoryIntegrityChecker:
+    """Maintains a baseline snapshot and repairs deviations."""
+
+    baseline: Dict[str, Any] | None = field(default=None, init=False)
+
+    def scan(self, memory: Dict[str, Any]) -> List[str]:
+        """Return keys whose values differ from the baseline.
+
+        The first call establishes the baseline and returns an empty list.
+        Subsequent calls compare against this snapshot.
+        """
+
+        if self.baseline is None:
+            self.baseline = copy.deepcopy(memory)
+            return []
+        return [k for k, v in memory.items() if self.baseline.get(k) != v]
+
+    def repair(self, memory: Dict[str, Any]) -> None:
+        """Restore memory to the baseline snapshot."""
+        if self.baseline is None:
+            self.baseline = copy.deepcopy(memory)
+            return
+        for k, v in self.baseline.items():
+            memory[k] = copy.deepcopy(v)
+
+
+# ---------------------------------------------------------------------------
+# Security guard orchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NeuralSecurityGuard:
+    """Coordinates security checks for neural processing."""
+
+    adversarial_detector: AdversarialInputDetector = field(
+        default_factory=AdversarialInputDetector
+    )
+    backdoor_scanner: BackdoorScanner = field(default_factory=BackdoorScanner)
+    memory_checker: MemoryIntegrityChecker = field(
+        default_factory=MemoryIntegrityChecker
+    )
+
+    # -- Input validation ----------------------------------------------------
+    def validate_neural_input(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Detect and clean adversarial or backdoor patterns in input data."""
+        if self.adversarial_detector.detect(input_data):
+            input_data = self.adversarial_detector.sanitize(input_data)
+        if self.backdoor_scanner.scan(input_data):
+            input_data = self.backdoor_scanner.clean(input_data)
+        return input_data
+
+    # -- Memory protection ---------------------------------------------------
+    def protect_neural_memory(self, memory: Dict[str, Any]) -> List[str]:
+        """Scan memory for corruption and repair deviations."""
+        issues = self.memory_checker.scan(memory)
+        if issues:
+            self.memory_checker.repair(memory)
+        return issues
+
+
+__all__ = [
+    "AdversarialInputDetector",
+    "BackdoorScanner",
+    "MemoryIntegrityChecker",
+    "NeuralSecurityGuard",
+]

--- a/tests/brain/test_neural_security.py
+++ b/tests/brain/test_neural_security.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.brain.security import NeuralSecurityGuard
+
+
+def test_validate_neural_input_handles_threats():
+    guard = NeuralSecurityGuard()
+    data = {"values": [0.2, 99.0], "text": "hello trigger"}
+    cleaned = guard.validate_neural_input(data)
+    assert max(cleaned["values"]) <= guard.adversarial_detector.threshold
+    assert "trigger" not in cleaned["text"]
+
+
+def test_memory_checker_repairs_corruption():
+    guard = NeuralSecurityGuard()
+    memory = {"status": "ok"}
+    assert guard.protect_neural_memory(memory) == []
+    memory["status"] = "tampered"
+    issues = guard.protect_neural_memory(memory)
+    assert issues == ["status"]
+    assert memory["status"] == "ok"


### PR DESCRIPTION
## Summary
- Implement AdversarialInputDetector, BackdoorScanner, and MemoryIntegrityChecker for basic neural security
- Add NeuralSecurityGuard orchestration and export through brain module
- Include tests simulating adversarial and backdoor scenarios

## Testing
- `pytest tests/brain/test_neural_security.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6689ffd70832fa4fbe33c4e8a60d7