### PR TITLE
Add neural message bus with routing and circuit breaker

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -5,6 +5,11 @@ from .limbic import LimbicSystem
 from .oscillations import NeuralOscillations
 from .whole_brain import WholeBrainSimulation
 from .security import NeuralSecurityGuard
+from .message_bus import (
+    publish_neural_event,
+    reset_message_bus,
+    subscribe_to_brain_region,
+)
 
 __all__ = [
     "VisualCortex",
@@ -16,4 +21,7 @@ __all__ = [
     "NeuralOscillations",
     "WholeBrainSimulation",
     "NeuralSecurityGuard",
+    "publish_neural_event",
+    "subscribe_to_brain_region",
+    "reset_message_bus",
 ]

--- a/modules/brain/message_bus.py
+++ b/modules/brain/message_bus.py
@@ -1,0 +1,113 @@
+"""Lightweight message bus for brain region communication.
+
+This module defines small components for dispatching and routing neural events
+between simulated brain regions.  It exposes simple ``publish_neural_event``
+and ``subscribe_to_brain_region`` interfaces that perform event validation,
+message routing and basic fault isolation via a circuit breaker.
+
+The goal is clarity over sophistication so the implementation stays
+straight‑forward and easily testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List
+
+
+# ---------------------------------------------------------------------------
+# Core components
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EventDispatcher:
+    """Store and notify event subscribers."""
+
+    subscribers: Dict[str, List[Callable[[Dict[str, Any]], None]]] = field(
+        default_factory=dict
+    )
+
+    def subscribe(self, region: str, handler: Callable[[Dict[str, Any]], None]) -> None:
+        if not region:
+            raise ValueError("region must be non-empty")
+        if not callable(handler):
+            raise TypeError("handler must be callable")
+        self.subscribers.setdefault(region, []).append(handler)
+
+    def publish(self, region: str, event: Dict[str, Any]) -> None:
+        for handler in self.subscribers.get(region, []):
+            handler(event)
+
+
+@dataclass
+class CircuitBreaker:
+    """Simple circuit breaker to isolate failing regions."""
+
+    max_failures: int = 3
+    failure_counts: Dict[str, int] = field(default_factory=dict)
+    open_regions: set[str] = field(default_factory=set)
+
+    def call(
+        self, region: str, handler: Callable[[Dict[str, Any]], None], event: Dict[str, Any]
+    ) -> None:
+        if region in self.open_regions:
+            return
+        try:
+            handler(event)
+            self.failure_counts[region] = 0
+        except Exception:
+            count = self.failure_counts.get(region, 0) + 1
+            self.failure_counts[region] = count
+            if count >= self.max_failures:
+                self.open_regions.add(region)
+
+
+@dataclass
+class MessageRouter:
+    """Route events to target regions via an :class:`EventDispatcher`."""
+
+    dispatcher: EventDispatcher
+
+    def route(self, event: Dict[str, Any]) -> None:
+        region = event.get("target")
+        if not region:
+            raise ValueError("event missing 'target'")
+        self.dispatcher.publish(region, event)
+
+
+# ---------------------------------------------------------------------------
+# Module level bus instance and public API
+# ---------------------------------------------------------------------------
+
+_dispatcher = EventDispatcher()
+_router = MessageRouter(_dispatcher)
+_breaker = CircuitBreaker()
+
+
+def reset_message_bus() -> None:
+    """Reset all subscribers and breaker state (useful for tests)."""
+
+    _dispatcher.subscribers.clear()
+    _breaker.failure_counts.clear()
+    _breaker.open_regions.clear()
+
+
+def subscribe_to_brain_region(
+    region: str, handler: Callable[[Dict[str, Any]], None]
+) -> None:
+    """Register a handler for events destined for ``region``."""
+
+    def wrapped(event: Dict[str, Any]) -> None:
+        _breaker.call(region, handler, event)
+
+    _dispatcher.subscribe(region, wrapped)
+
+
+def publish_neural_event(event: Dict[str, Any]) -> None:
+    """Validate and publish ``event`` to its target region."""
+
+    if not isinstance(event, dict):
+        raise TypeError("event must be a dictionary")
+    if "target" not in event:
+        raise ValueError("event missing 'target'")
+    _router.route(event)

--- a/modules/brain/message_bus_example.py
+++ b/modules/brain/message_bus_example.py
@@ -1,0 +1,30 @@
+"""Example of brain regions communicating over the message bus."""
+from __future__ import annotations
+
+from modules.brain.message_bus import (
+    publish_neural_event,
+    reset_message_bus,
+    subscribe_to_brain_region,
+)
+
+
+def run_example() -> None:
+    reset_message_bus()
+    log: list[str] = []
+
+    def motor_handler(event):
+        log.append(f"motor received: {event['payload']}")
+
+    def visual_handler(event):
+        # Visual cortex decides to instruct the motor cortex
+        publish_neural_event({"target": "motor", "payload": event["payload"]})
+
+    subscribe_to_brain_region("visual", visual_handler)
+    subscribe_to_brain_region("motor", motor_handler)
+
+    publish_neural_event({"target": "visual", "payload": "move arm"})
+    print("\n".join(log))
+
+
+if __name__ == "__main__":
+    run_example()

--- a/tests/brain/test_message_bus.py
+++ b/tests/brain/test_message_bus.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from modules.brain.message_bus import (
+    CircuitBreaker,
+    publish_neural_event,
+    reset_message_bus,
+    subscribe_to_brain_region,
+)
+
+
+def test_publish_and_subscribe() -> None:
+    reset_message_bus()
+    received: list[str] = []
+
+    subscribe_to_brain_region("motor", lambda e: received.append(e["payload"]))
+    publish_neural_event({"target": "motor", "payload": "step"})
+
+    assert received == ["step"]
+
+
+def test_circuit_breaker_isolates_failures() -> None:
+    reset_message_bus()
+    calls: list[int] = []
+
+    def failing_handler(event):
+        calls.append(1)
+        raise ValueError("boom")
+
+    subscribe_to_brain_region("visual", failing_handler)
+    limit = CircuitBreaker().max_failures
+
+    for _ in range(limit + 1):
+        publish_neural_event({"target": "visual", "payload": None})
+
+    assert len(calls) == limit


### PR DESCRIPTION
## Summary
- introduce EventDispatcher, MessageRouter and CircuitBreaker for brain region messaging
- provide publish_neural_event and subscribe_to_brain_region interfaces with reset helper
- add example and tests demonstrating inter-region communication and fault isolation

## Testing
- `pytest tests/brain/test_message_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66c91dda8832f8624c342ef85cd21