### PR TITLE
Add brain-computer interface module with async streaming

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -13,6 +13,7 @@ from .message_bus import (
 )
 from .multimodal import MultimodalFusionEngine
 from .adapter import BrainModule
+from .bci import BrainComputerInterface
 
 __all__ = [
     "VisualCortex",
@@ -30,4 +31,5 @@ __all__ = [
     "reset_message_bus",
     "MultimodalFusionEngine",
     "BrainModule",
+    "BrainComputerInterface",
 ]

--- a/modules/brain/bci/__init__.py
+++ b/modules/brain/bci/__init__.py
@@ -1,0 +1,96 @@
+"""Brain-computer interface abstractions.
+
+This module provides an asynchronous ``BrainComputerInterface`` that interacts
+with EEG, EMG, and robotic arm devices through pluggable device adapters. It
+supports error recovery and ships with a ``MockDeviceAdapter`` for testing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator, Callable, Iterable, Optional
+
+
+class DeviceAdapter:
+    """Abstract adapter for BCI peripheral devices."""
+
+    async def read(self) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    async def write(self, data: Any) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    async def reset(self) -> None:  # pragma: no cover - interface
+        """Reset the device after an error."""
+        return None
+
+
+class BrainComputerInterface:
+    """Coordinates asynchronous I/O with a BCI device.
+
+    Data from the device can be consumed via the asynchronous ``stream``
+    generator. If a device error occurs, the interface attempts to reset the
+    adapter and continue streaming.
+    """
+
+    def __init__(self, device: DeviceAdapter) -> None:
+        self.device = device
+        self._listeners: list[Callable[[Any], None]] = []
+
+    def add_listener(self, callback: Callable[[Any], None]) -> None:
+        """Register a callback invoked for every received item."""
+
+        self._listeners.append(callback)
+
+    async def stream(self) -> AsyncIterator[Any]:
+        """Yield data from the device indefinitely with error recovery."""
+
+        while True:
+            try:
+                data = await self.device.read()
+            except Exception:  # pragma: no cover - error path tested separately
+                await self.device.reset()
+                continue
+            for cb in self._listeners:
+                cb(data)
+            yield data
+
+    async def send(self, data: Any) -> None:
+        """Send data to the device."""
+
+        await self.device.write(data)
+
+
+class MockDeviceAdapter(DeviceAdapter):
+    """Simple in-memory adapter for testing and simulation.
+
+    Parameters
+    ----------
+    data_stream:
+        Iterable providing initial data to be read from the device.
+    fail_at:
+        Optional index at which ``read`` will raise ``RuntimeError`` to simulate
+        a device failure. After a call to ``reset`` the adapter resumes normal
+        operation.
+    """
+
+    def __init__(self, data_stream: Iterable[Any], fail_at: Optional[int] = None) -> None:
+        self.queue: asyncio.Queue[Any] = asyncio.Queue()
+        for item in data_stream:
+            self.queue.put_nowait(item)
+        self.fail_at = fail_at
+        self._count = 0
+
+    async def read(self) -> Any:
+        if self.fail_at is not None and self._count >= self.fail_at:
+            # simulate failure before consuming next item
+            self._count = 0
+            raise RuntimeError("simulated device failure")
+        self._count += 1
+        return await self.queue.get()
+
+    async def write(self, data: Any) -> None:
+        await self.queue.put(data)
+
+    async def reset(self) -> None:
+        self._count = 0

--- a/tests/bci/test_brain_computer_interface.py
+++ b/tests/bci/test_brain_computer_interface.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from modules.brain.bci import BrainComputerInterface, MockDeviceAdapter
+
+
+def test_stream_basic():
+    adapter = MockDeviceAdapter([1, 2, 3])
+    bci = BrainComputerInterface(adapter)
+
+    async def runner():
+        stream = bci.stream()
+        return [await stream.__anext__() for _ in range(3)]
+
+    results = asyncio.run(runner())
+    assert results == [1, 2, 3]
+
+
+def test_send_and_receive():
+    adapter = MockDeviceAdapter([])
+    bci = BrainComputerInterface(adapter)
+
+    async def runner():
+        await bci.send("ping")
+        stream = bci.stream()
+        return await stream.__anext__()
+
+    assert asyncio.run(runner()) == "ping"
+
+
+def test_error_recovery():
+    adapter = MockDeviceAdapter(["ok", "after"], fail_at=1)
+    bci = BrainComputerInterface(adapter)
+
+    async def runner():
+        stream = bci.stream()
+        first = await stream.__anext__()
+        second = await stream.__anext__()
+        return first, second
+
+    assert asyncio.run(runner()) == ("ok", "after")


### PR DESCRIPTION
## Summary
- introduce BrainComputerInterface for asynchronous EEG/EMG/robotic device I/O with error recovery
- provide MockDeviceAdapter for simulation and testing
- add basic streaming, send/receive, and fault injection tests

## Testing
- `pytest tests/bci -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67aa3ca58832f8fa7f6a2b0fae394