### PR TITLE
feat: add time context utilities for iching

### DIFF
--- a/modules/iching/__init__.py
+++ b/modules/iching/__init__.py
@@ -1,6 +1,25 @@
 """I Ching related utilities."""
 
 from .bagua import PreHeavenBagua, PostHeavenBagua, get_trigram
+from .hexagram_engine import HexagramEngine
+from .time_context import (
+    TimeContext,
+    get_chinese_hour,
+    get_lunar_date,
+    get_solar_term,
+    get_time_context,
+)
 from .yinyang_wuxing import YinYangFiveElements
 
-__all__ = ["PreHeavenBagua", "PostHeavenBagua", "get_trigram", "YinYangFiveElements"]
+__all__ = [
+    "PreHeavenBagua",
+    "PostHeavenBagua",
+    "get_trigram",
+    "YinYangFiveElements",
+    "HexagramEngine",
+    "TimeContext",
+    "get_time_context",
+    "get_lunar_date",
+    "get_solar_term",
+    "get_chinese_hour",
+]

--- a/modules/iching/hexagram_engine.py
+++ b/modules/iching/hexagram_engine.py
@@ -1,0 +1,25 @@
+"""Simple hexagram engine that can utilize time context."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .time_context import TimeContext
+
+
+class HexagramEngine:
+    """Generate basic I Ching interpretations with optional time context."""
+
+    def interpret(self, hexagram: str, context: Optional[TimeContext] = None) -> str:
+        """Return an interpretation string for the given hexagram.
+
+        If ``context`` is provided, the solar term and Chinese hour are included in
+        the interpretation to illustrate how timing can affect divination results.
+        """
+
+        explanation = f"Interpretation for {hexagram}"
+        if context:
+            explanation += (
+                f" during {context.solar_term} {context.chinese_hour} hour"
+            )
+        return explanation

--- a/modules/iching/time_context.py
+++ b/modules/iching/time_context.py
@@ -1,0 +1,54 @@
+"""Time context utilities for I Ching calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from lunar_python import Solar
+
+
+@dataclass(frozen=True)
+class TimeContext:
+    """Represents lunar calendar context information."""
+
+    lunar_year: int
+    lunar_month: int
+    lunar_day: int
+    solar_term: str
+    chinese_hour: str
+
+
+def get_lunar_date(dt: datetime) -> tuple[int, int, int]:
+    """Return lunar year, month and day for the given datetime."""
+
+    solar = Solar.fromDate(dt)
+    lunar = solar.getLunar()
+    return lunar.getYear(), lunar.getMonth(), lunar.getDay()
+
+
+def get_solar_term(dt: datetime) -> str:
+    """Return solar term (\u8282\u6c14) for the given datetime."""
+
+    solar = Solar.fromDate(dt)
+    return solar.getLunar().getJieQi()
+
+
+def get_chinese_hour(dt: datetime) -> str:
+    """Return traditional Chinese hour (\u65f6\u8fb0) for the given datetime."""
+
+    solar = Solar.fromDate(dt)
+    return solar.getLunar().getTimeZhi()
+
+
+def get_time_context(dt: datetime) -> TimeContext:
+    """Return a complete :class:`TimeContext` for the given datetime."""
+
+    solar = Solar.fromDate(dt)
+    lunar = solar.getLunar()
+    return TimeContext(
+        lunar_year=lunar.getYear(),
+        lunar_month=lunar.getMonth(),
+        lunar_day=lunar.getDay(),
+        solar_term=lunar.getJieQi(),
+        chinese_hour=lunar.getTimeZhi(),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ torchvision = ">=0.16.0,<0.17.0"
 transformers = ">=4.38.0,<5.0.0"
 onnxruntime = { version = ">=1.16.0,<2.0.0", optional = true }
 tensorrt = { version = ">=8.6.0,<9.0.0", optional = true }
+"lunar-python" = ">=1.4.4,<2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=23.3.0,<24.0.0"

--- a/tests/iching/test_hexagram_engine.py
+++ b/tests/iching/test_hexagram_engine.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from modules.iching.hexagram_engine import HexagramEngine
+from modules.iching.time_context import get_time_context
+
+
+def test_hexagram_engine_time_context_affects_interpretation():
+    engine = HexagramEngine()
+    hexagram = "乾"
+
+    ctx_summer = get_time_context(datetime(2023, 6, 21, 12, 0, 0))
+    ctx_winter = get_time_context(datetime(2023, 12, 22, 23, 0, 0))
+
+    result_summer = engine.interpret(hexagram, ctx_summer)
+    result_winter = engine.interpret(hexagram, ctx_winter)
+
+    assert ctx_summer.solar_term != ctx_winter.solar_term
+    assert ctx_summer.chinese_hour != ctx_winter.chinese_hour
+    assert result_summer != result_winter
+    assert ctx_summer.solar_term in result_summer
+    assert ctx_winter.solar_term in result_winter

--- a/tests/iching/test_time_context.py
+++ b/tests/iching/test_time_context.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from modules.iching.time_context import (
+    get_chinese_hour,
+    get_lunar_date,
+    get_solar_term,
+    get_time_context,
+)
+
+
+def test_time_context_summer_solstice_noon():
+    dt = datetime(2023, 6, 21, 12, 0, 0)
+    year, month, day = get_lunar_date(dt)
+    assert (year, month, day) == (2023, 5, 4)
+    assert get_solar_term(dt) == "夏至"
+    assert get_chinese_hour(dt) == "午"
+
+
+def test_time_context_winter_solstice_midnight():
+    dt = datetime(2023, 12, 22, 23, 0, 0)
+    ctx = get_time_context(dt)
+    assert ctx.solar_term == "冬至"
+    assert ctx.chinese_hour == "子"


### PR DESCRIPTION
## Summary
- add utility to derive lunar date, solar term, and traditional hour from datetime
- introduce HexagramEngine that integrates time context into interpretations
- test hexagram interpretations across different solar terms and hours

## Testing
- `pytest tests/iching/test_time_context.py tests/iching/test_hexagram_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69c6c184c832f94156d44feb8c5c1