### PR TITLE
feat: add bagua trigram mappings

### DIFF
--- a/modules/iching/__init__.py
+++ b/modules/iching/__init__.py
@@ -1,0 +1,5 @@
+"""I Ching related utilities."""
+
+from .bagua import PreHeavenBagua, PostHeavenBagua, get_trigram
+
+__all__ = ["PreHeavenBagua", "PostHeavenBagua", "get_trigram"]

--- a/modules/iching/bagua.py
+++ b/modules/iching/bagua.py
@@ -1,0 +1,72 @@
+"""Definitions of the eight trigrams (Bagua)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Trigram:
+    """Represents a single trigram with its metadata."""
+
+    name: str
+    chinese: str
+    symbol: str
+    direction: str
+
+
+class PreHeavenBagua(Enum):
+    """Fu Xi's (Earlier Heaven) arrangement of the eight trigrams."""
+
+    QIAN = Trigram("Qian", "乾", "☰", "South")
+    DUI = Trigram("Dui", "兑", "☱", "Southeast")
+    LI = Trigram("Li", "离", "☲", "East")
+    ZHEN = Trigram("Zhen", "震", "☳", "Northeast")
+    XUN = Trigram("Xun", "巽", "☴", "Southwest")
+    KAN = Trigram("Kan", "坎", "☵", "West")
+    GEN = Trigram("Gen", "艮", "☶", "Northwest")
+    KUN = Trigram("Kun", "坤", "☷", "North")
+
+
+class PostHeavenBagua(Enum):
+    """King Wen's (Later Heaven) arrangement of the eight trigrams."""
+
+    QIAN = Trigram("Qian", "乾", "☰", "Northwest")
+    DUI = Trigram("Dui", "兑", "☱", "West")
+    LI = Trigram("Li", "离", "☲", "South")
+    ZHEN = Trigram("Zhen", "震", "☳", "East")
+    XUN = Trigram("Xun", "巽", "☴", "Southeast")
+    KAN = Trigram("Kan", "坎", "☵", "North")
+    GEN = Trigram("Gen", "艮", "☶", "Northeast")
+    KUN = Trigram("Kun", "坤", "☷", "Southwest")
+
+
+def _iterate_bagua(order: str) -> Iterable[Trigram]:
+    order = order.lower()
+    if order not in {"pre", "post"}:
+        raise ValueError("order must be 'pre' or 'post'")
+    bagua_cls = PreHeavenBagua if order == "pre" else PostHeavenBagua
+    for trigram in bagua_cls:
+        yield trigram.value
+
+
+def get_trigram(order: str, name: str) -> Trigram:
+    """Return the trigram by order ('pre' or 'post') and its name.
+
+    Parameters
+    ----------
+    order:
+        Either ``"pre"`` for the Earlier Heaven sequence or ``"post"`` for the Later
+        Heaven sequence.
+    name:
+        English (e.g., ``"Qian"``) or Chinese (e.g., ``"乾"``) name of the trigram.
+    """
+
+    normalized = name.lower()
+    for trigram in _iterate_bagua(order):
+        if normalized == trigram.name.lower() or name == trigram.chinese:
+            return trigram
+    raise KeyError(f"Trigram '{name}' not found in {order}-heaven bagua")
+

--- a/tests/iching/test_bagua.py
+++ b/tests/iching/test_bagua.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pytest
+
+from modules.iching.bagua import get_trigram
+
+
+def test_pre_heaven_bagua_mapping():
+    expected = {
+        "Qian": ("乾", "☰", "South"),
+        "Dui": ("兑", "☱", "Southeast"),
+        "Li": ("离", "☲", "East"),
+        "Zhen": ("震", "☳", "Northeast"),
+        "Xun": ("巽", "☴", "Southwest"),
+        "Kan": ("坎", "☵", "West"),
+        "Gen": ("艮", "☶", "Northwest"),
+        "Kun": ("坤", "☷", "North"),
+    }
+    for name, (chinese, symbol, direction) in expected.items():
+        trigram = get_trigram("pre", name)
+        assert (trigram.chinese, trigram.symbol, trigram.direction) == (
+            chinese,
+            symbol,
+            direction,
+        )
+        assert get_trigram("pre", chinese) == trigram
+
+
+def test_post_heaven_bagua_mapping():
+    expected = {
+        "Qian": ("乾", "☰", "Northwest"),
+        "Dui": ("兑", "☱", "West"),
+        "Li": ("离", "☲", "South"),
+        "Zhen": ("震", "☳", "East"),
+        "Xun": ("巽", "☴", "Southeast"),
+        "Kan": ("坎", "☵", "North"),
+        "Gen": ("艮", "☶", "Northeast"),
+        "Kun": ("坤", "☷", "Southwest"),
+    }
+    for name, (chinese, symbol, direction) in expected.items():
+        trigram = get_trigram("post", name)
+        assert (trigram.chinese, trigram.symbol, trigram.direction) == (
+            chinese,
+            symbol,
+            direction,
+        )
+        assert get_trigram("post", chinese) == trigram


### PR DESCRIPTION
## Summary
- add Fu Xi and King Wen bagua enumerations with trigram metadata
- provide `get_trigram` helper for looking up trigrams by order and name
- include unit tests verifying pre- and post-heaven mappings

## Testing
- `pytest tests/iching/test_bagua.py`


------
https://chatgpt.com/codex/tasks/task_e_68c694e4d024832f822b2042a84175c0