### PR TITLE
feat(brain): add neural message bus

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -4,6 +4,7 @@ from .cerebellum import Cerebellum
 from .limbic import LimbicSystem
 from .oscillations import NeuralOscillations
 from .whole_brain import WholeBrainSimulation
+from .message_bus import publish_neural_event, subscribe_to_brain_region
 
 __all__ = [
     "VisualCortex",
@@ -14,4 +15,6 @@ __all__ = [
     "LimbicSystem",
     "NeuralOscillations",
     "WholeBrainSimulation",
+    "publish_neural_event",
+    "subscribe_to_brain_region",
 ]

--- a/modules/brain/message_bus.py
+++ b/modules/brain/message_bus.py
@@ -1,0 +1,96 @@
+"""Neural message bus for communication between brain regions."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, Dict, List
+
+
+class EventDispatcher:
+    """Dispatches events to registered handlers."""
+
+    def __init__(self) -> None:
+        self._listeners: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
+
+    def subscribe(self, event_type: str, handler: Callable[[Any], None]) -> None:
+        """Register a handler for a specific event type."""
+        self._listeners[event_type].append(handler)
+
+    def dispatch(self, event_type: str, data: Any) -> None:
+        """Send data to all handlers of an event type."""
+        for handler in list(self._listeners.get(event_type, [])):
+            try:
+                handler(data)
+            except Exception:
+                # Isolate faulty handlers so others can proceed
+                continue
+
+
+class CircuitBreaker:
+    """Simple circuit breaker to isolate failing handlers."""
+
+    def __init__(self, threshold: int = 3) -> None:
+        self.threshold = threshold
+        self.failures = 0
+        self.open = False
+
+    def call(self, func: Callable[[Any], None], data: Any) -> None:
+        if self.open:
+            return
+        try:
+            func(data)
+            self.failures = 0
+        except Exception:
+            self.failures += 1
+            if self.failures >= self.threshold:
+                self.open = True
+            raise
+
+
+class MessageRouter:
+    """Routes events to brain regions via an EventDispatcher."""
+
+    def __init__(self, dispatcher: EventDispatcher) -> None:
+        self.dispatcher = dispatcher
+        self._breakers: Dict[Callable[[Any], None], CircuitBreaker] = {}
+
+    def register(
+        self,
+        region: str,
+        event_type: str,
+        handler: Callable[[Any], None],
+        threshold: int = 3,
+    ) -> None:
+        """Register a region's handler for an event type."""
+        breaker = CircuitBreaker(threshold)
+        self._breakers[handler] = breaker
+
+        def wrapped(data: Any, h: Callable[[Any], None] = handler, b: CircuitBreaker = breaker) -> None:
+            try:
+                b.call(h, data)
+            except Exception:
+                # suppress to allow other handlers to process
+                pass
+
+        self.dispatcher.subscribe(event_type, wrapped)
+
+    def publish(self, event_type: str, data: Any) -> None:
+        """Publish an event after basic validation."""
+        if not isinstance(event_type, str):
+            raise TypeError("event_type must be str")
+        self.dispatcher.dispatch(event_type, data)
+
+
+_dispatcher = EventDispatcher()
+_router = MessageRouter(_dispatcher)
+
+
+def subscribe_to_brain_region(
+    region: str, event_type: str, handler: Callable[[Any], None], threshold: int = 3
+) -> None:
+    """Public API to subscribe a brain region to an event type."""
+    _router.register(region, event_type, handler, threshold)
+
+
+def publish_neural_event(event_type: str, data: Any) -> None:
+    """Public API to publish neural events to the bus."""
+    _router.publish(event_type, data)

--- a/modules/brain/message_bus_example.py
+++ b/modules/brain/message_bus_example.py
@@ -1,0 +1,21 @@
+"""Example demonstrating brain regions communicating via the message bus."""
+from modules.brain.message_bus import publish_neural_event, subscribe_to_brain_region
+
+
+def motor_cortex(event: dict) -> None:
+    """Handle motor commands."""
+    print(f"Motor cortex received: {event['command']}")
+
+
+def visual_cortex() -> None:
+    """Publish a visual signal that triggers a motor response."""
+    publish_neural_event("visual_signal", {"command": "wave"})
+
+
+def main() -> None:
+    subscribe_to_brain_region("motor", "visual_signal", motor_cortex)
+    visual_cortex()
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/tests/test_message_bus.py
+++ b/modules/tests/test_message_bus.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from modules.brain.message_bus import publish_neural_event, subscribe_to_brain_region
+
+
+def test_bus_routes_messages():
+    received = []
+
+    def handler(data):
+        received.append(data)
+
+    subscribe_to_brain_region("motor", "move", handler)
+    publish_neural_event("move", {"direction": "left"})
+    assert received == [{"direction": "left"}]
+
+
+def test_circuit_breaker_isolates_failures():
+    received = []
+    fail_count = {"count": 0}
+
+    def good_handler(data):
+        received.append(data)
+
+    def failing_handler(data):
+        fail_count["count"] += 1
+        raise ValueError("boom")
+
+    subscribe_to_brain_region("good", "signal", good_handler)
+    subscribe_to_brain_region("bad", "signal", failing_handler)
+
+    for _ in range(4):
+        publish_neural_event("signal", 1)
+
+    assert received == [1, 1, 1, 1]
+    # circuit breaker stops calling after 3 failures
+    assert fail_count["count"] == 3


### PR DESCRIPTION
## Summary
- add neural message bus with dispatcher, router and circuit breaker
- expose publish/subscribe helpers for brain regions
- provide example and tests for inter-region messaging and fault isolation

## Testing
- `pytest modules/tests/test_message_bus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c66899f758832f9afdca74a65f08d5