### PR TITLE
feat: add neuromorphic-quantum hybrid processing

### DIFF
--- a/modules/brain/hybrid/__init__.py
+++ b/modules/brain/hybrid/__init__.py
@@ -1,0 +1,5 @@
+"""Hybrid neuromorphic-quantum processing utilities."""
+
+from .neuromorphic_quantum_hybrid import NeuromorphicQuantumHybrid
+
+__all__ = ["NeuromorphicQuantumHybrid"]

--- a/modules/brain/hybrid/neuromorphic_quantum_hybrid.py
+++ b/modules/brain/hybrid/neuromorphic_quantum_hybrid.py
@@ -1,0 +1,68 @@
+"""Neuromorphic-quantum hybrid processing module."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+import numpy as np
+
+from modules.brain.neuromorphic import temporal_encoding
+
+
+class NeuromorphicQuantumHybrid:
+    """Combine neuromorphic preprocessing with quantum feature mapping."""
+
+    def neuromorphic_preprocess(self, signal: Iterable[float]) -> List[int]:
+        """Simple neuromorphic feature extraction via thresholding and latency encoding."""
+        values = [1.0 if x >= 0.5 else 0.0 for x in signal]
+        events = temporal_encoding.latency_encode(values)
+        features = [0] * len(values)
+        for _, spikes in events:
+            for i, s in enumerate(spikes):
+                features[i] += s
+        return features
+
+    def quantum_feature_map(self, features: Iterable[float]) -> np.ndarray:
+        """Map classical features to a normalised quantum-style state vector."""
+        vec = np.array(list(features), dtype=float)
+        norm = np.linalg.norm(vec)
+        if norm == 0:
+            return vec
+        return vec / norm
+
+    def mixed_optimize(
+        self,
+        state: np.ndarray,
+        target: np.ndarray,
+        iterations: int = 10,
+        lr: float = 0.1,
+    ) -> np.ndarray:
+        """Toy gradient-descent optimisation of ``state`` toward ``target``."""
+        s = state.copy()
+        for _ in range(iterations):
+            grad = target - s
+            s = s + lr * grad
+            n = np.linalg.norm(s)
+            if n != 0:
+                s = s / n
+        return s
+
+    def hybrid_processing(
+        self,
+        signal: Iterable[float],
+        *,
+        target_state: Optional[Iterable[float]] = None,
+        iterations: int = 10,
+        lr: float = 0.1,
+    ) -> np.ndarray:
+        """Run neuromorphic preprocessing, quantum mapping and optional optimisation."""
+        features = self.neuromorphic_preprocess(signal)
+        state = self.quantum_feature_map(features)
+        if target_state is not None:
+            target = np.array(list(target_state), dtype=float)
+            n = np.linalg.norm(target)
+            if n != 0:
+                target = target / n
+            state = self.mixed_optimize(state, target, iterations, lr)
+        return state
+
+
+__all__ = ["NeuromorphicQuantumHybrid"]

--- a/tests/hybrid/test_neuromorphic_quantum_hybrid.py
+++ b/tests/hybrid/test_neuromorphic_quantum_hybrid.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from modules.brain.hybrid.neuromorphic_quantum_hybrid import NeuromorphicQuantumHybrid
+
+
+def test_hybrid_outperforms_single_modes():
+    hybrid = NeuromorphicQuantumHybrid()
+    signal = [0.49, 0.51, 0.52]
+    target = np.array([0.0, 1.0, 1.0], dtype=float)
+    target /= np.linalg.norm(target)
+
+    hybrid_state = hybrid.hybrid_processing(signal, target_state=target)
+    hybrid_err = np.linalg.norm(hybrid_state - target)
+
+    features = hybrid.neuromorphic_preprocess(signal)
+    neu_err = np.linalg.norm(np.array(features, dtype=float) - target)
+
+    quantum_state = hybrid.quantum_feature_map(signal)
+    quantum_err = np.linalg.norm(quantum_state - target)
+
+    assert hybrid_err < neu_err
+    assert hybrid_err < quantum_err


### PR DESCRIPTION
## Summary
- implement `NeuromorphicQuantumHybrid` linking neuromorphic preprocessing with quantum feature mapping and mixed optimisation
- expose a `hybrid_processing` pipeline for feature extraction, quantum mapping and optimisation
- add benchmark test comparing hybrid approach with separate neuromorphic or quantum modes

## Testing
- `python -m pytest tests/hybrid/test_neuromorphic_quantum_hybrid.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67aa9d6c4832fbda950c7899c86a8