### PR TITLE
Add scenario simulation engine with forward/backward inference

### DIFF
--- a/modules/brain/reasoning/__init__.py
+++ b/modules/brain/reasoning/__init__.py
@@ -2,5 +2,6 @@
 
 from .analogical import AnalogicalReasoner
 from .commonsense import CommonSenseReasoner
+from .simulation_engine import ScenarioSimulationEngine
 
-__all__ = ["AnalogicalReasoner", "CommonSenseReasoner"]
+__all__ = ["AnalogicalReasoner", "CommonSenseReasoner", "ScenarioSimulationEngine"]

--- a/modules/brain/reasoning/simulation_engine.py
+++ b/modules/brain/reasoning/simulation_engine.py
@@ -1,0 +1,81 @@
+"""Scenario simulation engine integrating world model and rule repository."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable, Dict, List
+
+State = Dict[str, Any]
+RuleFunc = Callable[[State], State | List[State]]
+Rule = Dict[str, RuleFunc]
+Rules = Dict[str, Rule]
+
+
+class ScenarioSimulationEngine:
+    """Engine for multi-step scenario simulation.
+
+    The engine combines a *world model* represented as an arbitrary state
+    dictionary with a repository of rules mapping action names to forward and
+    backward transition functions. It can simulate sequences of actions in the
+    forward direction and also perform reverse simulation using the backward
+    rules. Rules may yield multiple states to support branching scenarios.
+
+    Parameters
+    ----------
+    world_model:
+        Optional default state used when no ``initial_state`` is provided.
+    rules:
+        Optional pre-populated rule repository.
+    """
+
+    def __init__(self, world_model: State | None = None, rules: Rules | None = None) -> None:
+        self.world_model: State = world_model or {}
+        self.rules: Rules = rules or {}
+
+    def add_rule(self, action: str, forward: RuleFunc, backward: RuleFunc) -> None:
+        """Register ``forward`` and ``backward`` rules for ``action``."""
+
+        self.rules[action] = {"forward": forward, "backward": backward}
+
+    def simulate_scenario(
+        self,
+        initial_state: State | None,
+        actions: List[str],
+        reverse: bool = False,
+    ) -> List[List[State]]:
+        """Simulate ``actions`` starting from ``initial_state``.
+
+        Returns a history list where each element contains the possible states
+        after the corresponding step. The first element represents the initial
+        state. When ``reverse`` is true the actions are processed in reverse
+        order using their backward rules.
+        """
+
+        state = deepcopy(initial_state) if initial_state is not None else deepcopy(self.world_model)
+        states: List[State] = [state]
+        history: List[List[State]] = [deepcopy(states)]
+        sequence = list(reversed(actions)) if reverse else actions
+        for action in sequence:
+            rule = self.rules.get(action)
+            if not rule:
+                history.append(states)
+                continue
+            fn = rule["backward"] if reverse else rule["forward"]
+            next_states: List[State] = []
+            for s in states:
+                result = fn(deepcopy(s))
+                if isinstance(result, list):
+                    next_states.extend(result)
+                else:
+                    next_states.append(result)
+            states = next_states
+            history.append(deepcopy(states))
+        return history
+
+    def predict_outcome(self, initial_state: State | None, actions: List[str]) -> List[State]:
+        """Return the final state(s) after simulating ``actions``."""
+
+        return self.simulate_scenario(initial_state, actions)[-1]
+
+
+__all__ = ["ScenarioSimulationEngine"]

--- a/modules/tests/reasoning/__init__.py
+++ b/modules/tests/reasoning/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for reasoning components."""

--- a/modules/tests/reasoning/test_scenario_simulation.py
+++ b/modules/tests/reasoning/test_scenario_simulation.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from modules.brain.reasoning import ScenarioSimulationEngine
+
+
+def test_forward_and_backward_simulation():
+    engine = ScenarioSimulationEngine()
+
+    def step_forward(state):
+        s = state.copy()
+        s["position"] += 1
+        return s
+
+    def step_backward(state):
+        s = state.copy()
+        s["position"] -= 1
+        return s
+
+    engine.add_rule("step", step_forward, step_backward)
+
+    forward_history = engine.simulate_scenario({"position": 0}, ["step", "step"])
+    assert forward_history[-1] == [{"position": 2}]
+
+    backward_history = engine.simulate_scenario({"position": 2}, ["step", "step"], reverse=True)
+    assert backward_history[-1] == [{"position": 0}]
+
+
+def test_branching_scenario():
+    engine = ScenarioSimulationEngine()
+
+    def branch_forward(state):
+        s = state["position"]
+        return [{"position": s + 1}, {"position": s - 1}]
+
+    def branch_backward(state):
+        s = state["position"]
+        return [{"position": s - 1}, {"position": s + 1}]
+
+    def step_forward(state):
+        s = state.copy()
+        s["position"] += 1
+        return s
+
+    def step_backward(state):
+        s = state.copy()
+        s["position"] -= 1
+        return s
+
+    engine.add_rule("branch", branch_forward, branch_backward)
+    engine.add_rule("step", step_forward, step_backward)
+
+    outcomes = engine.predict_outcome({"position": 0}, ["branch", "step"])
+
+    assert len(outcomes) == 2
+    assert {"position": 2} in outcomes
+    assert {"position": 0} in outcomes


### PR DESCRIPTION
## Summary
- implement `ScenarioSimulationEngine` combining a world model with rule-based forward/backward simulation
- expose scenario simulation through `simulate_scenario` and `predict_outcome`
- add unit tests for multi-step reasoning and branching outcomes

## Testing
- `pytest modules/tests/reasoning/test_scenario_simulation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6952c4ebc832fa75b8ed93a38f3a2