### PR TITLE
feat: add self-healing brain utilities

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -5,6 +5,7 @@ from .limbic import LimbicSystem
 from .oscillations import NeuralOscillations
 from .whole_brain import WholeBrainSimulation
 from .security import NeuralSecurityGuard
+from .self_healing import SelfHealingBrain
 from .message_bus import (
     publish_neural_event,
     reset_message_bus,
@@ -21,6 +22,7 @@ __all__ = [
     "NeuralOscillations",
     "WholeBrainSimulation",
     "NeuralSecurityGuard",
+    "SelfHealingBrain",
     "publish_neural_event",
     "subscribe_to_brain_region",
     "reset_message_bus",

--- a/modules/brain/self_healing.py
+++ b/modules/brain/self_healing.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Self-healing brain utilities.
+
+This module combines performance monitoring and security checks to
+produce diagnostic reports and enact automatic repairs for simple
+simulations.  The implementation intentionally favours clarity over
+complexity so it can serve as a lightweight example for unit tests."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+import copy
+
+from .performance import profile_brain_performance, auto_optimize_performance
+from .security import NeuralSecurityGuard
+
+
+@dataclass
+class SelfHealingBrain:
+    """Orchestrates diagnosis and repair using monitoring modules."""
+
+    security_guard: NeuralSecurityGuard = field(default_factory=NeuralSecurityGuard)
+
+    def comprehensive_diagnosis(
+        self,
+        spikes: List[float],
+        currents: List[float],
+        latencies: List[float],
+        input_data: Dict[str, Any],
+        memory: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Run performance profiling and security scans.
+
+        Returns a nested dictionary containing performance metrics,
+        suggestions, security findings and sanitized input.
+        """
+
+        # Performance analysis
+        metrics, suggestions = profile_brain_performance(
+            spikes, currents, latencies
+        )
+
+        # Security analysis on a copy so the caller's data remains unchanged
+        original_input = copy.deepcopy(input_data)
+        sanitized_input = self.security_guard.validate_neural_input(
+            copy.deepcopy(input_data)
+        )
+        input_issues = sanitized_input != original_input
+
+        memory_copy = copy.deepcopy(memory)
+        memory_issues = self.security_guard.memory_checker.scan(memory_copy)
+
+        report = {
+            "performance": {"metrics": metrics, "suggestions": suggestions},
+            "security": {
+                "input_issues": input_issues,
+                "sanitized_input": sanitized_input,
+                "memory_issues": memory_issues,
+            },
+        }
+        return report
+
+    def generate_repair_plans(self, diagnosis: Dict[str, Any]) -> List[str]:
+        """Create human readable repair actions from *diagnosis*."""
+
+        plans: List[str] = []
+        plans.extend(diagnosis["performance"]["suggestions"])
+        if diagnosis["security"]["input_issues"]:
+            plans.append(
+                "Sanitize input data to remove adversarial patterns or triggers"
+            )
+        if diagnosis["security"]["memory_issues"]:
+            plans.append(
+                "Restore memory keys: "
+                + ", ".join(diagnosis["security"]["memory_issues"])
+            )
+        return plans
+
+    def execute_repairs(
+        self,
+        spikes: List[float],
+        currents: List[float],
+        latencies: List[float],
+        input_data: Dict[str, Any],
+        memory: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply optimisations and security repairs in-place.
+
+        The returned dictionary summarises adjustments taken and resulting
+        states of input data and memory.
+        """
+
+        performance_result = auto_optimize_performance(spikes, currents, latencies)
+        sanitized_input = self.security_guard.validate_neural_input(input_data)
+        memory_issues = self.security_guard.protect_neural_memory(memory)
+
+        return {
+            "performance": performance_result,
+            "sanitized_input": sanitized_input,
+            "memory_issues": memory_issues,
+        }
+
+
+__all__ = ["SelfHealingBrain"]

--- a/modules/tests/test_self_healing_brain.py
+++ b/modules/tests/test_self_healing_brain.py
@@ -1,0 +1,72 @@
+import copy
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.self_healing import SelfHealingBrain
+
+
+def test_self_healing_normal_scenario():
+    brain = SelfHealingBrain()
+
+    spikes = [0.1, 0.2, 0.1]
+    currents = [0.5, 0.5]
+    latencies = [0.1, 0.2]
+    input_data = {"value": 1, "text": "hello"}
+    memory = {"x": 1}
+
+    diagnosis = brain.comprehensive_diagnosis(
+        spikes, currents, latencies, copy.deepcopy(input_data), copy.deepcopy(memory)
+    )
+
+    assert diagnosis["performance"]["suggestions"] == []
+    assert not diagnosis["security"]["input_issues"]
+    assert diagnosis["security"]["memory_issues"] == []
+
+    plans = brain.generate_repair_plans(diagnosis)
+    assert plans == []
+
+    exec_result = brain.execute_repairs(spikes, currents, latencies, input_data, memory)
+
+    assert exec_result["performance"]["suggestions"] == []
+    assert exec_result["performance"]["adjustments"] == []
+    assert exec_result["sanitized_input"] == input_data
+    assert exec_result["memory_issues"] == []
+    assert memory == {"x": 1}
+
+
+def test_self_healing_detects_and_repairs_anomalies():
+    brain = SelfHealingBrain()
+
+    # Simulate previously recorded baseline for memory integrity
+    brain.security_guard.memory_checker.baseline = {"a": 1, "b": 2}
+
+    spikes = [0.1, 0.2, 0.3]
+    currents = [5.0, 5.0, 5.0]
+    latencies = [1.0, 0.8]
+    input_data = {"value": 20, "text": "hello trigger"}
+    memory = {"a": 1, "b": 3}
+
+    diagnosis = brain.comprehensive_diagnosis(
+        spikes, currents, latencies, copy.deepcopy(input_data), copy.deepcopy(memory)
+    )
+
+    suggestions = diagnosis["performance"]["suggestions"]
+    assert any("energy" in s.lower() for s in suggestions)
+    assert any("latency" in s.lower() for s in suggestions)
+    assert diagnosis["security"]["input_issues"] is True
+    assert diagnosis["security"]["memory_issues"] == ["b"]
+
+    plans = brain.generate_repair_plans(diagnosis)
+    assert any("Sanitize" in p for p in plans)
+    assert any("Restore memory keys: b" in p for p in plans)
+
+    exec_result = brain.execute_repairs(spikes, currents, latencies, input_data, memory)
+
+    assert exec_result["sanitized_input"]["value"] == 10
+    assert "trigger" not in exec_result["sanitized_input"]["text"]
+    assert exec_result["memory_issues"] == ["b"]
+    assert memory == {"a": 1, "b": 2}
+    assert exec_result["performance"]["suggestions"]
+    assert exec_result["performance"]["adjustments"]


### PR DESCRIPTION
## Summary
- add `SelfHealingBrain` to coordinate performance and security checks
- expose `SelfHealingBrain` from brain package
- test self-healing workflow for normal and anomalous scenarios

## Testing
- `pytest modules/tests/test_self_healing_brain.py`

------
https://chatgpt.com/codex/tasks/task_e_68c670889020832fb9614ace18804916