### PR TITLE
feat: add quantum hardware interface and task queue

### DIFF
--- a/modules/brain/quantum/__init__.py
+++ b/modules/brain/quantum/__init__.py
@@ -5,6 +5,7 @@ from .quantum_attention import QuantumAttention
 from .quantum_reasoning import QuantumReasoning
 from .grover_search import grover_search
 from .quantum_ml import QuantumClassifier
+from .hardware_interface import QuantumHardwareInterface
 
 __all__ = [
     "SuperpositionState",
@@ -15,4 +16,5 @@ __all__ = [
     "QuantumReasoning",
     "grover_search",
     "QuantumClassifier",
+    "QuantumHardwareInterface",
 ]

--- a/modules/brain/quantum/hardware_interface.py
+++ b/modules/brain/quantum/hardware_interface.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Abstraction layer for interacting with quantum hardware backends.
+
+This module provides a minimal wrapper around different quantum computation
+backends such as Qiskit or Amazon Braket.  The implementation intentionally
+keeps the interface lightweight so unit tests can mock the behaviour without
+requiring the actual heavy dependencies to be installed.
+"""
+
+from typing import Any, Mapping
+
+
+class QuantumHardwareInterface:
+    """Facade for executing circuits on various quantum backends."""
+
+    def __init__(self, backend: str = "local", **config: Any) -> None:
+        self.backend = backend
+        self.config = config
+        self.client: Any | None = None
+
+    # ------------------------------------------------------------------
+    # Connection utilities
+    def connect(self) -> Any:
+        """Connect to the configured backend and return the client object."""
+
+        if self.backend == "qiskit":  # pragma: no cover - requires qiskit
+            from qiskit import IBMQ
+
+            token = self.config.get("token")
+            if token:
+                IBMQ.enable_account(token)
+            provider = IBMQ.load_account()
+            backend_name = self.config.get("backend_name", "qasm_simulator")
+            self.client = provider.get_backend(backend_name)
+        elif self.backend == "braket":  # pragma: no cover - requires braket
+            from braket.aws import AwsDevice
+
+            arn = self.config.get("device_arn")
+            self.client = AwsDevice(arn)
+        else:
+            # "local" mode does not require a connection
+            self.client = None
+        return self.client
+
+    # ------------------------------------------------------------------
+    # Execution utilities
+    def run(self, circuit: Any, shots: int = 1024) -> Any:
+        """Execute *circuit* on the selected backend."""
+
+        if self.backend == "qiskit":  # pragma: no cover - requires qiskit
+            from qiskit import execute
+
+            job = execute(circuit, self.client, shots=shots)
+            return job.result()
+        if self.backend == "braket":  # pragma: no cover - requires braket
+            task = self.client.run(circuit, shots=shots)
+            return task.result()
+
+        # Local simulation: allow ``circuit`` to be a callable or have a
+        # ``simulate`` method.  If neither is available, assume it already
+        # represents the result.
+        if callable(circuit):
+            return circuit()
+        if hasattr(circuit, "simulate"):
+            return circuit.simulate(shots=shots)
+        return circuit
+
+    # ------------------------------------------------------------------
+    # Result handling
+    def parse_counts(self, result: Any) -> Mapping[str, int] | dict[str, int]:
+        """Extract measurement counts from a backend result object."""
+
+        if hasattr(result, "get_counts"):
+            return dict(result.get_counts())
+        if hasattr(result, "counts"):
+            return dict(result.counts)
+        if hasattr(result, "measurement_counts"):
+            return dict(result.measurement_counts)
+        if isinstance(result, Mapping):
+            return dict(result)
+        return {}
+
+
+__all__ = ["QuantumHardwareInterface"]

--- a/tests/quantum/test_quantum_hardware_interface.py
+++ b/tests/quantum/test_quantum_hardware_interface.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# Ensure repository root on path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.brain.quantum.quantum_cognition import QuantumCognition
+from modules.brain.quantum.hardware_interface import QuantumHardwareInterface
+
+
+class DummyCircuit:
+    def __init__(self, counts=None):
+        self._counts = counts or {"00": 1024}
+
+    def simulate(self, shots=1024):
+        # Return a copy so tests can mutate without affecting internal state
+        return dict(self._counts)
+
+
+def test_local_simulation_task_queue():
+    qc = QuantumCognition()
+    circuit = DummyCircuit({"00": 100})
+    qc.add_task(circuit, shots=100)
+    results = qc.run_tasks()
+    assert results == [{"00": 100}]
+
+
+def test_hardware_backend_task_queue():
+    # Create a mocked hardware interface
+    mock_iface = Mock(spec=QuantumHardwareInterface)
+    raw_result = object()
+    mock_iface.run.return_value = raw_result
+    mock_iface.parse_counts.return_value = {"11": 7}
+
+    qc = QuantumCognition(hardware=mock_iface, backend="qiskit")
+    qc.add_task("circuit", shots=7)
+    results = qc.run_tasks()
+
+    mock_iface.run.assert_called_once_with("circuit", shots=7)
+    mock_iface.parse_counts.assert_called_once_with(raw_result)
+    assert results == [{"11": 7}]


### PR DESCRIPTION
## Summary
- add `QuantumHardwareInterface` abstraction for Qiskit/Braket or local backends
- extend `QuantumCognition` to queue and run tasks on hardware or local simulator
- cover new hardware interface with unit tests for both local and mocked hardware execution

## Testing
- `pytest tests/quantum/test_quantum_cognition.py tests/quantum/test_quantum_interfaces.py tests/quantum/test_quantum_hardware_interface.py -q`
- `pytest tests/quantum -q`

------
https://chatgpt.com/codex/tasks/task_e_68c67a980218832f8961643c11e7af1a