### PR TITLE
feat: add evolution engine orchestrator with tests

### DIFF
--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -9,6 +9,7 @@ from .evolving_cognitive_architecture import (
 )
 from .self_evolving_cognition import SelfEvolvingCognition
 from .self_evolving_ai_architecture import SelfEvolvingAIArchitecture
+from .evolution_engine import EvolutionEngine
 from .adapter import EvolutionModule
 
 try:  # optional dependencies
@@ -61,6 +62,7 @@ __all__ = [
     "EvolutionGeneticAlgorithm",
     "SelfEvolvingCognition",
     "SelfEvolvingAIArchitecture",
+    "EvolutionEngine",
     "PPO",
     "PPOConfig",
     "A3C",

--- a/modules/evolution/evolution_engine.py
+++ b/modules/evolution/evolution_engine.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Unified evolution engine coordinating cognitive evolution components.
+
+This module defines :class:`EvolutionEngine` which ties together
+:class:`SelfEvolvingCognition` and :class:`EvolvingCognitiveArchitecture`.
+It exposes :meth:`run_evolution_cycle` to drive the evolution process using
+performance metrics and keeps a history of all evolved architectures to enable
+rollback.
+"""
+
+from typing import Dict, Iterable, List
+
+from modules.monitoring.collector import MetricEvent
+
+from .evolving_cognitive_architecture import EvolvingCognitiveArchitecture, GeneticAlgorithm
+from .self_evolving_cognition import EvolutionRecord, SelfEvolvingCognition
+
+
+class EvolutionEngine:
+    """Coordinate architecture evolution based on performance metrics."""
+
+    def __init__(
+        self,
+        initial_architecture: Dict[str, float],
+        fitness_fn,
+        ga: GeneticAlgorithm | None = None,
+    ) -> None:
+        self.evolver = EvolvingCognitiveArchitecture(fitness_fn, ga)
+        self.cognition = SelfEvolvingCognition(initial_architecture, self.evolver)
+
+    # ------------------------------------------------------------------
+    def run_evolution_cycle(self, metrics: Iterable[MetricEvent]) -> Dict[str, float]:
+        """Evolve the architecture using the provided ``metrics``.
+
+        The metrics are aggregated into a single performance score. Candidate
+        architectures are generated via the underlying genetic algorithm and
+        the best one replaces the current architecture. The new architecture is
+        appended to the evolution history and returned.
+        """
+
+        metrics = list(metrics)
+        if not metrics:
+            return self.cognition.architecture
+
+        # Aggregate metrics into a performance score.
+        performance = sum(self.cognition._score_event(m) for m in metrics) / len(metrics)
+
+        # Generate and apply the best candidate architecture.
+        new_arch = self.evolver.evolve_architecture(self.cognition.architecture, performance)
+        new_perf = self.evolver.fitness_fn(new_arch)
+
+        self.cognition.version += 1
+        self.cognition.architecture = new_arch
+        self.cognition.history.append(
+            EvolutionRecord(self.cognition.version, new_arch.copy(), new_perf)
+        )
+        return new_arch
+
+    # ------------------------------------------------------------------
+    def rollback(self, version: int) -> Dict[str, float]:
+        """Rollback to a previous architecture version."""
+
+        return self.cognition.rollback(version)
+
+    # ------------------------------------------------------------------
+    def history(self) -> List[EvolutionRecord]:
+        """Return the evolution history."""
+
+        return self.cognition.history

--- a/modules/tests/evolution/test_evolution_engine.py
+++ b/modules/tests/evolution/test_evolution_engine.py
@@ -1,0 +1,44 @@
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.evolution import EvolutionEngine, EvolutionGeneticAlgorithm
+from modules.evolution.evolving_cognitive_architecture import GAConfig
+from modules.monitoring.collector import MetricEvent
+
+
+def fitness_fn(arch):
+    x = arch["weight"]
+    return -(x - 1.0) ** 2
+
+
+def test_multi_cycle_evolution_and_rollback():
+    random.seed(0)
+    ga = EvolutionGeneticAlgorithm(
+        fitness_fn, GAConfig(population_size=10, generations=5, mutation_sigma=0.5)
+    )
+    engine = EvolutionEngine({"weight": 0.0}, fitness_fn, ga)
+
+    # Run several evolution cycles using feedback derived from current performance
+    for step in range(5):
+        perf = fitness_fn(engine.cognition.architecture)
+        metrics = [
+            MetricEvent(
+                module="evolve",
+                latency=0.0,
+                energy=0.0,
+                throughput=perf,
+                timestamp=float(step),
+            )
+        ]
+        engine.run_evolution_cycle(metrics)
+
+    performances = [rec.performance for rec in engine.history()]
+    assert performances[-1] > performances[0]
+
+    # Verify rollback restores initial architecture
+    initial_arch = engine.history()[0].architecture
+    engine.rollback(0)
+    assert engine.cognition.architecture == initial_arch


### PR DESCRIPTION
## Summary
- add EvolutionEngine to coordinate SelfEvolvingCognition and EvolvingCognitiveArchitecture
- expose run_evolution_cycle to evolve architectures from metrics
- include multi-cycle evolution test with rollback verification

## Testing
- `pytest modules/tests/evolution/test_evolution_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c69537846c832f89d0c3b4e1df25ee