### PR TITLE
Add computation orchestrator for algorithm execution

### DIFF
--- a/modules/brain/computation/__init__.py
+++ b/modules/brain/computation/__init__.py
@@ -1,0 +1,5 @@
+"""Computation orchestration utilities."""
+
+from .orchestrator import ComputationOrchestrator
+
+__all__ = ["ComputationOrchestrator"]

--- a/modules/brain/computation/orchestrator.py
+++ b/modules/brain/computation/orchestrator.py
@@ -1,0 +1,61 @@
+"""Orchestrator for executing algorithms by name."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Any, Dict, Type
+
+from algorithms.base import Algorithm
+
+
+class ComputationOrchestrator:
+    """Utility class to load and execute algorithms from the ``algorithms`` package."""
+
+    def __init__(self, root_package: str = "algorithms") -> None:
+        self.root_package = root_package
+
+    def _find_module(self, name: str):
+        """Locate the module containing the algorithm.
+
+        Args:
+            name: The module name (without package prefix) to search for.
+
+        Returns:
+            The imported module containing the algorithm implementation.
+
+        Raises:
+            ValueError: If no matching module is found.
+        """
+        package = importlib.import_module(self.root_package)
+        for _, module_name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+            if module_name.endswith(f".{name}"):
+                return importlib.import_module(module_name)
+        raise ValueError(f"Algorithm '{name}' not found")
+
+    def execute_algorithm(self, name: str, data: Any, params: Dict[str, Any] | None = None) -> Any:
+        """Execute an algorithm by name and return the result.
+
+        Args:
+            name: The algorithm's module name (e.g. ``"bubble_sort"``).
+            data: Primary data input passed as the first argument to the algorithm.
+            params: Optional dictionary of additional keyword arguments.
+
+        Returns:
+            The result produced by the algorithm's ``execute`` method.
+
+        Raises:
+            ValueError: If the algorithm cannot be located or does not define a subclass of
+                :class:`~algorithms.base.Algorithm`.
+        """
+        module = self._find_module(name)
+        algorithm_cls: Type[Algorithm] | None = None
+        for attr in module.__dict__.values():
+            if isinstance(attr, type) and issubclass(attr, Algorithm) and attr is not Algorithm:
+                algorithm_cls = attr
+                break
+        if algorithm_cls is None:
+            raise ValueError(f"No Algorithm subclass found for '{name}'")
+        algorithm = algorithm_cls()
+        params = params or {}
+        return algorithm.execute(data, **params)

--- a/modules/tests/computation/test_orchestrator.py
+++ b/modules/tests/computation/test_orchestrator.py
@@ -1,0 +1,23 @@
+import pytest
+
+from modules.brain.computation import ComputationOrchestrator
+
+
+def test_execute_bubble_sort():
+    orchestrator = ComputationOrchestrator()
+    data = [5, 1, 4, 2, 8]
+    result = orchestrator.execute_algorithm("bubble_sort", data, {})
+    assert result == sorted(data)
+
+
+def test_execute_binary_search():
+    orchestrator = ComputationOrchestrator()
+    data = [1, 3, 5, 7, 9]
+    index = orchestrator.execute_algorithm("binary_search", data, {"target": 7})
+    assert index == 3
+
+
+def test_execute_invalid_algorithm():
+    orchestrator = ComputationOrchestrator()
+    with pytest.raises(ValueError):
+        orchestrator.execute_algorithm("nonexistent", [], {})


### PR DESCRIPTION
## Summary
- add `ComputationOrchestrator` to dynamically load and execute algorithms by name
- cover typical and error scenarios with new tests

## Testing
- `PYTHONPATH=. pytest modules/tests/computation/test_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6953090f4832faf18d49b73cb832e