### PR TITLE
feat: add self-evolving cognition based on performance metrics

### DIFF
--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -7,6 +7,7 @@ from .evolving_cognitive_architecture import (
     EvolvingCognitiveArchitecture,
     GeneticAlgorithm as EvolutionGeneticAlgorithm,
 )
+from .self_evolving_cognition import SelfEvolvingCognition
 from .adapter import EvolutionModule
 
 try:  # optional dependencies
@@ -57,6 +58,7 @@ __all__ = [
     "ReplayBuffer",
     "EvolvingCognitiveArchitecture",
     "EvolutionGeneticAlgorithm",
+    "SelfEvolvingCognition",
     "PPO",
     "PPOConfig",
     "A3C",

--- a/modules/evolution/self_evolving_cognition.py
+++ b/modules/evolution/self_evolving_cognition.py
@@ -1,0 +1,94 @@
+"""Self-evolving cognition module integrating performance monitoring.
+
+This module provides :class:`SelfEvolvingCognition` which observes performance
+metrics and automatically triggers evolution of a cognitive architecture using
+:class:`EvolvingCognitiveArchitecture`.  After each evolution step the
+performance and architecture version are recorded, enabling rollback and
+comparison of past versions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from modules.monitoring.collector import MetricEvent, RealTimeMetricsCollector
+from .evolving_cognitive_architecture import EvolvingCognitiveArchitecture
+
+
+@dataclass
+class EvolutionRecord:
+    """Record of a single evolution step."""
+
+    version: int
+    architecture: Dict[str, float]
+    performance: float
+
+
+class SelfEvolvingCognition:
+    """Automatically evolve a cognitive architecture based on performance metrics."""
+
+    def __init__(
+        self,
+        initial_architecture: Dict[str, float],
+        evolver: EvolvingCognitiveArchitecture,
+        collector: Optional[RealTimeMetricsCollector] = None,
+    ) -> None:
+        self.architecture = initial_architecture
+        self.evolver = evolver
+        self.collector = collector
+        self._processed_events = 0
+        self.version = 0
+        initial_perf = self.evolver.fitness_fn(initial_architecture)
+        self.history: List[EvolutionRecord] = [
+            EvolutionRecord(self.version, initial_architecture.copy(), initial_perf)
+        ]
+
+    # ------------------------------------------------------------------
+    def _score_event(self, event: MetricEvent) -> float:
+        """Derive a scalar performance score from a metric event."""
+
+        return event.throughput - event.latency - event.energy
+
+    # ------------------------------------------------------------------
+    def _process_event(self, event: MetricEvent) -> None:
+        """Process a new metric event and evolve the architecture."""
+
+        performance = self._score_event(event)
+        new_arch = self.evolver.evolve_architecture(self.architecture, performance)
+        new_perf = self.evolver.fitness_fn(new_arch)
+        self.version += 1
+        self.architecture = new_arch
+        self.history.append(
+            EvolutionRecord(self.version, new_arch.copy(), new_perf)
+        )
+
+    # ------------------------------------------------------------------
+    def observe(self) -> None:
+        """Observe new metric events and trigger evolution steps."""
+
+        if self.collector is None:
+            return
+        events = self.collector.events()
+        for event in events[self._processed_events :]:
+            self._process_event(event)
+        self._processed_events = len(events)
+
+    # ------------------------------------------------------------------
+    def rollback(self, version: int) -> Dict[str, float]:
+        """Rollback to a previous architecture version."""
+
+        for record in self.history:
+            if record.version == version:
+                self.architecture = record.architecture.copy()
+                self.version = record.version
+                return self.architecture
+        raise ValueError(f"Version {version} not found in history")
+
+    # ------------------------------------------------------------------
+    def compare(self, v1: int, v2: int) -> Dict[str, float]:
+        """Compare the performance between two versions."""
+
+        rec1 = next(r for r in self.history if r.version == v1)
+        rec2 = next(r for r in self.history if r.version == v2)
+        return {"performance_diff": rec2.performance - rec1.performance}

--- a/tests/evolution/test_self_evolving_cognition.py
+++ b/tests/evolution/test_self_evolving_cognition.py
@@ -1,0 +1,43 @@
+"""Tests for the SelfEvolvingCognition module."""
+
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.evolution import (
+    EvolvingCognitiveArchitecture,
+    EvolutionGeneticAlgorithm,
+    SelfEvolvingCognition,
+)
+from modules.evolution.evolving_cognitive_architecture import GAConfig
+from modules.monitoring.collector import MetricEvent, RealTimeMetricsCollector
+
+
+def fitness_fn(arch):
+    x = arch["weight"]
+    return -(x - 1.0) ** 2
+
+
+def test_long_term_evolution_improves_performance():
+    random.seed(0)
+    ga = EvolutionGeneticAlgorithm(fitness_fn, GAConfig(population_size=10, generations=5, mutation_sigma=0.5))
+    evolver = EvolvingCognitiveArchitecture(fitness_fn, ga)
+    collector = RealTimeMetricsCollector()
+    cognition = SelfEvolvingCognition({"weight": 0.0}, evolver, collector)
+
+    for step in range(5):
+        perf = fitness_fn(cognition.architecture)
+        event = MetricEvent(
+            module="evolve", latency=0.0, energy=0.0, throughput=perf, timestamp=float(step)
+        )
+        collector._events.append(event)
+        cognition.observe()
+
+    performances = [rec.performance for rec in cognition.history]
+    assert performances[-1] > performances[0]
+    cognition.rollback(0)
+    assert cognition.architecture == cognition.history[0].architecture
+    diff = cognition.compare(0, len(cognition.history) - 1)
+    assert diff["performance_diff"] == performances[-1] - performances[0]


### PR DESCRIPTION
## Summary
- integrate RealTimeMetricsCollector with a new SelfEvolvingCognition helper that monitors metrics and evolves the cognitive architecture
- track versioned evolution history with rollback and comparison utilities
- add long-term evolution test ensuring performance improves across iterations

## Testing
- `pytest tests/evolution/test_self_evolving_cognition.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c67aa64e48832fb63690ef69299816