### PR TITLE
Add multi-dimensional hexagram interpretation engine

### DIFF
--- a/modules/iching/__init__.py
+++ b/modules/iching/__init__.py
@@ -2,5 +2,16 @@
 
 from .bagua import PreHeavenBagua, PostHeavenBagua, get_trigram
 from .yinyang_wuxing import YinYangFiveElements
+from .hexagram_engine import HexagramEngine
+from .analysis_dimensions import ANALYSIS_DIMENSIONS, DimensionRule, get_dimension_rule
 
-__all__ = ["PreHeavenBagua", "PostHeavenBagua", "get_trigram", "YinYangFiveElements"]
+__all__ = [
+    "PreHeavenBagua",
+    "PostHeavenBagua",
+    "get_trigram",
+    "YinYangFiveElements",
+    "HexagramEngine",
+    "ANALYSIS_DIMENSIONS",
+    "DimensionRule",
+    "get_dimension_rule",
+]

--- a/modules/iching/analysis_dimensions.py
+++ b/modules/iching/analysis_dimensions.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Definitions for I Ching analysis dimensions and their interpretation rules."""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class DimensionRule:
+    """Represents interpretation rules for a hexagram within a dimension.
+
+    Attributes
+    ----------
+    interpretation: str
+        The meaning derived from the hexagram for the given dimension.
+    advice: str
+        Actionable guidance associated with the interpretation.
+    """
+
+    interpretation: str
+    advice: str
+
+
+# Mapping of dimension name -> hexagram -> DimensionRule
+# Hexagrams are represented as six-character strings of ``1`` (yang) and ``0`` (yin).
+ANALYSIS_DIMENSIONS: Dict[str, Dict[str, DimensionRule]] = {
+    "career": {
+        "111111": DimensionRule(
+            "Great potential for leadership", "Take charge of projects."),
+        "000000": DimensionRule(
+            "Need for support and collaboration", "Seek guidance from mentors."),
+    },
+    "relationship": {
+        "111111": DimensionRule(
+            "Strong personal drive may overshadow others", "Practice empathy."),
+        "000000": DimensionRule(
+            "Stable and nurturing environment", "Foster open communication."),
+    },
+    "fortune": {
+        "111111": DimensionRule(
+            "Favorable circumstances ahead", "Capitalize on momentum."),
+        "000000": DimensionRule(
+            "Challenges may arise", "Remain patient and prepared."),
+    },
+}
+
+
+def get_dimension_rule(dimension: str, hexagram: str) -> DimensionRule:
+    """Retrieve the rule for a given dimension and hexagram.
+
+    Parameters
+    ----------
+    dimension: str
+        Name of the analysis dimension.
+    hexagram: str
+        Six-character hexagram key composed of ``1`` and ``0``.
+
+    Returns
+    -------
+    DimensionRule
+        The corresponding rule.
+
+    Raises
+    ------
+    KeyError
+        If either the dimension or hexagram is not defined.
+    """
+
+    try:
+        return ANALYSIS_DIMENSIONS[dimension][hexagram]
+    except KeyError as exc:  # pragma: no cover - defensive error path
+        raise KeyError(
+            f"Unknown dimension '{dimension}' or hexagram '{hexagram}'" 
+        ) from exc

--- a/modules/iching/hexagram_engine.py
+++ b/modules/iching/hexagram_engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Hexagram interpretation engine using predefined analysis dimensions."""
+
+from typing import Iterable, Dict
+
+from .analysis_dimensions import ANALYSIS_DIMENSIONS, DimensionRule, get_dimension_rule
+
+
+class HexagramEngine:
+    """Provide interpretations for hexagrams across multiple analysis dimensions."""
+
+    def interpret_hexagram(
+        self, hexagram: str, dimensions: Iterable[str]
+    ) -> Dict[str, Dict[str, str]]:
+        """Interpret ``hexagram`` within the specified ``dimensions``.
+
+        Parameters
+        ----------
+        hexagram: str
+            Six-character string representing the hexagram (``1`` for yang, ``0`` for yin).
+        dimensions: Iterable[str]
+            Names of the analysis dimensions to evaluate.
+
+        Returns
+        -------
+        Dict[str, Dict[str, str]]
+            Mapping of dimension name to a dictionary containing ``interpretation`` and
+            ``advice``.
+        """
+
+        results: Dict[str, Dict[str, str]] = {}
+        for dimension in dimensions:
+            if dimension not in ANALYSIS_DIMENSIONS:
+                raise KeyError(f"Unknown dimension: {dimension}")
+            rule: DimensionRule = get_dimension_rule(dimension, hexagram)
+            results[dimension] = {
+                "interpretation": rule.interpretation,
+                "advice": rule.advice,
+            }
+        return results

--- a/tests/iching/test_hexagram_engine.py
+++ b/tests/iching/test_hexagram_engine.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from modules.iching.hexagram_engine import HexagramEngine
+
+
+def test_interpretation_and_independence():
+    engine = HexagramEngine()
+    hexagram = "111111"
+    dims = ["career", "relationship", "fortune"]
+
+    result = engine.interpret_hexagram(hexagram, dims)
+
+    assert result["career"] == {
+        "interpretation": "Great potential for leadership",
+        "advice": "Take charge of projects.",
+    }
+    assert result["relationship"] == {
+        "interpretation": "Strong personal drive may overshadow others",
+        "advice": "Practice empathy.",
+    }
+    assert result["fortune"] == {
+        "interpretation": "Favorable circumstances ahead",
+        "advice": "Capitalize on momentum.",
+    }
+
+    # Order of dimensions should not affect the outcome
+    reversed_result = engine.interpret_hexagram(hexagram, list(reversed(dims)))
+    assert result == reversed_result
+
+    # Individual dimension interpretation should match subset of multi-dimensional result
+    career_only = engine.interpret_hexagram(hexagram, ["career"])
+    assert career_only["career"] == result["career"]
+
+
+def test_different_hexagram_consistency():
+    engine = HexagramEngine()
+    hexagram = "000000"
+    dims = ["career", "relationship", "fortune"]
+
+    result = engine.interpret_hexagram(hexagram, dims)
+
+    assert result["career"] == {
+        "interpretation": "Need for support and collaboration",
+        "advice": "Seek guidance from mentors.",
+    }
+    assert result["relationship"] == {
+        "interpretation": "Stable and nurturing environment",
+        "advice": "Foster open communication.",
+    }
+    assert result["fortune"] == {
+        "interpretation": "Challenges may arise",
+        "advice": "Remain patient and prepared.",
+    }
+
+    fortune_only = engine.interpret_hexagram(hexagram, ["fortune"])
+    assert fortune_only["fortune"] == result["fortune"]


### PR DESCRIPTION
## Summary
- define analysis dimensions (career, relationship, fortune) with interpretation rules
- add HexagramEngine that interprets hexagrams across specified dimensions
- test multi-dimensional combinations for consistent, independent results

## Testing
- `pytest tests/iching/test_bagua.py tests/iching/test_yinyang_wuxing.py tests/iching/test_hexagram_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68c69c7763d8832fae18cce15e25b60f