### PR TITLE
feat(iching): add personalized hexagram engine

### DIFF
--- a/modules/iching/__init__.py
+++ b/modules/iching/__init__.py
@@ -4,6 +4,7 @@ from .bagua import PreHeavenBagua, PostHeavenBagua, get_trigram
 from .yinyang_wuxing import YinYangFiveElements
 from .hexagram64 import HexagramEngine
 from .ai_interpreter import AIEnhancedInterpreter
+from .personalization import UserProfile, PersonalizedHexagramEngine
 from .time_context import (
     TimeContext,
     get_lunar_date,
@@ -19,6 +20,8 @@ __all__ = [
     "YinYangFiveElements",
     "HexagramEngine",
     "AIEnhancedInterpreter",
+    "UserProfile",
+    "PersonalizedHexagramEngine",
     "TimeContext",
     "get_lunar_date",
     "get_solar_term",

--- a/modules/iching/personalization.py
+++ b/modules/iching/personalization.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""User personalization utilities for I Ching interpretations."""
+
+from dataclasses import dataclass, field, replace
+from typing import Dict, List, Optional
+
+from .hexagram64 import Hexagram, HexagramEngine
+
+
+@dataclass
+class UserProfile:
+    """Basic user profile storing preferences and interaction history."""
+
+    user_id: str
+    history: List[int] = field(default_factory=list)
+    preferences: Dict[str, str] = field(default_factory=dict)
+    traits: Dict[str, str] = field(default_factory=dict)
+
+    def record(self, hexagram: Hexagram) -> None:
+        """Record a consulted ``hexagram`` in the user's history."""
+
+        self.history.append(hexagram.number)
+
+
+class PersonalizedHexagramEngine:
+    """Engine that generates personalised I Ching readings."""
+
+    def __init__(self, engine: Optional[HexagramEngine] = None) -> None:
+        self.engine = engine or HexagramEngine()
+
+    def interpret(
+        self,
+        upper: str,
+        lower: str,
+        user: UserProfile,
+        context: Optional[str] = None,
+    ) -> Hexagram:
+        """Return a personalised interpretation for ``user``.
+
+        The underlying :class:`HexagramEngine` provides the base reading while
+        this method injects the user's preferences and traits into the result.
+        Each call also updates the user's history.
+        """
+
+        base = self.engine.interpret(upper, lower, context=context)
+        previous = user.history[-1] if user.history else None
+        user.record(base)
+
+        focus = user.preferences.get("focus", "balance")
+        trait = next(iter(user.traits.values()), None)
+
+        judgement = (
+            f"{base.judgement} Personalized for {user.user_id}, emphasizing {focus}."
+        )
+        if trait:
+            judgement += f" Draw on your {trait}."
+        if previous is not None:
+            judgement += f" Previously you received hexagram {previous}."
+
+        lines = tuple(f"{line} [{focus}]" for line in base.lines)
+        return replace(base, judgement=judgement, lines=lines)

--- a/modules/tests/iching/test_personalization.py
+++ b/modules/tests/iching/test_personalization.py
@@ -1,0 +1,28 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from modules.iching.personalization import (
+    UserProfile,
+    PersonalizedHexagramEngine,
+)
+
+
+def test_personalized_output_differs():
+    engine = PersonalizedHexagramEngine()
+    user1 = UserProfile("u1", preferences={"focus": "career"})
+    user2 = UserProfile("u2", preferences={"focus": "relationships"})
+
+    h1 = engine.interpret("Qian", "Qian", user1)
+    h2 = engine.interpret("Qian", "Qian", user2)
+
+    assert "career" in h1.judgement.lower()
+    assert "relationships" in h2.judgement.lower()
+    assert h1.judgement != h2.judgement
+    assert user1.history == [1]
+    assert user2.history == [1]


### PR DESCRIPTION
## Summary
- add UserProfile and PersonalizedHexagramEngine for user-tailored I Ching readings
- expose personalization tools through iching package
- test personalized readings for different user profiles

## Testing
- `pytest modules/tests/iching/test_hexagram_engine.py::test_qian_hexagram -q`
- `pytest modules/tests/iching/test_time_context.py -q`
- `pytest modules/tests/iching/test_personalization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4e1a4dc832f86a00f817a11fb46