### PR TITLE
docs: auto-generate configuration reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
 
+      - name: Generate configuration reference
+        run: |
+          python scripts/generate_user_config_docs.py --output docs/configuration.md
+
       - name: Build documentation
         run: |
           mkdocs build -f docs/mkdocs.yml

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install -r algorithms/requirements.txt
 pip install -r modules/requirements.txt
 ```
 
-**📖 [完整文档](https://docs.agpt.co)** | **🚀 [贡献指南](CONTRIBUTING.md)**
+**📖 [完整文档](https://docs.agpt.co)** | **⚙️ [配置说明](docs/configuration.md)** | **🚀 [贡献指南](CONTRIBUTING.md)**
 
 ## 🔌 硬件支持
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,7 @@
 | `browse_spacy_language_model` | `"en_core_web_sm"` |  |
 | `memory_backend` | `"json_file"` |  |
 | `memory_index` | `"auto-gpt-memory"` |  |
+| `memory_embedding_strategy` | `"summary"` |  |
 | `redis_host` | `"localhost"` |  |
 | `redis_port` | `6379` |  |
 | `redis_password` | `""` |  |


### PR DESCRIPTION
## Summary
- auto-generate docs/configuration.md with configuration fields
- ensure docs CI runs the generation script
- link configuration reference from README

## Testing
- `python scripts/generate_user_config_docs.py --output docs/configuration.md`
- `pip install -r docs/requirements.txt`
- `mkdocs build -f docs/mkdocs.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6a9d85084832f8bdf2a5e04b35881