### PR TITLE
feat: add creative evaluator and meta-learning

### DIFF
--- a/benchmarks/test_creativity_benchmark.py
+++ b/benchmarks/test_creativity_benchmark.py
@@ -1,0 +1,47 @@
+from backend.creative_engine import CrossModalCreativeEngine
+from modules.metrics.creative_evaluator import CreativeEvaluator
+from modules.optimization.meta_learner import MetaLearner
+
+
+class DummyAligner:
+    def align(self, embedding, vector_type):
+        return []
+
+
+def dummy_encoder(prompt: str):
+    return [0.0]
+
+
+def text_generator(prompt: str, concepts):
+    return prompt
+
+
+def image_generator(prompt: str, concepts):
+    return f"image:{prompt}"
+
+
+def make_engine():
+    evaluator = CreativeEvaluator()
+    meta = MetaLearner(["text", "image"])
+    engine = CrossModalCreativeEngine(
+        aligner=DummyAligner(),
+        encoders={"text": dummy_encoder, "image": dummy_encoder},
+        generators={"text": text_generator, "image": image_generator},
+        evaluator=evaluator,
+        meta_learner=meta,
+    )
+    return engine, meta
+
+
+def test_creativity_feedback():
+    engine, meta = make_engine()
+    result1 = engine.generate("hello hello", ["text", "image"])
+    score1 = result1["text"]["creative_score"]
+    weight_before = meta.weights["text"]
+    result2 = engine.generate("hello unique world", ["text", "image"])
+    score2 = result2["text"]["creative_score"]
+    weight_after = meta.weights["text"]
+    s1 = (score1.novelty + score1.usefulness) / 2
+    s2 = (score2.novelty + score2.usefulness) / 2
+    assert s2 >= s1
+    assert weight_after > weight_before

--- a/capability/__init__.py
+++ b/capability/__init__.py
@@ -1,0 +1,1 @@
+"""Stub capability package for testing."""

--- a/capability/librarian.py
+++ b/capability/librarian.py
@@ -1,0 +1,5 @@
+class Librarian:
+    """Minimal stub librarian used for tests."""
+
+    def search(self, *args, **kwargs):
+        return []

--- a/modules/metrics/creative_evaluator.py
+++ b/modules/metrics/creative_evaluator.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Evaluation utilities for assessing creative multimodal outputs."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - circular import safety
+    from modules.optimization.meta_learner import MetaLearner
+
+
+@dataclass
+class CreativeScore:
+    """Holds novelty and usefulness scores for a modality output."""
+
+    novelty: float
+    usefulness: float
+
+
+class CreativeEvaluator:
+    """Evaluate outputs and provide feedback for self-optimization."""
+
+    def evaluate(self, results: Dict[str, Dict[str, Any]]) -> Dict[str, CreativeScore]:
+        """Return novelty and usefulness scores for each modality.
+
+        Parameters
+        ----------
+        results: Mapping from modality to its generation result. Each result
+            is expected to contain an ``"output"`` entry with the produced
+            content.
+        """
+        scores: Dict[str, CreativeScore] = {}
+        for modality, data in results.items():
+            output = data.get("output")
+            if isinstance(output, str):
+                words = output.split()
+                novelty = len(set(words)) / (len(words) or 1)
+                usefulness = 1.0 if output else 0.0
+            else:
+                novelty = 0.5
+                usefulness = 1.0 if output is not None else 0.0
+            scores[modality] = CreativeScore(novelty, usefulness)
+        return scores
+
+    def feedback(
+        self, meta_learner: Optional["MetaLearner"], scores: Dict[str, CreativeScore]
+    ) -> Dict[str, float]:
+        """Provide feedback to the generation process via ``meta_learner``.
+
+        Returns a mapping from modality to the aggregated score used for
+        learning. If ``meta_learner`` is provided its weights are updated.
+        """
+        aggregate = {
+            modality: (score.novelty + score.usefulness) / 2
+            for modality, score in scores.items()
+        }
+        if meta_learner is not None:
+            meta_learner.update(aggregate)
+        return aggregate
+
+
+__all__ = ["CreativeEvaluator", "CreativeScore"]

--- a/modules/optimization/__init__.py
+++ b/modules/optimization/__init__.py
@@ -6,10 +6,12 @@ and to recommend parameters for future runs based on historical performance.
 
 from .optimizer import optimize_params, log_run
 from .storage import load_history, DEFAULT_HISTORY_FILE
+from .meta_learner import MetaLearner
 
 __all__ = [
     "optimize_params",
     "log_run",
     "load_history",
     "DEFAULT_HISTORY_FILE",
+    "MetaLearner",
 ]

--- a/modules/optimization/meta_learner.py
+++ b/modules/optimization/meta_learner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simple meta-learning utilities for modality weight optimization."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class MetaLearner:
+    """Maintain and update weights for different modality generators."""
+
+    weights: Dict[str, float] = field(default_factory=dict)
+
+    def __init__(self, modalities: List[str]):
+        self.weights = {m: 0.5 for m in modalities}
+
+    def update(self, scores: Dict[str, float]) -> Dict[str, float]:
+        """Update modality weights towards observed ``scores``.
+
+        The update rule performs a small step toward the provided score for each
+        modality, enabling gradual self-optimization.
+        """
+        for modality, score in scores.items():
+            w = self.weights.get(modality, 0.5)
+            self.weights[modality] = w + 0.1 * (score - w)
+        return self.weights
+
+
+__all__ = ["MetaLearner"]


### PR DESCRIPTION
## Summary
- add `CreativeEvaluator` to score novelty/usefulness of multimodal outputs and provide feedback
- introduce lightweight `MetaLearner` for adaptive modality weighting
- integrate evaluator and meta-learner into `CrossModalCreativeEngine`
- benchmark creativity feedback to ensure scores and weights improve

## Testing
- `pytest benchmarks/test_creativity_benchmark.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c691a42c38832f9d6c297adc0c8bd1