### PR TITLE
Move summary limit to ActionHistoryConfiguration

### DIFF
--- a/backend/autogpt/autogpt/agents/base.py
+++ b/backend/autogpt/autogpt/agents/base.py
@@ -52,7 +52,11 @@ from autogpt.core.resource.model_providers.openai import (
 from autogpt.core.runner.client_lib.logging.helpers import dump_prompt
 from autogpt.file_storage.base import FileStorage
 from autogpt.llm.providers.openai import get_openai_command_specs
-from autogpt.models.action_history import ActionResult, EpisodicActionHistory
+from autogpt.models.action_history import (
+    ActionHistoryConfiguration,
+    ActionResult,
+    EpisodicActionHistory,
+)
 from autogpt.prompts.prompt import DEFAULT_TRIGGERING_PROMPT
 
 logger = logging.getLogger(__name__)
@@ -111,8 +115,10 @@ class BaseAgentConfiguration(SystemConfiguration):
     defaults to 75% of `llm.max_tokens`.
     """
 
-    summary_max_tlength: Optional[int] = None
-    # TODO: move to ActionHistoryConfiguration
+    history: ActionHistoryConfiguration = Field(
+        default_factory=ActionHistoryConfiguration
+    )
+    """Configuration for action history handling."""
 
     plugins: list[AutoGPTPluginTemplate] = Field(default_factory=list, exclude=True)
 

--- a/backend/autogpt/autogpt/models/action_history.py
+++ b/backend/autogpt/autogpt/models/action_history.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterator, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from autogpt.core.configuration import SystemConfiguration, UserConfigurable
 from autogpt.processing.text import summarize_text
 from autogpt.prompts.utils import format_numbered_list, indent
 
@@ -12,6 +13,13 @@ if TYPE_CHECKING:
     from autogpt.agents.base import CommandArgs, CommandName
     from autogpt.config.config import Config
     from autogpt.core.resource.model_providers import ChatModelProvider
+
+
+class ActionHistoryConfiguration(SystemConfiguration):
+    """Configuration options for action history summarization."""
+
+    summary_max_tlength: int = UserConfigurable(default=1000)
+    """Maximum token length for the action history summary."""
 
 
 class Action(BaseModel):


### PR DESCRIPTION
## Summary
- add ActionHistoryConfiguration with summary_max_tlength
- configure BaseAgentSettings to reference ActionHistoryConfiguration

## Testing
- `ruff check backend/autogpt/autogpt/agents/base.py backend/autogpt/autogpt/models/action_history.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c6b1ce6f6c832fb15875402b86dc4a