### PR TITLE
Add ethical reasoning engine and integrate pre-execution checks

### DIFF
--- a/modules/brain/__init__.py
+++ b/modules/brain/__init__.py
@@ -14,6 +14,7 @@ from .message_bus import (
 from .multimodal import MultimodalFusionEngine
 from .adapter import BrainModule
 from .bci import BrainComputerInterface
+from .ethics import EthicalReasoningEngine, EthicalRule
 
 __all__ = [
     "VisualCortex",
@@ -32,4 +33,6 @@ __all__ = [
     "MultimodalFusionEngine",
     "BrainModule",
     "BrainComputerInterface",
+    "EthicalReasoningEngine",
+    "EthicalRule",
 ]

--- a/modules/brain/ethics.py
+++ b/modules/brain/ethics.py
@@ -1,0 +1,91 @@
+"""Ethical reasoning engine for evaluating planned actions.
+
+This module provides an :class:`EthicalReasoningEngine` that can be
+configured with a library of ethical rules and value weights.  Each rule
+specifies a condition on an action, the ethical value it relates to and a
+suggestion for remediation.  The engine evaluates an action against all
+rules and aggregates a weighted score of any violations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional
+
+
+@dataclass
+class EthicalRule:
+    """Representation of a single ethical rule.
+
+    Attributes
+    ----------
+    condition:
+        A callable that receives the action description and returns ``True``
+        when the rule is violated.
+    value:
+        Name of the ethical value the rule is associated with (e.g.
+        ``"nonmaleficence"``).
+    suggestion:
+        Guidance provided when the rule is violated.
+    """
+
+    condition: Callable[[str], bool]
+    value: str
+    suggestion: str
+
+
+class EthicalReasoningEngine:
+    """Evaluate actions against a set of ethical rules.
+
+    Parameters
+    ----------
+    rules:
+        Iterable of :class:`EthicalRule` objects representing the rule
+        library.
+    value_weights:
+        Optional mapping from value names to their relative weights when
+        scoring violations.  Unspecified values default to a weight of ``1``.
+    """
+
+    def __init__(
+        self,
+        rules: Optional[Iterable[EthicalRule]] = None,
+        value_weights: Optional[Dict[str, float]] = None,
+    ) -> None:
+        self.rules: List[EthicalRule] = list(rules) if rules else []
+        self.value_weights: Dict[str, float] = value_weights or {}
+
+    def add_rule(self, rule: EthicalRule) -> None:
+        """Add an :class:`EthicalRule` to the library."""
+
+        self.rules.append(rule)
+
+    def evaluate_action(self, action: str) -> Dict[str, object]:
+        """Evaluate ``action`` and return compliance and suggestions.
+
+        The returned dictionary contains:
+
+        ``compliant``:
+            ``True`` when no rules are violated.
+        ``score``:
+            Aggregated weight of violated rules.
+        ``suggestions``:
+            List of remediation suggestions for violated rules.
+        """
+
+        description = str(action)
+        compliant = True
+        score = 0.0
+        suggestions: List[str] = []
+
+        for rule in self.rules:
+            if rule.condition(description):
+                compliant = False
+                weight = self.value_weights.get(rule.value, 1)
+                score += weight
+                suggestions.append(rule.suggestion)
+
+        return {
+            "compliant": compliant,
+            "score": score,
+            "suggestions": suggestions,
+        }

--- a/modules/brain/motor_cortex.py
+++ b/modules/brain/motor_cortex.py
@@ -22,13 +22,23 @@ class SupplementaryMotor:
 class MotorCortex:
     """Motor cortex integrating multiple motor-related areas."""
 
-    def __init__(self, basal_ganglia=None, cerebellum=None, spiking_backend=None):
+    def __init__(
+        self,
+        basal_ganglia=None,
+        cerebellum=None,
+        spiking_backend=None,
+        ethics=None,
+    ):
         self.primary_motor = PrimaryMotor()
         self.premotor_area = PreMotorArea()
         self.supplementary_motor = SupplementaryMotor()
         self.basal_ganglia = basal_ganglia
         self.cerebellum = cerebellum
         self.spiking_backend = spiking_backend
+        # Optional ethical reasoning engine used to vet actions before
+        # execution.  The engine is expected to expose an ``evaluate_action``
+        # method returning a compliance report.
+        self.ethics = ethics
 
     def plan_movement(self, intention: str) -> str:
         """Plan a movement based on an intention."""
@@ -40,6 +50,12 @@ class MotorCortex:
 
     def execute_action(self, motor_command: str):
         """Execute a motor command, optionally using a spiking backend."""
+        # Perform ethical evaluation before any physical execution.
+        if self.ethics:
+            report = self.ethics.evaluate_action(motor_command)
+            if not report["compliant"]:
+                return report
+
         if self.spiking_backend and isinstance(motor_command, (list, tuple)):
             spikes = self.spiking_backend.run(motor_command)
             self.spiking_backend.synapses.adapt(

--- a/tests/test_ethics_engine.py
+++ b/tests/test_ethics_engine.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.brain import EthicalReasoningEngine, EthicalRule, MotorCortex
+
+
+def test_ethics_blocks_harmful_action():
+    rules = [
+        EthicalRule(
+            condition=lambda action: "harm" in action.lower(),
+            value="nonmaleficence",
+            suggestion="Avoid causing harm; choose a benign alternative.",
+        )
+    ]
+    weights = {"nonmaleficence": 10}
+    engine = EthicalReasoningEngine(rules=rules, value_weights=weights)
+    cortex = MotorCortex(ethics=engine)
+
+    report = cortex.execute_action("harm humans")
+
+    assert not report["compliant"]
+    assert report["score"] == 10
+    assert "Avoid causing harm" in report["suggestions"][0]
+
+
+def test_ethics_allows_safe_action():
+    engine = EthicalReasoningEngine(
+        rules=[
+            EthicalRule(
+                condition=lambda action: "steal" in action.lower(),
+                value="justice",
+                suggestion="Respect property rights.",
+            )
+        ]
+    )
+    cortex = MotorCortex(ethics=engine)
+
+    result = cortex.execute_action("wave")
+
+    assert isinstance(result, str)
+    assert "executed" in result


### PR DESCRIPTION
## Summary
- add rule-based EthicalReasoningEngine with configurable value weights
- integrate ethics evaluation into MotorCortex
- provide safety tests covering harmful and safe actions

## Testing
- `pytest tests/test_ethics_engine.py tests/test_motor_cortex.py -q`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c6919c4b48832fb3bc5f305f77b6c0