### PR TITLE
feat: add configuration registry and tests

### DIFF
--- a/backend/autogpt/autogpt/core/configuration/__init__.py
+++ b/backend/autogpt/autogpt/core/configuration/__init__.py
@@ -6,6 +6,7 @@ from autogpt.core.configuration.schema import (
     UserConfigurable,
 )
 from .learning import LearningConfiguration, LearningSettings
+from .registry import ConfigRegistry
 
 __all__ = [
     "Configurable",
@@ -14,4 +15,5 @@ __all__ = [
     "UserConfigurable",
     "LearningConfiguration",
     "LearningSettings",
+    "ConfigRegistry",
 ]

--- a/backend/autogpt/autogpt/core/configuration/registry.py
+++ b/backend/autogpt/autogpt/core/configuration/registry.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+"""Registry for SystemConfiguration and SystemSettings instances.
+
+This registry provides a central place to collect configuration objects used
+throughout the system. It supports loading values from environment variables,
+YAML configuration files and explicit overrides (e.g. from command line
+arguments).
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from .schema import (
+    SystemConfiguration,
+    SystemSettings,
+    _update_user_config_from_env,
+    deep_update,
+)
+
+
+class ConfigRegistry:
+    """Collect and manage configuration objects."""
+
+    def __init__(self) -> None:
+        self._configs: Dict[str, SystemConfiguration] = {}
+        self._settings: Dict[str, SystemSettings] = {}
+
+    # ------------------------------------------------------------------
+    # Registration & collection
+    # ------------------------------------------------------------------
+    def register(self, instance: SystemConfiguration | SystemSettings) -> None:
+        """Register a configuration or settings instance."""
+        if isinstance(instance, SystemConfiguration):
+            key = instance.__class__.__name__
+            self._configs[key] = instance
+        elif isinstance(instance, SystemSettings):
+            key = instance.__class__.__name__
+            self._settings[key] = instance
+        else:
+            raise TypeError("Unsupported type for registry")
+
+    def collect(self) -> None:
+        """Automatically collect subclasses of configuration/settings."""
+        for cls in SystemConfiguration.__subclasses__():
+            try:
+                instance = cls.from_env()
+            except Exception:
+                try:
+                    instance = cls()
+                except Exception:
+                    continue
+            self.register(instance)
+
+        for cls in SystemSettings.__subclasses__():
+            try:
+                instance = cls()
+            except Exception:
+                continue
+            self.register(instance)
+
+    # ------------------------------------------------------------------
+    # Loading and overrides
+    # ------------------------------------------------------------------
+    def load_from_env(self) -> None:
+        """Update registered objects from environment variables."""
+        for name, conf in list(self._configs.items()):
+            data = conf.dict()
+            data.update(_update_user_config_from_env(conf))
+            self._configs[name] = conf.__class__.parse_obj(data)
+
+        for name, st in list(self._settings.items()):
+            data = st.dict()
+            data.update(_update_user_config_from_env(st))
+            self._settings[name] = st.__class__.parse_obj(data)
+
+    def load_from_yaml(self, path: str | Path) -> None:
+        """Load overrides from a YAML file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        self.apply_overrides(data)
+
+    def apply_overrides(self, overrides: Dict[str, Any]) -> None:
+        """Apply overrides (e.g. from command line)."""
+        for key, value in overrides.items():
+            if key in self._configs:
+                inst = self._configs[key]
+                merged = deep_update(inst.dict(), value)
+                self._configs[key] = inst.__class__.parse_obj(merged)
+            elif key in self._settings:
+                inst = self._settings[key]
+                merged = deep_update(inst.dict(), value)
+                self._settings[key] = inst.__class__.parse_obj(merged)
+
+    # ------------------------------------------------------------------
+    # Access helpers
+    # ------------------------------------------------------------------
+    def get(self, name: str) -> SystemConfiguration | SystemSettings | None:
+        return self._configs.get(name) or self._settings.get(name)
+
+    def to_dict(self) -> Dict[str, Dict[str, Any]]:
+        data: Dict[str, Dict[str, Any]] = {
+            name: inst.dict() for name, inst in self._configs.items()
+        }
+        data.update({name: inst.dict() for name, inst in self._settings.items()})
+        return data

--- a/scripts/migrate_config_registry.py
+++ b/scripts/migrate_config_registry.py
@@ -1,0 +1,35 @@
+"""Populate ConfigRegistry with configuration classes scattered across the codebase.
+
+This script walks the ``autogpt`` package, imports all modules to ensure that
+configuration classes are loaded, and registers them with a ``ConfigRegistry``
+instance. It can be used during development to verify that all configuration
+objects are discoverable by the registry.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+from autogpt.core.configuration import ConfigRegistry
+
+
+def migrate() -> ConfigRegistry:
+    registry = ConfigRegistry()
+
+    # Import all modules under the autogpt package to expose configuration classes
+    package = importlib.import_module("autogpt")
+    for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+        try:
+            importlib.import_module(module_info.name)
+        except Exception:
+            # Skip modules that fail to import; they are not required for migration.
+            continue
+
+    registry.collect()
+    return registry
+
+
+if __name__ == "__main__":
+    reg = migrate()
+    print("Registered configurations:", list(reg.to_dict().keys()))

--- a/tests/config/test_config_registry.py
+++ b/tests/config/test_config_registry.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+import yaml
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "backend", "autogpt"))
+)
+
+from autogpt.core.configuration import ConfigRegistry, SystemConfiguration, SystemSettings, UserConfigurable
+
+
+class ExampleConfiguration(SystemConfiguration):
+    foo: int = UserConfigurable(1, from_env="EXAMPLE_FOO")
+    bar: str = UserConfigurable("bar", from_env="EXAMPLE_BAR")
+
+
+class ExampleSettings(SystemSettings):
+    name: str = "example"
+    description: str = "Example settings"
+    mode: str = UserConfigurable("dev", from_env="EXAMPLE_MODE")
+
+
+def test_registry_load_and_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("EXAMPLE_FOO", "2")
+    monkeypatch.setenv("EXAMPLE_MODE", "prod")
+
+    registry = ConfigRegistry()
+    registry.collect()
+
+    # Load environment variables
+    registry.load_from_env()
+    conf = registry.get("ExampleConfiguration")
+    settings = registry.get("ExampleSettings")
+    assert conf and conf.foo == 2
+    assert settings and settings.mode == "prod"
+
+    # YAML overrides
+    config_yaml = tmp_path / "config.yaml"
+    with config_yaml.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(
+            {
+                "ExampleConfiguration": {"foo": 5, "bar": "baz"},
+                "ExampleSettings": {"mode": "test"},
+            },
+            f,
+        )
+    registry.load_from_yaml(str(config_yaml))
+    conf = registry.get("ExampleConfiguration")
+    settings = registry.get("ExampleSettings")
+    assert conf.foo == 5 and conf.bar == "baz"
+    assert settings.mode == "test"
+
+    # CLI overrides
+    registry.apply_overrides(
+        {
+            "ExampleConfiguration": {"bar": "cli"},
+            "ExampleSettings": {"mode": "cli"},
+        }
+    )
+    conf = registry.get("ExampleConfiguration")
+    settings = registry.get("ExampleSettings")
+    assert conf.bar == "cli"
+    assert settings.mode == "cli"


### PR DESCRIPTION
## Summary
- introduce ConfigRegistry to gather SystemConfiguration and SystemSettings instances
- add migration script to populate registry across the project
- add tests verifying env, YAML, and CLI overrides

## Testing
- `pytest tests/config/test_config_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c691969abc832fbd3496bec12341b6