### PR TITLE
feat: add module interface with dependency-aware loader

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -12,6 +12,7 @@ from .message_bus import (
     subscribe_to_brain_region,
 )
 from .multimodal import MultimodalFusionEngine
+from .adapter import BrainModule
 
 __all__ = [
     "VisualCortex",
@@ -28,4 +29,5 @@ __all__ = [
     "subscribe_to_brain_region",
     "reset_message_bus",
     "MultimodalFusionEngine",
+    "BrainModule",
 ]

--- a/modules/brain/adapter.py
+++ b/modules/brain/adapter.py
@@ -1,0 +1,21 @@
+"""Adapter for brain module implementing the common ModuleInterface."""
+
+from __future__ import annotations
+
+from modules.interface import ModuleInterface
+
+
+class BrainModule(ModuleInterface):
+    """Thin adapter exposing brain functionality via ModuleInterface."""
+
+    # For demonstration purposes the brain depends on the evolution module.
+    dependencies = ["evolution"]
+
+    def __init__(self) -> None:
+        self.initialized = False
+
+    def initialize(self) -> None:  # pragma: no cover - trivial
+        self.initialized = True
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        self.initialized = False

--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -7,6 +7,7 @@ from .evolving_cognitive_architecture import (
     EvolvingCognitiveArchitecture,
     GeneticAlgorithm as EvolutionGeneticAlgorithm,
 )
+from .adapter import EvolutionModule
 
 try:  # optional dependencies
     from .ppo import PPO, PPOConfig
@@ -62,4 +63,5 @@ __all__ = [
     "A3CConfig",
     "SAC",
     "SACConfig",
+    "EvolutionModule",
 ]

--- a/modules/evolution/adapter.py
+++ b/modules/evolution/adapter.py
@@ -1,0 +1,20 @@
+"""Adapter for evolution module implementing the common ModuleInterface."""
+
+from __future__ import annotations
+
+from modules.interface import ModuleInterface
+
+
+class EvolutionModule(ModuleInterface):
+    """Expose evolution capabilities via ModuleInterface."""
+
+    dependencies: list[str] = []
+
+    def __init__(self) -> None:
+        self.initialized = False
+
+    def initialize(self) -> None:  # pragma: no cover - trivial
+        self.initialized = True
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        self.initialized = False

--- a/modules/interface/__init__.py
+++ b/modules/interface/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Common interface for AutoGPT modules."""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class ModuleInterface(ABC):
+    """Abstract base class for all dynamic modules.
+
+    Modules can declare other modules they depend on via the ``dependencies``
+    attribute. The :class:`RuntimeModuleManager` uses this information to load
+    modules in the correct order and to call the lifecycle hooks.
+    """
+
+    #: Names of modules that must be loaded before this module initializes.
+    dependencies: List[str] = []
+
+    @abstractmethod
+    def initialize(self) -> None:
+        """Perform any setup after all dependencies have loaded."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Gracefully release resources before the module is unloaded."""

--- a/tests/test_runtime_module_manager.py
+++ b/tests/test_runtime_module_manager.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from backend.capability import register_module
 from backend.capability.runtime_loader import RuntimeModuleManager
+from modules.interface import ModuleInterface
 
 
 def test_runtime_module_manager_load_and_unload():
@@ -31,3 +32,32 @@ def test_runtime_module_manager_update(tmp_path):
 
     mgr.update([])
     assert name not in mgr.loaded_modules()
+
+
+def test_runtime_module_manager_resolves_dependencies():
+    class Dep(ModuleInterface):
+        initialized = False
+        def initialize(self) -> None:
+            self.initialized = True
+        def shutdown(self) -> None:
+            self.initialized = False
+
+    class Main(ModuleInterface):
+        dependencies = ["dep"]
+        initialized = False
+        def initialize(self) -> None:
+            self.initialized = True
+        def shutdown(self) -> None:
+            self.initialized = False
+
+    register_module("dep", Dep)
+    register_module("main", Main)
+
+    mgr = RuntimeModuleManager()
+    main_mod = mgr.load("main")
+    dep_mod = mgr.load("dep")  # should return already loaded dependency
+
+    # both main and dependency should be loaded and initialized
+    assert "dep" in mgr.loaded_modules()
+    assert "main" in mgr.loaded_modules()
+    assert main_mod.initialized and dep_mod.initialized


### PR DESCRIPTION
## Summary
- introduce `ModuleInterface` for consistent module lifecycle and dependency declarations
- add adapters for brain and evolution modules implementing the interface
- enhance `RuntimeModuleManager` to resolve dependencies and trigger lifecycle hooks
- test dependency resolution when loading modules

## Testing
- `pytest tests/test_runtime_module_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c676e2b8ac832f8e5c698d6f1d8e1f