### PR TITLE
feat: add multimodal fusion engine

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -10,6 +10,7 @@ from .message_bus import (
     reset_message_bus,
     subscribe_to_brain_region,
 )
+from .multimodal import MultimodalFusionEngine
 
 __all__ = [
     "VisualCortex",
@@ -24,4 +25,5 @@ __all__ = [
     "publish_neural_event",
     "subscribe_to_brain_region",
     "reset_message_bus",
+    "MultimodalFusionEngine",
 ]

--- a/modules/brain/multimodal/__init__.py
+++ b/modules/brain/multimodal/__init__.py
@@ -1,0 +1,7 @@
+from .cross_modal_transformer import CrossModalTransformer
+from .fusion_engine import MultimodalFusionEngine
+
+__all__ = [
+    "CrossModalTransformer",
+    "MultimodalFusionEngine",
+]

--- a/modules/brain/multimodal/cross_modal_transformer.py
+++ b/modules/brain/multimodal/cross_modal_transformer.py
@@ -1,0 +1,64 @@
+"""Simple cross-modal transformer for modality alignment and fusion.
+
+This module provides a tiny stand-in implementation that projects each
+modality to a common embedding space and averages them.  It is designed
+for testing and illustrative purposes rather than performance.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+class CrossModalTransformer:
+    """Align and fuse multiple sensory modalities into one vector.
+
+    Parameters
+    ----------
+    output_dim:
+        Dimensionality of the shared representation space.  All modalities
+        are projected to this size before fusion.
+    """
+
+    def __init__(self, output_dim: int = 16) -> None:
+        self.output_dim = int(output_dim)
+
+    def _project(self, x: np.ndarray) -> np.ndarray:
+        """Project an input modality to the shared representation space.
+
+        The projection here is intentionally simple: we compute the mean of
+        the modality and repeat it ``output_dim`` times.  This keeps the
+        implementation deterministic and lightweight while allowing tests to
+        verify behaviour.
+        """
+
+        arr = np.asarray(x, dtype=float).reshape(-1)
+        if arr.size == 0:
+            raise ValueError("modality input is empty")
+        mean = arr.mean()
+        return np.full(self.output_dim, mean, dtype=float)
+
+    def fuse(self, modalities: Sequence[np.ndarray]) -> np.ndarray:
+        """Fuse multiple modalities into a unified representation.
+
+        Parameters
+        ----------
+        modalities:
+            Sequence of modality arrays to be fused.  Each modality is first
+            aligned to the shared space and then averaged.
+
+        Returns
+        -------
+        np.ndarray
+            The fused representation of shape ``(output_dim,)``.
+        """
+
+        if not modalities or any(m is None for m in modalities):
+            raise ValueError("modalities must be provided")
+        aligned = [self._project(m) for m in modalities]
+        return np.mean(aligned, axis=0)
+
+
+__all__ = ["CrossModalTransformer"]

--- a/modules/brain/multimodal/fusion_engine.py
+++ b/modules/brain/multimodal/fusion_engine.py
@@ -1,0 +1,48 @@
+"""Engine for fusing multiple sensory modalities.
+
+The :class:`MultimodalFusionEngine` provides a tiny abstraction around a
+``CrossModalTransformer``.  It exposes a dependency injection interface so
+that different transformer implementations can be supplied in tests or by
+other parts of the system.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .cross_modal_transformer import CrossModalTransformer
+
+
+class MultimodalFusionEngine:
+    """Fuse visual, auditory and tactile data into a shared representation."""
+
+    def __init__(self, transformer: Optional[CrossModalTransformer] = None) -> None:
+        self._transformer = transformer or CrossModalTransformer()
+
+    def set_transformer(self, transformer: CrossModalTransformer) -> None:
+        """Inject a different :class:`CrossModalTransformer` instance."""
+
+        self._transformer = transformer
+
+    def fuse_sensory_modalities(
+        self, visual: np.ndarray, auditory: np.ndarray, tactile: np.ndarray
+    ) -> np.ndarray:
+        """Return a unified representation of the provided modalities.
+
+        Parameters
+        ----------
+        visual, auditory, tactile:
+            Arrays containing the sensory data.  All three modalities must be
+            supplied.  Each is aligned via the configured transformer and then
+            fused into a single representation.
+        """
+
+        modalities = [visual, auditory, tactile]
+        if any(m is None for m in modalities):
+            raise ValueError("all modalities must be provided")
+        return self._transformer.fuse(modalities)
+
+
+__all__ = ["MultimodalFusionEngine"]

--- a/modules/tests/multimodal/test_fusion_engine.py
+++ b/modules/tests/multimodal/test_fusion_engine.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.multimodal import CrossModalTransformer, MultimodalFusionEngine
+
+
+def test_fused_representation_shape_and_value():
+    transformer = CrossModalTransformer(output_dim=4)
+    engine = MultimodalFusionEngine(transformer)
+    visual = np.array([1.0, 3.0])
+    auditory = np.array([2.0, 2.0])
+    tactile = np.array([1.0, 1.0, 1.0])
+    fused = engine.fuse_sensory_modalities(visual, auditory, tactile)
+    expected_val = np.mean([visual.mean(), auditory.mean(), tactile.mean()])
+    assert fused.shape == (4,)
+    np.testing.assert_allclose(fused, expected_val)
+
+
+def test_missing_modality_raises_error():
+    engine = MultimodalFusionEngine()
+    visual = np.array([1.0])
+    auditory = np.array([1.0])
+    with pytest.raises(ValueError):
+        engine.fuse_sensory_modalities(visual, auditory, None)
+
+
+def test_dependency_injection():
+    class DummyTransformer:
+        def fuse(self, modalities):
+            return np.array([sum(np.sum(m) for m in modalities)])
+
+    engine = MultimodalFusionEngine()
+    engine.set_transformer(DummyTransformer())
+    fused = engine.fuse_sensory_modalities(
+        np.array([1.0]), np.array([2.0]), np.array([3.0])
+    )
+    assert fused.shape == (1,)
+    assert fused[0] == 6.0


### PR DESCRIPTION
## Summary
- implement lightweight `CrossModalTransformer` for modality alignment and fusion
- add `MultimodalFusionEngine` with dependency injection and sensory fusion
- include comprehensive tests for fusion accuracy, injection, and error handling

## Testing
- `pytest modules/tests/multimodal/test_fusion_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c671837e60832f8ac48e5fa7926604