### PR TITLE
Track LLM token usage in prompt strategies

### DIFF
--- a/backend/autogpt/autogpt/agents/prompt_strategies/one_shot.py
+++ b/backend/autogpt/autogpt/agents/prompt_strategies/one_shot.py
@@ -214,13 +214,17 @@ class OneShotAgentPromptStrategy(PromptStrategy):
                 ChatMessage.system(f"## Progress\n\n{progress}"),
             )
 
+        prompt_messages = [
+            ChatMessage.system(system_prompt),
+            ChatMessage.user(user_task),
+            *extra_messages,
+            final_instruction_msg,
+        ]
+        tokens_used = count_message_tokens(prompt_messages)
+        self.logger.debug(f"Constructed prompt uses {tokens_used} tokens")
         prompt = ChatPrompt(
-            messages=[
-                ChatMessage.system(system_prompt),
-                ChatMessage.user(user_task),
-                *extra_messages,
-                final_instruction_msg,
-            ],
+            messages=prompt_messages,
+            tokens_used=tokens_used,
         )
 
         return prompt

--- a/backend/autogpt/autogpt/core/planning/prompt_strategies/initial_plan.py
+++ b/backend/autogpt/autogpt/core/planning/prompt_strategies/initial_plan.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 
 from autogpt.core.configuration import SystemConfiguration, UserConfigurable
 from autogpt.core.planning.schema import Task, TaskType
@@ -144,6 +145,7 @@ class InitialPlan(PromptStrategy):
         os_info: str,
         api_budget: float,
         current_time: str,
+        count_message_tokens: Callable[[ChatMessage | list[ChatMessage]], int] | None = None,
         **kwargs,
     ) -> ChatPrompt:
         template_kwargs = {
@@ -168,12 +170,16 @@ class InitialPlan(PromptStrategy):
         user_prompt = ChatMessage.user(
             self._user_prompt_template.format(**template_kwargs),
         )
+        messages = [system_prompt, user_prompt]
+        tokens_used = (
+            count_message_tokens(messages) if count_message_tokens is not None else 0
+        )
+        logger.debug(f"Constructed prompt uses {tokens_used} tokens")
 
         return ChatPrompt(
-            messages=[system_prompt, user_prompt],
+            messages=messages,
             functions=[self._create_plan_function],
-            # TODO:
-            tokens_used=0,
+            tokens_used=tokens_used,
         )
 
     def parse_response_content(

--- a/backend/autogpt/autogpt/core/planning/simple.py
+++ b/backend/autogpt/autogpt/core/planning/simple.py
@@ -174,7 +174,12 @@ class SimplePlanner(Configurable):
                 multimodal_input, _embed
             )
         template_kwargs.update(kwargs)
-        prompt = prompt_strategy.build_prompt(**template_kwargs)
+        prompt = prompt_strategy.build_prompt(
+            count_message_tokens=lambda m: provider.count_message_tokens(
+                m, model_configuration["model_name"]
+            ),
+            **template_kwargs,
+        )
 
         self._logger.debug(f"Using prompt:\n{dump_prompt(prompt)}\n")
         response = await provider.create_chat_completion(

--- a/backend/autogpt/autogpt/core/prompting/schema.py
+++ b/backend/autogpt/autogpt/core/prompting/schema.py
@@ -24,6 +24,7 @@ class LanguageModelClassification(str, enum.Enum):
 class ChatPrompt(BaseModel):
     messages: list[ChatMessage]
     functions: list[CompletionModelFunction] = Field(default_factory=list)
+    tokens_used: int = 0
 
     def raw(self) -> list[ChatMessageDict]:
         return [m.dict() for m in self.messages]

--- a/tests/test_prompt_tokens.py
+++ b/tests/test_prompt_tokens.py
@@ -1,0 +1,139 @@
+import logging
+import sys
+from pathlib import Path
+import types
+import enum
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "backend/autogpt"))
+
+# Stub out heavy dependencies from autogpt.config
+config_stub = types.ModuleType("autogpt.config")
+class AIProfile:
+    ai_name = "GPT"
+    ai_role = "assistant"
+    api_budget = 0
+class AIDirectives:
+    constraints = []
+    resources = []
+    best_practices = []
+config_stub.AIProfile = AIProfile
+config_stub.AIDirectives = AIDirectives
+sys.modules["autogpt.config"] = config_stub
+
+# Stub forge Task
+forge_module = types.ModuleType("forge")
+forge_sdk_module = types.ModuleType("forge.sdk")
+forge_sdk_model_module = types.ModuleType("forge.sdk.model")
+class Task:
+    def __init__(self, input=""):
+        self.input = input
+forge_sdk_model_module.Task = Task
+forge_sdk_module.model = forge_sdk_model_module
+forge_module.sdk = forge_sdk_module
+sys.modules["forge"] = forge_module
+sys.modules["forge.sdk"] = forge_sdk_module
+sys.modules["forge.sdk.model"] = forge_sdk_model_module
+
+# Stub core prompting and resource modules
+prompting_stub = types.ModuleType("autogpt.core.prompting")
+class PromptStrategy:
+    pass
+prompting_stub.PromptStrategy = PromptStrategy
+prompt_schema_stub = types.ModuleType("autogpt.core.prompting.schema")
+class LanguageModelClassification(str, enum.Enum):
+    FAST_MODEL = "fast_model"
+    SMART_MODEL = "smart_model"
+class ChatPrompt:
+    def __init__(self, messages=None, functions=None, tokens_used=0):
+        self.messages = messages or []
+        self.functions = functions or []
+        self.tokens_used = tokens_used
+prompt_schema_stub.LanguageModelClassification = LanguageModelClassification
+prompt_schema_stub.ChatPrompt = ChatPrompt
+sys.modules["autogpt.core.prompting.schema"] = prompt_schema_stub
+
+prompting_stub.ChatPrompt = ChatPrompt
+prompting_stub.LanguageModelClassification = LanguageModelClassification
+sys.modules["autogpt.core.prompting"] = prompting_stub
+
+resource_schema_stub = types.ModuleType(
+    "autogpt.core.resource.model_providers.schema"
+)
+class AssistantChatMessage:
+    pass
+class ChatMessage:
+    def __init__(self, content=""):
+        self.content = content
+    @staticmethod
+    def system(content):
+        return ChatMessage(content)
+    @staticmethod
+    def user(content):
+        return ChatMessage(content)
+class CompletionModelFunction:
+    pass
+resource_schema_stub.AssistantChatMessage = AssistantChatMessage
+resource_schema_stub.ChatMessage = ChatMessage
+resource_schema_stub.CompletionModelFunction = CompletionModelFunction
+sys.modules["autogpt.core.resource.model_providers.schema"] = resource_schema_stub
+
+json_schema_stub = types.ModuleType("autogpt.core.utils.json_schema")
+class JSONSchema(dict):
+    class Type:
+        OBJECT = "object"
+        STRING = "string"
+        ARRAY = "array"
+    @classmethod
+    def from_dict(cls, d):
+        return cls(d)
+    def to_dict(self):
+        return dict(self)
+    def copy(self, deep=False):
+        return JSONSchema(dict(self))
+    def to_typescript_object_interface(self, name: str) -> str:
+        return "{}"
+json_schema_stub.JSONSchema = JSONSchema
+sys.modules["autogpt.core.utils.json_schema"] = json_schema_stub
+
+json_utils_stub = types.ModuleType("autogpt.core.utils.json_utils")
+json_utils_stub.extract_dict_from_json = lambda x: {}
+sys.modules["autogpt.core.utils.json_utils"] = json_utils_stub
+
+prompts_utils_stub = types.ModuleType("autogpt.prompts.utils")
+prompts_utils_stub.format_numbered_list = lambda x: ""
+prompts_utils_stub.indent = lambda text, indent_level=0: text
+sys.modules["autogpt.prompts.utils"] = prompts_utils_stub
+
+from autogpt.agents.prompt_strategies.one_shot import (
+    OneShotAgentPromptConfiguration,
+    OneShotAgentPromptStrategy,
+)
+
+def fake_count_message_tokens(messages):
+    if isinstance(messages, list):
+        return sum(len(m.content) for m in messages)
+    return len(messages.content)
+
+
+def test_prompt_tokens_are_tracked():
+    config = OneShotAgentPromptConfiguration(
+        model_classification=LanguageModelClassification.FAST_MODEL
+    )
+    strategy = OneShotAgentPromptStrategy(
+        configuration=config, logger=logging.getLogger(__name__)
+    )
+    task = Task(input="do something")
+    prompt = strategy.build_prompt(
+        task=task,
+        ai_profile=AIProfile(),
+        ai_directives=AIDirectives(),
+        commands=[],
+        event_history=[],
+        include_os_info=False,
+        max_prompt_tokens=1000,
+        count_tokens=len,
+        count_message_tokens=fake_count_message_tokens,
+    )
+    expected = fake_count_message_tokens(prompt.messages)
+    assert prompt.tokens_used == expected


### PR DESCRIPTION
## Summary
- compute and store `tokens_used` when building prompts
- log prompt token counts and plumb through planner
- add unit test for prompt token accounting

## Testing
- `pytest tests/test_prompt_tokens.py -q`
- `pytest tests/test_one_shot_model_classification.py -q` *(fails: ModuleNotFoundError: No module named 'forge')*


------
https://chatgpt.com/codex/tasks/task_e_68c68e155fa4832f867e074025ddd992