### PR TITLE
Add quantum memory, attention, and reasoning modules

### DIFF
--- a/modules/brain/quantum/__init__.py
+++ b/modules/brain/quantum/__init__.py
@@ -1,0 +1,14 @@
+"""Quantum brain subpackage."""
+from .quantum_cognition import SuperpositionState, EntanglementNetwork, QuantumCognition
+from .quantum_memory import QuantumMemory
+from .quantum_attention import QuantumAttention
+from .quantum_reasoning import QuantumReasoning
+
+__all__ = [
+    "SuperpositionState",
+    "EntanglementNetwork",
+    "QuantumCognition",
+    "QuantumMemory",
+    "QuantumAttention",
+    "QuantumReasoning",
+]

--- a/modules/brain/quantum/quantum_attention.py
+++ b/modules/brain/quantum/quantum_attention.py
@@ -1,0 +1,19 @@
+"""Quantum attention mechanisms for amplitude re-weighting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .quantum_cognition import SuperpositionState
+
+
+@dataclass
+class QuantumAttention:
+    """Applies focus weights to a superposition state."""
+
+    def apply(self, state: SuperpositionState, focus: Mapping[str, float]) -> SuperpositionState:
+        amps = {basis: amp * focus.get(basis, 1.0) for basis, amp in state.amplitudes.items()}
+        return SuperpositionState(amps)
+
+
+__all__ = ["QuantumAttention"]

--- a/modules/brain/quantum/quantum_cognition.py
+++ b/modules/brain/quantum/quantum_cognition.py
@@ -14,33 +14,29 @@ SuperpositionState
 EntanglementNetwork
     Produces a small set of predefined entangled states used by the tests and
     exposes :meth:`entangle_concepts` for simple decoherence simulations.
-QuantumMemory
-    Minimal in-memory store allowing superposition based retrieval.
 QuantumCognition
-    High level interface exposing :meth:`evaluate_probabilities` and
-    :meth:`make_decision` which can operate on either
-    :class:`SuperpositionState` instances or density matrices.
+    High level interface exposing :meth:`evaluate_probabilities`,
+    :meth:`quantum_decision_making` and :meth:`quantum_memory_retrieval` which
+    operate on quantum states represented by :class:`SuperpositionState` or
+    density matrices.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 import math
-from typing import Dict, Iterable, Mapping, Union
+from typing import Dict, Iterable, Mapping, Union, TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .quantum_attention import QuantumAttention
+    from .quantum_memory import QuantumMemory
+    from .quantum_reasoning import QuantumReasoning
 
 
 @dataclass
 class SuperpositionState:
-    """Representation of a quantum superposition.
-
-    Parameters
-    ----------
-    amplitudes:
-        Mapping of basis state labels to complex amplitudes.  The
-        amplitudes are normalised on construction so their squared
-        magnitudes sum to one.
-    """
+    """Representation of a quantum superposition."""
 
     amplitudes: Dict[str, complex]
 
@@ -67,25 +63,12 @@ class EntanglementNetwork:
     def create_bell_pair(self) -> SuperpositionState:
         """Return a Bell pair :math:`(|00\rangle + |11\rangle)/\sqrt{2}`."""
         amp = 1 / math.sqrt(2)
-        # Include the full two-qubit computational basis with zero amplitudes
         return SuperpositionState({"00": amp, "01": 0, "10": 0, "11": amp})
 
     def entangle_concepts(
         self, concept_a: str, concept_b: str, decoherence: float = 0.0
     ) -> np.ndarray:
-        """Return density matrix for two entangled *concepts*.
-
-        Parameters
-        ----------
-        concept_a, concept_b:
-            Names of the concepts being entangled.  The names are currently
-            only informational but mirror a potential semantic mapping.
-        decoherence:
-            Value in ``[0, 1]`` representing how much the off-diagonal terms
-            of the Bell state's density matrix are damped.  ``0`` corresponds
-            to a pure Bell pair while ``1`` yields a fully decohered mixed
-            state.
-        """
+        """Return density matrix for two entangled *concepts*."""
 
         density = self.create_bell_pair().density_matrix()
         if decoherence:
@@ -96,50 +79,29 @@ class EntanglementNetwork:
         return density
 
 
-@dataclass
-class QuantumMemory:
-    """Simple storage for :class:`SuperpositionState` objects.
-
-    The memory can retrieve classical states or superpositions across stored
-    entries by supplying amplitude weights.
-    """
-
-    storage: Dict[str, SuperpositionState]
-
-    def __init__(self) -> None:
-        self.storage = {}
-
-    def store(self, key: str, state: SuperpositionState) -> None:
-        self.storage[key] = state
-
-    def retrieve(self, key: str) -> SuperpositionState:
-        return self.storage[key]
-
-    def superposition(self, weights: Mapping[str, complex]) -> SuperpositionState:
-        combined: Dict[str, complex] = {}
-        for key, amp in weights.items():
-            state = self.storage[key]
-            for basis, value in state.amplitudes.items():
-                combined[basis] = combined.get(basis, 0) + amp * value
-        return SuperpositionState(combined)
-
-
 class QuantumCognition:
     """High level interface for evaluating quantum cognitive states."""
 
-    def __init__(self, network: EntanglementNetwork | None = None) -> None:
+    def __init__(
+        self,
+        network: EntanglementNetwork | None = None,
+        memory: QuantumMemory | None = None,
+        attention: QuantumAttention | None = None,
+        reasoning: QuantumReasoning | None = None,
+    ) -> None:
+        from .quantum_attention import QuantumAttention as QA
+        from .quantum_memory import QuantumMemory as QM
+        from .quantum_reasoning import QuantumReasoning as QR
+
         self.network = network or EntanglementNetwork()
+        self.memory = memory or QM()
+        self.attention = attention or QA()
+        self.reasoning = reasoning or QR()
 
     def evaluate_probabilities(
         self, input_state: Union[SuperpositionState, np.ndarray]
     ) -> Dict[str, float]:
-        """Evaluate measurement probabilities for *input_state*.
-
-        ``input_state`` may either be a :class:`SuperpositionState` or a
-        density matrix expressed as a NumPy array.  In the latter case the
-        diagonal entries of the matrix are interpreted as probabilities in
-        the computational basis.
-        """
+        """Evaluate measurement probabilities for *input_state*."""
 
         if isinstance(input_state, SuperpositionState):
             return input_state.probabilities()
@@ -156,28 +118,34 @@ class QuantumCognition:
         options: Mapping[str, Iterable[complex]],
         rng: np.random.Generator | None = None,
     ) -> tuple[str, Dict[str, float]]:
-        """Perform a quantum-style decision over *options*.
+        """Backward compatible alias for :meth:`quantum_decision_making`."""
 
-        ``options`` maps each label to a collection of amplitudes which are
-        summed to produce interference effects.  The squared magnitudes of
-        the resulting amplitudes yield the decision probabilities.  The
-        selected option and the probability distribution are returned.
-        """
+        return self.quantum_decision_making(options, rng)
 
-        amps = {label: sum(values) for label, values in options.items()}
-        norm = math.sqrt(sum(abs(a) ** 2 for a in amps.values()))
-        if not np.isclose(norm, 1):
-            amps = {k: v / norm for k, v in amps.items()}
-        labels = list(amps.keys())
-        probs = [float(abs(a) ** 2) for a in amps.values()]
+    def quantum_decision_making(
+        self,
+        options: Mapping[str, Iterable[complex]],
+        rng: np.random.Generator | None = None,
+    ) -> tuple[str, Dict[str, float]]:
+        """Perform a quantum-style decision over *options*."""
+
+        probs = self.reasoning.interference(options)
+        labels = list(probs.keys())
         generator = rng or np.random.default_rng()
-        choice = generator.choice(labels, p=probs)
-        return choice, {label: prob for label, prob in zip(labels, probs)}
+        choice = generator.choice(labels, p=list(probs.values()))
+        return choice, probs
+
+    def quantum_memory_retrieval(
+        self,
+        weights: Mapping[str, complex],
+        focus: Mapping[str, float] | None = None,
+    ) -> SuperpositionState:
+        """Retrieve a superposition from memory optionally applying attention."""
+
+        state = self.memory.superposition(weights)
+        if focus:
+            state = self.attention.apply(state, focus)
+        return state
 
 
-__all__ = [
-    "SuperpositionState",
-    "EntanglementNetwork",
-    "QuantumMemory",
-    "QuantumCognition",
-]
+__all__ = ["SuperpositionState", "EntanglementNetwork", "QuantumCognition"]

--- a/modules/brain/quantum/quantum_memory.py
+++ b/modules/brain/quantum/quantum_memory.py
@@ -1,0 +1,34 @@
+"""Quantum memory storage and superposition retrieval."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from .quantum_cognition import SuperpositionState
+
+
+@dataclass
+class QuantumMemory:
+    """Simple storage for :class:`SuperpositionState` objects."""
+
+    storage: Dict[str, SuperpositionState]
+
+    def __init__(self) -> None:
+        self.storage = {}
+
+    def store(self, key: str, state: SuperpositionState) -> None:
+        self.storage[key] = state
+
+    def retrieve(self, key: str) -> SuperpositionState:
+        return self.storage[key]
+
+    def superposition(self, weights: Mapping[str, complex]) -> SuperpositionState:
+        combined: Dict[str, complex] = {}
+        for key, amp in weights.items():
+            state = self.storage[key]
+            for basis, value in state.amplitudes.items():
+                combined[basis] = combined.get(basis, 0) + amp * value
+        return SuperpositionState(combined)
+
+
+__all__ = ["QuantumMemory"]

--- a/modules/brain/quantum/quantum_reasoning.py
+++ b/modules/brain/quantum/quantum_reasoning.py
@@ -1,0 +1,23 @@
+"""Quantum reasoning via amplitude interference."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Dict, Iterable, Mapping
+
+import numpy as np
+
+
+@dataclass
+class QuantumReasoning:
+    """Combine amplitudes to produce interference-based probabilities."""
+
+    def interference(self, options: Mapping[str, Iterable[complex]]) -> Dict[str, float]:
+        amps = {label: sum(values) for label, values in options.items()}
+        norm = math.sqrt(sum(abs(a) ** 2 for a in amps.values()))
+        if not np.isclose(norm, 1):
+            amps = {k: v / norm for k, v in amps.items()}
+        return {label: float(abs(a) ** 2) for label, a in amps.items()}
+
+
+__all__ = ["QuantumReasoning"]

--- a/tests/quantum/test_quantum_cognition.py
+++ b/tests/quantum/test_quantum_cognition.py
@@ -10,10 +10,10 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".
 
 from modules.brain.quantum.quantum_cognition import (
     EntanglementNetwork,
-    QuantumMemory,
     QuantumCognition,
     SuperpositionState,
 )
+from modules.brain.quantum.quantum_memory import QuantumMemory
 
 
 def test_superposition_probabilities():

--- a/tests/quantum/test_quantum_interfaces.py
+++ b/tests/quantum/test_quantum_interfaces.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# Ensure repo root in path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.brain.quantum.quantum_cognition import QuantumCognition, SuperpositionState
+
+
+def test_quantum_memory_retrieval_superposition():
+    qc = QuantumCognition()
+    qc.memory.store("A", SuperpositionState({"0": 1}))
+    qc.memory.store("B", SuperpositionState({"1": 1}))
+    state = qc.quantum_memory_retrieval({"A": 1 / np.sqrt(2), "B": 1 / np.sqrt(2)})
+    probs = qc.evaluate_probabilities(state)
+    assert probs["0"] == pytest.approx(0.5, rel=1e-6)
+    assert probs["1"] == pytest.approx(0.5, rel=1e-6)
+
+
+def test_quantum_decision_making_interference():
+    qc = QuantumCognition()
+    choice, probs = qc.quantum_decision_making(
+        {"A": [0.5, 0.5], "B": [0.5, -0.5]}, rng=np.random.default_rng(0)
+    )
+    assert choice == "A"
+    assert probs["A"] == pytest.approx(1.0, abs=1e-6)
+    assert probs["B"] == pytest.approx(0.0, abs=1e-6)

--- a/tests/quantum/test_quantum_memory.py
+++ b/tests/quantum/test_quantum_memory.py
@@ -7,7 +7,8 @@ import pytest
 # Ensure repo root in path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from modules.brain.quantum.quantum_cognition import QuantumMemory, QuantumCognition, SuperpositionState
+from modules.brain.quantum.quantum_cognition import QuantumCognition, SuperpositionState
+from modules.brain.quantum.quantum_memory import QuantumMemory
 
 
 def test_store_and_retrieve():


### PR DESCRIPTION
## Summary
- Split QuantumMemory into its own module and add QuantumAttention and QuantumReasoning components
- Extend QuantumCognition with quantum_decision_making and quantum_memory_retrieval interfaces
- Cover superposition retrieval and interference via new tests

## Testing
- `pytest tests/quantum -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66895c814832f90964dda35de4e56