### PR TITLE
Add error handling for task deletion

### DIFF
--- a/frontend/lib/viewmodels/task_viewmodel.dart
+++ b/frontend/lib/viewmodels/task_viewmodel.dart
@@ -29,6 +29,10 @@ class TaskViewModel extends ChangeNotifier {
   }
 
   void deleteTask(int id) {
+    final taskExists = tasks.any((task) => task.id == id);
+    if (!taskExists) {
+      throw ArgumentError('Task with id $id not found');
+    }
     tasks.removeWhere((task) => task.id == id);
     notifyListeners();
   }

--- a/frontend/test/task_viewmodel_test.dart
+++ b/frontend/test/task_viewmodel_test.dart
@@ -1,5 +1,6 @@
 import 'package:auto_gpt_flutter_client/viewmodels/task_viewmodel.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/mock_data.dart';
+import 'package:auto_gpt_flutter_client/models/task.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -8,6 +9,12 @@ void main() {
 
     setUp(() {
       viewModel = TaskViewModel();
+      mockTasks
+        ..clear()
+        ..addAll([
+          Task(id: 1, title: 'Sample Task 1'),
+          Task(id: 2, title: 'Sample Task 2'),
+        ]);
     });
 
     test('Fetches tasks successfully', () {
@@ -63,10 +70,10 @@ void main() {
     });
 
     test('Deletes a task with invalid id', () {
-      // TODO: Update this test to expect an error once we have TaskService implemented
+      viewModel.fetchTasks();
       final initialCount = viewModel.tasks.length;
-      viewModel.deleteTask(9999); // Assuming no task with this id exists
-      expect(viewModel.tasks.length, initialCount); // Count remains same
+      expect(() => viewModel.deleteTask(9999), throwsA(isA<ArgumentError>()));
+      expect(viewModel.tasks.length, initialCount);
     });
 
     test('Select a task that doesn\'t exist', () {


### PR DESCRIPTION
## Summary
- throw ArgumentError when deleting non-existent task
- reset mock data and assert exception for invalid delete in tests

## Testing
- `flutter test test/task_viewmodel_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68c6aa00a284832fa0bbfec4bf584724