### PR TITLE
Add YinYangFiveElements utility for Yin-Yang and Five Elements

### DIFF
--- a/modules/iching/__init__.py
+++ b/modules/iching/__init__.py
@@ -1,5 +1,6 @@
 """I Ching related utilities."""
 
 from .bagua import PreHeavenBagua, PostHeavenBagua, get_trigram
+from .yinyang_wuxing import YinYangFiveElements
 
-__all__ = ["PreHeavenBagua", "PostHeavenBagua", "get_trigram"]
+__all__ = ["PreHeavenBagua", "PostHeavenBagua", "get_trigram", "YinYangFiveElements"]

--- a/modules/iching/yinyang_wuxing.py
+++ b/modules/iching/yinyang_wuxing.py
@@ -1,0 +1,93 @@
+"""Yin-Yang transformations and Five Elements interactions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class YinYangFiveElements:
+    """Utility class providing Yin-Yang conversion and Five Elements relations."""
+
+    # Constants for Yin and Yang
+    YIN: str = "yin"
+    YANG: str = "yang"
+
+    # Generation (sheng) cycle mapping
+    GENERATION = {
+        "wood": "fire",
+        "fire": "earth",
+        "earth": "metal",
+        "metal": "water",
+        "water": "wood",
+    }
+
+    # Control (ke) cycle mapping
+    CONTROL = {
+        "wood": "earth",
+        "earth": "water",
+        "water": "fire",
+        "fire": "metal",
+        "metal": "wood",
+    }
+
+    @staticmethod
+    def transform_yinyang(value: str | int | bool):
+        """Return the opposite Yin/Yang for the provided value.
+
+        Parameters
+        ----------
+        value: str | int | bool
+            ``"yin"``/``"yang"`` (case insensitive), ``0``/``1``, or ``True``/``False``.
+
+        Returns
+        -------
+        Same type as ``value`` with Yin and Yang swapped.
+        """
+
+        if isinstance(value, str):
+            normalized = value.lower()
+            if normalized == YinYangFiveElements.YIN:
+                return YinYangFiveElements.YANG
+            if normalized == YinYangFiveElements.YANG:
+                return YinYangFiveElements.YIN
+        elif isinstance(value, bool):
+            return not value
+        elif isinstance(value, int):
+            if value in (0, 1):
+                return 1 - value
+
+        raise ValueError("value must be 'yin', 'yang', 0/1, or boolean")
+
+    @classmethod
+    def element_interaction(cls, element_a: str, element_b: str) -> str:
+        """Determine the interaction between two Five Elements.
+
+        Parameters
+        ----------
+        element_a, element_b: str
+            Names of the Five Elements (wood, fire, earth, metal, water).
+
+        Returns
+        -------
+        str
+            One of ``"generate"``, ``"generated_by"``, ``"control"``,
+            ``"controlled_by"``, or ``"same"``.
+        """
+
+        a = element_a.lower()
+        b = element_b.lower()
+        valid = cls.GENERATION.keys()
+        if a not in valid or b not in valid:
+            raise ValueError("element must be one of wood, fire, earth, metal, water")
+        if a == b:
+            return "same"
+        if cls.GENERATION[a] == b:
+            return "generate"
+        if cls.GENERATION[b] == a:
+            return "generated_by"
+        if cls.CONTROL[a] == b:
+            return "control"
+        if cls.CONTROL[b] == a:
+            return "controlled_by"
+        return "none"

--- a/tests/iching/test_yinyang_wuxing.py
+++ b/tests/iching/test_yinyang_wuxing.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pytest
+
+from modules.iching.yinyang_wuxing import YinYangFiveElements
+
+
+def test_transform_yinyang_strings():
+    assert YinYangFiveElements.transform_yinyang("yin") == "yang"
+    assert YinYangFiveElements.transform_yinyang("YANG") == "yin"
+
+
+def test_transform_yinyang_numbers_and_bool():
+    assert YinYangFiveElements.transform_yinyang(0) == 1
+    assert YinYangFiveElements.transform_yinyang(1) == 0
+    assert YinYangFiveElements.transform_yinyang(True) is False
+
+
+def test_transform_yinyang_invalid():
+    with pytest.raises(ValueError):
+        YinYangFiveElements.transform_yinyang("neutral")
+
+
+def test_element_generation_and_control():
+    y = YinYangFiveElements
+    assert y.element_interaction("wood", "fire") == "generate"
+    assert y.element_interaction("fire", "wood") == "generated_by"
+    assert y.element_interaction("wood", "earth") == "control"
+    assert y.element_interaction("earth", "wood") == "controlled_by"
+
+
+def test_element_same():
+    assert YinYangFiveElements.element_interaction("water", "water") == "same"


### PR DESCRIPTION
## Summary
- add `YinYangFiveElements` class modeling yin-yang conversion and five-element generation/control cycles
- expose `YinYangFiveElements` in the iching module
- test yin-yang transformations and element interactions

## Testing
- `pytest tests/iching -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69998fefc832fbfafc3cb84e4724a