### PR TITLE
feat(agent): allow shared workspace

### DIFF
--- a/backend/autogpt/autogpt/agent_factory/configurators.py
+++ b/backend/autogpt/autogpt/agent_factory/configurators.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from forge.sdk.model import Task
 
@@ -11,11 +11,11 @@ from autogpt.logs.config import configure_chat_plugins
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.plugins import scan_plugins
 
-
 if TYPE_CHECKING:
-    from autogpt.core.brain.transformer_brain import TransformerBrain
     from knowledge import UnifiedKnowledgeBase
     from reasoning import DecisionEngine
+
+    from autogpt.core.brain.transformer_brain import TransformerBrain
 
 
 def create_agent(
@@ -133,6 +133,7 @@ def create_agent_state(
 
     return AgentSettings(
         agent_id=agent_id,
+        workspace_id=agent_id,
         name=Agent.default_settings.name,
         description=Agent.default_settings.description,
         task=task,

--- a/backend/autogpt/autogpt/agents/base.py
+++ b/backend/autogpt/autogpt/agents/base.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
+from datetime import datetime
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Optional
-import time
+from uuid import uuid4
 
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
-from datetime import datetime
-from uuid import uuid4
-from pydantic import Field, validator
 from events import EventBus, create_event_bus
 from events.client import EventClient
 from events.coordination import TaskStatus, TaskStatusEvent
 from forge.sdk.model import Task
+from pydantic import Field, validator
 
 if TYPE_CHECKING:
     from autogpt.config import Config
@@ -32,6 +32,8 @@ from autogpt.agents.utils.prompt_scratchpad import PromptScratchpad
 from autogpt.config import ConfigBuilder
 from autogpt.config.ai_directives import AIDirectives
 from autogpt.config.ai_profile import AIProfile
+from autogpt.core.brain.config import TransformerBrainConfig
+from autogpt.core.brain.transformer_brain import TransformerBrain
 from autogpt.core.configuration import (
     Configurable,
     SystemConfiguration,
@@ -52,8 +54,6 @@ from autogpt.file_storage.base import FileStorage
 from autogpt.llm.providers.openai import get_openai_command_specs
 from autogpt.models.action_history import ActionResult, EpisodicActionHistory
 from autogpt.prompts.prompt import DEFAULT_TRIGGERING_PROMPT
-from autogpt.core.brain.config import TransformerBrainConfig
-from autogpt.core.brain.transformer_brain import TransformerBrain
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +148,7 @@ class BaseAgentConfiguration(SystemConfiguration):
 
 class BaseAgentSettings(SystemSettings):
     agent_id: str = ""
+    workspace_id: str | None = None
 
     ai_profile: AIProfile = Field(default_factory=lambda: AIProfile(ai_name="AutoGPT"))
     """The AI profile or "personality" of the agent."""

--- a/backend/autogpt/autogpt/app/agent_protocol_server.py
+++ b/backend/autogpt/autogpt/app/agent_protocol_server.py
@@ -454,7 +454,9 @@ class AgentProtocolServer:
 
     def _get_task_agent_file_workspace(self, task_id: str | int) -> FileStorage:
         agent_id = task_agent_id(task_id)
-        return self.file_storage.clone_with_subroot(f"agents/{agent_id}/workspace")
+        state = self.agent_manager.load_agent_state(agent_id)
+        workspace_id = state.workspace_id or agent_id
+        return self.file_storage.clone_with_subroot(f"workspaces/{workspace_id}/")
 
     def _get_task_llm_provider(
         self, task: Task, step_id: str = ""

--- a/backend/autogpt/tests/agents/test_shared_workspace.py
+++ b/backend/autogpt/tests/agents/test_shared_workspace.py
@@ -1,0 +1,59 @@
+import asyncio
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from forge.sdk.model import Task
+
+from autogpt.agent_factory.configurators import (
+    configure_agent_with_state,
+    create_agent_state,
+)
+from autogpt.agent_manager import AgentManager
+from autogpt.config.ai_directives import AIDirectives
+from autogpt.config.ai_profile import AIProfile
+
+
+@pytest.mark.asyncio
+async def test_multiple_agents_shared_workspace(config, storage, llm_provider):
+    directives = AIDirectives.from_file(config.prompt_settings_file)
+    ai_profile = AIProfile(ai_name="Tester", ai_role="testing", ai_goals=[])
+
+    def make_task():
+        now = datetime.now()
+        return Task(
+            input="Test task",
+            additional_input=None,
+            created_at=now,
+            modified_at=now,
+            task_id=str(uuid4()),
+            artifacts=[],
+        )
+
+    state1 = create_agent_state("agent1", make_task(), ai_profile, directives, config)
+    state1.workspace_id = "shared"
+    agent1 = configure_agent_with_state(state1, config, storage, llm_provider)
+
+    state2 = create_agent_state("agent2", make_task(), ai_profile, directives, config)
+    state2.workspace_id = "shared"
+    agent2 = configure_agent_with_state(state2, config, storage, llm_provider)
+
+    await asyncio.gather(
+        agent1.workspace.write_file("file1.txt", "agent1"),
+        agent2.workspace.write_file("file2.txt", "agent2"),
+    )
+
+    await asyncio.gather(agent1.save_state(), agent2.save_state())
+
+    manager = AgentManager(storage)
+    restored1 = configure_agent_with_state(
+        manager.load_agent_state("agent1"), config, storage, llm_provider
+    )
+    restored2 = configure_agent_with_state(
+        manager.load_agent_state("agent2"), config, storage, llm_provider
+    )
+
+    assert restored1.workspace.read_file("file1.txt") == "agent1"
+    assert restored1.workspace.read_file("file2.txt") == "agent2"
+    assert restored2.workspace.read_file("file1.txt") == "agent1"
+    assert restored2.workspace.read_file("file2.txt") == "agent2"


### PR DESCRIPTION
## Summary
- allow configuring workspace_id separate from agent_id so multiple agents can share a workspace
- adjust state saving/restoration logic and protocol server to use new workspace layout
- add integration test covering concurrent save/restore with shared workspace

## Testing
- `pre-commit run --files autogpt/agent_factory/configurators.py autogpt/agents/base.py autogpt/agents/features/agent_file_manager.py autogpt/app/agent_protocol_server.py tests/agents/test_shared_workspace.py` *(fails: /usr/bin/bash: line 1: cd: autogpts/autogpt: No such file or directory)*
- `pytest tests/agents/test_shared_workspace.py -q` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_68c68e1f1098832fa9a7a33609ac51f8