### PR TITLE
feat: add unified brain manager with event bus

### DIFF
--- a/modules/brain/brain_manager.py
+++ b/modules/brain/brain_manager.py
@@ -1,0 +1,88 @@
+"""Unified brain manager for coordinating sub-managers.
+
+This module exposes :class:`UnifiedBrainManager`, a thin orchestrator that
+coordinates the ``AgentLifecycleManager`` and ``RuntimeModuleManager`` under a
+single interface.  The class listens for events on the ``message_bus`` and
+delegates work to the respective managers, publishing notifications for resource
+allocation or fault isolation.
+
+The implementation favours simplicity so that behaviour is easy to reason
+about and test.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol, TYPE_CHECKING
+
+from .message_bus import publish_neural_event, subscribe_to_brain_region
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from backend.execution.manager import AgentLifecycleManager
+    from backend.capability.runtime_loader import RuntimeModuleManager
+
+
+class LifecycleManager(Protocol):
+    """Minimal protocol for lifecycle managers."""
+
+    def pause_agent(self, name: str, reason: str | None = None) -> None:
+        ...
+
+    def resume_agent(self, name: str) -> None:
+        ...
+
+
+class ModuleManager(Protocol):
+    """Minimal protocol for runtime module managers."""
+
+    def load_module(self, name: str) -> None:
+        ...
+
+    def unload_module(self, name: str) -> None:
+        ...
+
+
+@dataclass
+class UnifiedBrainManager:
+    """Coordinate agent lifecycle and runtime modules via events.
+
+    Parameters
+    ----------
+    lifecycle : :class:`AgentLifecycleManager`
+        Manager responsible for agent creation and control.
+    modules : :class:`RuntimeModuleManager`
+        Manager responsible for loading runtime capability modules.
+    """
+
+    lifecycle: LifecycleManager
+    modules: ModuleManager
+
+    def __post_init__(self) -> None:
+        # Listen for events addressed to the brain manager itself.
+        subscribe_to_brain_region("brain_manager", self._handle_event)
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def _handle_event(self, event: Dict[str, Any]) -> None:
+        """Dispatch incoming events to the appropriate sub-manager."""
+
+        command = event.get("command")
+        if command == "pause_agent":
+            self.lifecycle.pause_agent(event.get("agent"), event.get("reason"))
+        elif command == "resume_agent":
+            self.lifecycle.resume_agent(event.get("agent"))
+        elif command == "load_module":
+            self.modules.load_module(event.get("module"))
+        elif command == "unload_module":
+            self.modules.unload_module(event.get("module"))
+        elif command == "fault":
+            agent = event.get("agent")
+            self.lifecycle.pause_agent(agent, "fault")
+            publish_neural_event(
+                {
+                    "target": event.get("notify", "monitor"),
+                    "agent": agent,
+                    "status": "isolated",
+                }
+            )
+        # Unknown commands are ignored to keep the manager robust.

--- a/modules/tests/test_unified_brain_manager.py
+++ b/modules/tests/test_unified_brain_manager.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.brain_manager import UnifiedBrainManager
+from modules.brain.message_bus import (
+    publish_neural_event,
+    subscribe_to_brain_region,
+    reset_message_bus,
+)
+
+
+class DummyLifecycleManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def pause_agent(self, name: str, reason: str | None = None) -> None:
+        self.calls.append((name, reason))
+
+    def resume_agent(self, name: str) -> None:  # pragma: no cover - unused
+        self.calls.append(("resume", name))
+
+
+class DummyModuleManager:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def load_module(self, name: str) -> None:
+        self.events.append(("load", name))
+
+    def unload_module(self, name: str) -> None:
+        self.events.append(("unload", name))
+
+
+class FailingLifecycleManager(DummyLifecycleManager):
+    def __init__(self) -> None:
+        super().__init__()
+        self.failures = 0
+
+    def pause_agent(self, name: str, reason: str | None = None) -> None:
+        self.failures += 1
+        raise RuntimeError("boom")
+
+
+def setup_function() -> None:
+    # Ensure a clean message bus for each test
+    reset_message_bus()
+
+
+def test_event_driven_coordination() -> None:
+    lifecycle = DummyLifecycleManager()
+    modules = DummyModuleManager()
+    UnifiedBrainManager(lifecycle, modules)
+
+    publish_neural_event(
+        {"target": "brain_manager", "command": "pause_agent", "agent": "007", "reason": "rest"}
+    )
+    publish_neural_event(
+        {"target": "brain_manager", "command": "load_module", "module": "vision"}
+    )
+
+    assert lifecycle.calls == [("007", "rest")]
+    assert modules.events == [("load", "vision")]
+
+
+def test_fault_isolation_and_notification() -> None:
+    lifecycle = DummyLifecycleManager()
+    modules = DummyModuleManager()
+    UnifiedBrainManager(lifecycle, modules)
+
+    notifications: list[dict] = []
+    subscribe_to_brain_region("monitor", lambda e: notifications.append(e))
+
+    publish_neural_event(
+        {"target": "brain_manager", "command": "fault", "agent": "bob", "notify": "monitor"}
+    )
+
+    assert lifecycle.calls == [("bob", "fault")]
+    assert notifications and notifications[-1]["status"] == "isolated"
+
+
+def test_circuit_breaker_isolates_failures() -> None:
+    lifecycle = FailingLifecycleManager()
+    modules = DummyModuleManager()
+    UnifiedBrainManager(lifecycle, modules)
+
+    for _ in range(4):
+        publish_neural_event(
+            {"target": "brain_manager", "command": "pause_agent", "agent": "bad"}
+        )
+
+    # Circuit breaker should stop after three failures
+    assert lifecycle.failures == 3


### PR DESCRIPTION
## Summary
- add UnifiedBrainManager orchestrating AgentLifecycleManager and RuntimeModuleManager via message bus
- implement event-driven resource allocation and fault isolation
- add integration tests for manager coordination and circuit breaker

## Testing
- `pytest modules/tests/test_unified_brain_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c69198237c832f978e0a00087f7fff