### PR TITLE
feat: add analogical reasoner

### DIFF
--- a/modules/brain/reasoning/__init__.py
+++ b/modules/brain/reasoning/__init__.py
@@ -1,0 +1,5 @@
+"""Reasoning subpackage exposing analogical reasoning utilities."""
+
+from .analogical import AnalogicalReasoner
+
+__all__ = ["AnalogicalReasoner"]

--- a/modules/brain/reasoning/analogical.py
+++ b/modules/brain/reasoning/analogical.py
@@ -1,0 +1,80 @@
+"""Analogical reasoning via simple structural mapping and vector retrieval."""
+
+from __future__ import annotations
+
+from collections import Counter
+from math import sqrt
+from typing import Dict, Tuple
+
+Vector = Dict[str, int]
+Structure = Dict[str, str]
+
+
+class AnalogicalReasoner:
+    """Minimal analogical reasoner using bag-of-words vector search.
+
+    Knowledge is stored per domain as pairs of a structured representation and
+    a free-text description. During transfer the description is compared to the
+    target task via cosine similarity and roles from the best matching structure
+    are mapped onto the target structure.
+    """
+
+    def __init__(self) -> None:
+        self._knowledge: Dict[str, list[Tuple[Structure, str, Vector]]] = {}
+
+    # ------------------ internal helpers ------------------
+    def _vectorize(self, text: str) -> Vector:
+        return Counter(text.lower().split())
+
+    def _cosine(self, a: Vector, b: Vector) -> float:
+        shared = set(a) & set(b)
+        num = sum(a[w] * b[w] for w in shared)
+        denom = sqrt(sum(v * v for v in a.values())) * sqrt(sum(v * v for v in b.values()))
+        return num / denom if denom else 0.0
+
+    # ------------------ public API ------------------
+    def add_knowledge(self, domain: str, structure: Structure, description: str) -> None:
+        """Store ``structure`` and ``description`` under ``domain``."""
+
+        vec = self._vectorize(description)
+        self._knowledge.setdefault(domain, []).append((structure, description, vec))
+
+    def transfer_knowledge(
+        self, source_domain: str, target_description: str, target_structure: Structure
+    ) -> Dict[str, str] | None:
+        """Transfer best matching knowledge from ``source_domain`` to target task.
+
+        Parameters
+        ----------
+        source_domain:
+            Domain containing source knowledge.
+        target_description:
+            Free-text description of the target task.
+        target_structure:
+            Structural representation of the target task using the same role keys
+            as in the source domain.
+
+        Returns
+        -------
+        mapping:
+            A dictionary mapping source entities to target entities, or ``None``
+            if no knowledge exists for the domain.
+        """
+
+        candidates = self._knowledge.get(source_domain)
+        if not candidates:
+            return None
+        target_vec = self._vectorize(target_description)
+        best: Tuple[Structure, str, Vector] | None = None
+        best_score = -1.0
+        for structure, _desc, vec in candidates:
+            score = self._cosine(vec, target_vec)
+            if score > best_score:
+                best = (structure, _desc, vec)
+                best_score = score
+        assert best is not None
+        source_structure = best[0]
+        return {source_structure[k]: target_structure.get(k, source_structure[k]) for k in source_structure}
+
+
+__all__ = ["AnalogicalReasoner"]

--- a/tests/brain/test_analogical_reasoner.py
+++ b/tests/brain/test_analogical_reasoner.py
@@ -1,0 +1,32 @@
+from modules.brain.reasoning import AnalogicalReasoner
+
+
+def test_transfer_monarchy_to_corporate():
+    reasoner = AnalogicalReasoner()
+    reasoner.add_knowledge(
+        "monarchy",
+        {"leader": "king", "followers": "subjects"},
+        "king rules subjects",
+    )
+    mapping = reasoner.transfer_knowledge(
+        "monarchy",
+        "CEO leads employees",
+        {"leader": "CEO", "followers": "employees"},
+    )
+    assert mapping == {"king": "CEO", "subjects": "employees"}
+
+
+def test_transfer_solar_to_atomic():
+    reasoner = AnalogicalReasoner()
+    reasoner.add_knowledge(
+        "solar",
+        {"central": "sun", "orbiting": "planet"},
+        "sun attracts planet with gravity",
+    )
+    mapping = reasoner.transfer_knowledge(
+        "solar",
+        "nucleus attracts electron electromagnetically",
+        {"central": "nucleus", "orbiting": "electron"},
+    )
+    assert mapping == {"sun": "nucleus", "planet": "electron"}
+


### PR DESCRIPTION
## Summary
- implement `AnalogicalReasoner` with structural mapping and vector retrieval
- expose `transfer_knowledge` for cross-domain knowledge mapping
- test analogical knowledge transfer across monarchy/corporate and solar/atomic domains

## Testing
- `python -m pytest tests/brain/test_analogical_reasoner.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6919e2f98832f90864667f9a3cb6f