### PR TITLE
feat(monitoring): add auto optimizer

### DIFF
--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -5,6 +5,7 @@ from .storage import TimeSeriesStorage
 from .system_metrics import SystemMetricsCollector
 from .metrics_collector import MetricsCollector
 from .performance_monitor import PerformanceMonitor, email_alert, dashboard_alert
+from .auto_optimizer import AutoOptimizer
 from .reflection import Reflection
 from .global_workspace import GlobalWorkspace, global_workspace
 from .brain_state import create_app as create_brain_app, record_memory_hit
@@ -19,6 +20,7 @@ __all__ = [
     "PerformanceMonitor",
     "email_alert",
     "dashboard_alert",
+    "AutoOptimizer",
     "Reflection",
     "GlobalWorkspace",
     "global_workspace",

--- a/backend/monitoring/auto_optimizer.py
+++ b/backend/monitoring/auto_optimizer.py
@@ -1,0 +1,143 @@
+"""Automatic optimization utilities for monitoring module.
+
+The :class:`AutoOptimizer` adjusts resource allocation or model parameters
+based on simple threshold strategies. Optimization decisions and their
+observed effects are recorded in the time-series storage for later analysis.
+"""
+from __future__ import annotations
+
+from typing import Dict, Tuple, Any
+
+from .performance_monitor import PerformanceMonitor
+from .storage import TimeSeriesStorage
+
+
+class AutoOptimizer:
+    """Adjust resources or parameters based on monitoring metrics.
+
+    The optimizer uses basic threshold-based heuristics to tweak resource
+    allocation limits (``cpu_limit`` and ``memory_limit``) as well as arbitrary
+    model parameters. All optimization decisions are logged to the provided
+    :class:`~monitoring.storage.TimeSeriesStorage` instance for offline
+    analysis.
+    """
+
+    def __init__(
+        self,
+        monitor: PerformanceMonitor,
+        storage: TimeSeriesStorage,
+        *,
+        cpu_threshold: float | None = None,
+        memory_threshold: float | None = None,
+        accuracy_threshold: float | None = None,
+        adjustment_factor: float = 0.1,
+        parameter_bounds: Dict[str, Tuple[float, float]] | None = None,
+    ) -> None:
+        self.monitor = monitor
+        self.storage = storage
+        self.cpu_threshold = cpu_threshold
+        self.memory_threshold = memory_threshold
+        self.accuracy_threshold = accuracy_threshold
+        self.adjustment_factor = adjustment_factor
+        self.resource_allocation: Dict[str, float] = {
+            "cpu_limit": 1.0,
+            "memory_limit": 1.0,
+        }
+        self.parameter_bounds = parameter_bounds or {}
+        self.model_params: Dict[str, float] = {
+            name: (bounds[0] + bounds[1]) / 2 for name, bounds in self.parameter_bounds.items()
+        }
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def step(self) -> None:
+        """Run one optimization step.
+
+        This checks the latest metrics from :class:`PerformanceMonitor` and
+        adjusts resource allocations or model parameters when thresholds are
+        exceeded. Each adjustment is recorded together with the observed metric
+        values before and after the change.
+        """
+
+        self._optimize_resources()
+        self._optimize_parameters()
+
+    # ------------------------------------------------------------------
+    # resource optimization
+    # ------------------------------------------------------------------
+    def _optimize_resources(self) -> None:
+        if self.cpu_threshold is not None:
+            cpu_usage = self.monitor.cpu_usage()
+            if cpu_usage > self.cpu_threshold:
+                before = self.resource_allocation["cpu_limit"]
+                after = before * (1 + self.adjustment_factor)
+                self.resource_allocation["cpu_limit"] = after
+                self.storage.store(
+                    "optimization",
+                    {
+                        "metric": "cpu",
+                        "decision": {
+                            "resource": "cpu_limit",
+                            "before": before,
+                            "after": after,
+                        },
+                        "effect": {
+                            "usage_before": cpu_usage,
+                            "usage_after": self.monitor.cpu_usage(),
+                        },
+                    },
+                )
+        if self.memory_threshold is not None:
+            mem_usage = self.monitor.memory_usage()
+            if mem_usage > self.memory_threshold:
+                before = self.resource_allocation["memory_limit"]
+                after = before * (1 + self.adjustment_factor)
+                self.resource_allocation["memory_limit"] = after
+                self.storage.store(
+                    "optimization",
+                    {
+                        "metric": "memory",
+                        "decision": {
+                            "resource": "memory_limit",
+                            "before": before,
+                            "after": after,
+                        },
+                        "effect": {
+                            "usage_before": mem_usage,
+                            "usage_after": self.monitor.memory_usage(),
+                        },
+                    },
+                )
+
+    # ------------------------------------------------------------------
+    # parameter optimization
+    # ------------------------------------------------------------------
+    def _optimize_parameters(self) -> None:
+        if self.accuracy_threshold is None:
+            return
+        acc = self.monitor.current_accuracy()
+        if acc >= self.accuracy_threshold:
+            return
+        for name, bounds in self.parameter_bounds.items():
+            before = self.model_params[name]
+            span = bounds[1] - bounds[0]
+            delta = span * self.adjustment_factor
+            after = min(bounds[1], before + delta)
+            self.model_params[name] = after
+            self.storage.store(
+                "optimization",
+                {
+                    "metric": "accuracy",
+                    "decision": {
+                        "parameter": name,
+                        "before": before,
+                        "after": after,
+                    },
+                    "effect": {
+                        "accuracy_before": acc,
+                        "accuracy_after": self.monitor.current_accuracy(),
+                    },
+                },
+            )
+

--- a/backend/tests/test_auto_optimizer.py
+++ b/backend/tests/test_auto_optimizer.py
@@ -1,0 +1,40 @@
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+# prepare module paths
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+sys.modules.setdefault("events", types.SimpleNamespace(EventBus=object))
+sys.modules.setdefault(
+    "common", types.SimpleNamespace(AutoGPTException=Exception, log_and_format_exception=lambda err: None)
+)
+
+monitoring_dir = Path(__file__).resolve().parent.parent / "monitoring"
+monitoring_pkg = types.ModuleType("monitoring")
+monitoring_pkg.__path__ = [str(monitoring_dir)]
+sys.modules["monitoring"] = monitoring_pkg
+
+auto_opt_mod = importlib.import_module("monitoring.auto_optimizer")
+perf_mod = importlib.import_module("monitoring.performance_monitor")
+storage_mod = importlib.import_module("monitoring.storage")
+
+AutoOptimizer = auto_opt_mod.AutoOptimizer
+PerformanceMonitor = perf_mod.PerformanceMonitor
+TimeSeriesStorage = storage_mod.TimeSeriesStorage
+
+
+def test_auto_optimizer_adjusts_and_logs(tmp_path: Path) -> None:
+    storage = TimeSeriesStorage(tmp_path / "opt.db")
+    monitor = PerformanceMonitor(storage, training_accuracy=1.0, degradation_threshold=0.1)
+    monitor.log_resource_usage("agent", cpu=90.0, memory=10.0)
+    optimizer = AutoOptimizer(monitor, storage, cpu_threshold=80.0)
+
+    optimizer.step()
+
+    assert optimizer.resource_allocation["cpu_limit"] > 1.0
+    events = storage.events("optimization")
+    assert events
+    assert any(e.get("metric") == "cpu" for e in events)

--- a/scripts/auto_optimizer_experiment.py
+++ b/scripts/auto_optimizer_experiment.py
@@ -1,0 +1,72 @@
+"""Long-running experiment for AutoOptimizer.
+
+This script simulates a system over an extended period, periodically logging
+resource usage and prediction outcomes. The
+:class:`~monitoring.auto_optimizer.AutoOptimizer` reacts to these metrics and
+records each optimization decision along with the observed effect. Inspecting
+the stored events after the run provides insight into the benefits of automatic
+tuning.
+
+Run the experiment:
+
+    python scripts/auto_optimizer_experiment.py --duration 60
+
+The default duration is short for demonstration purposes, but it can be
+increased for more exhaustive experiments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import time
+from pathlib import Path
+
+from monitoring import AutoOptimizer, PerformanceMonitor, TimeSeriesStorage
+
+
+def run(duration: int) -> None:
+    storage = TimeSeriesStorage(Path("experiment.db"))
+    monitor = PerformanceMonitor(
+        storage,
+        training_accuracy=0.9,
+        degradation_threshold=0.1,
+        cpu_threshold=80.0,
+        memory_threshold=80.0,
+    )
+    optimizer = AutoOptimizer(
+        monitor,
+        storage,
+        cpu_threshold=80.0,
+        memory_threshold=80.0,
+        accuracy_threshold=0.8,
+        parameter_bounds={"learning_rate": (0.001, 0.1)},
+    )
+
+    start = time.time()
+    while time.time() - start < duration:
+        # simulate metrics
+        monitor.log_resource_usage("agent", random.uniform(0, 100), random.uniform(0, 100))
+        prediction = 1 if random.random() > 0.5 else 0
+        outcome = 1 if random.random() > 0.3 else 0
+        monitor.log_prediction(prediction, outcome)
+
+        optimizer.step()
+        time.sleep(1)
+
+    events = storage.events("optimization")
+    print(f"Recorded {len(events)} optimization events")
+    for e in events:
+        print(e)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run AutoOptimizer experiment")
+    parser.add_argument("--duration", type=int, default=10, help="Duration of experiment in seconds")
+    args = parser.parse_args()
+    run(args.duration)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add AutoOptimizer to monitoring to tune resource allocation and model params based on thresholds
- log optimization decisions/effects for later analysis
- include script and tests for long-running experiments

## Testing
- `pytest backend/tests/test_auto_optimizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c67706e6d4832f80e82a19cc9371a1