### PR TITLE
feat: enhance consciousness advanced model

### DIFF
--- a/modules/tests/test_consciousness_advanced.py
+++ b/modules/tests/test_consciousness_advanced.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 from modules.brain.consciousness import ConsciousnessModel
 from modules.brain.consciousness_advanced import (
-    ConsciousnessAdvancedModel,
+    ConsciousnessAdvanced,
     AdaptiveAttention,
 )
 
@@ -23,7 +23,7 @@ def _dataset():
 
 
 def test_hierarchical_workspace_and_metacognition():
-    model = ConsciousnessAdvancedModel()
+    model = ConsciousnessAdvanced()
     data = _dataset()
     acc = model.evaluate_dataset(data)
     assert acc >= 0.66
@@ -42,7 +42,7 @@ def test_accuracy_improvement_over_simple_model():
         correct += int(pred == bool(item["ground_truth"]))
     simple_acc = correct / len(data)
 
-    advanced = ConsciousnessAdvancedModel(attention=AdaptiveAttention())
+    advanced = ConsciousnessAdvanced(attention=AdaptiveAttention())
     adv_acc = advanced.evaluate_dataset(data)
 
     assert adv_acc > simple_acc

--- a/tests/consciousness/test_hierarchical_model.py
+++ b/tests/consciousness/test_hierarchical_model.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.brain.consciousness import ConsciousnessModel
+from modules.brain.consciousness_advanced import ConsciousnessAdvanced, AdaptiveAttention
+
+
+def _dataset():
+    return [
+        {"score": 0.55, "ground_truth": 0},
+        {"score": 0.60, "ground_truth": 0},
+        {"score": 0.70, "ground_truth": 1},
+        {"score": 0.80, "ground_truth": 1},
+        {"score": 0.58, "ground_truth": 0},
+        {"score": 0.90, "ground_truth": 1},
+    ]
+
+
+def test_hierarchical_model_improves_task_performance():
+    data = _dataset()
+
+    simple = ConsciousnessModel()
+    preds = []
+    for item in data:
+        info = {"is_salient": item["score"] > 0.5}
+        preds.append(simple.conscious_access(info))
+    simple_acc = sum(int(p == bool(d["ground_truth"])) for p, d in zip(preds, data)) / len(data)
+
+    advanced = ConsciousnessAdvanced(attention=AdaptiveAttention())
+    adv_acc = advanced.evaluate_dataset(data)
+
+    assert adv_acc > simple_acc
+    assert len(advanced.global_workspace()) >= sum(d["ground_truth"] for d in data)
+    assert advanced.metacognitive_accuracy() == adv_acc
+
+
+def test_visualizer_hook_tracks_attention_and_memory():
+    model = ConsciousnessAdvanced()
+    snapshots = []
+
+    def hook(data):
+        snapshots.append(data)
+
+    model.add_visualizer(hook)
+    model.conscious_access({"score": 0.9, "ground_truth": 1})
+
+    assert snapshots
+    snap = snapshots[-1]
+    assert "attention_scores" in snap and "memory" in snap


### PR DESCRIPTION
## Summary
- add `ConsciousnessAdvanced` with hooks for global/local workspace, metacognition and emotion regulation
- expose visualization callbacks for attention distribution and working memory changes
- add tests comparing hierarchical and basic consciousness models

## Testing
- `pytest tests/consciousness modules/tests/test_consciousness_advanced.py`

------
https://chatgpt.com/codex/tasks/task_e_68c691a1ceb4832fa0827e226f2a0f01