### PR TITLE
docs: auto-generate configuration reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Generate configuration reference
         run: |
-          python scripts/generate_user_config_docs.py --output docs/configuration.md
+          python scripts/generate_user_config_docs.py --output docs/configuration.md docs/AutoGPT/configuration/user_configurable.md
+          git diff --exit-code docs/configuration.md docs/AutoGPT/configuration/user_configurable.md
 
       - name: Build documentation
         run: |

--- a/docs/AutoGPT/configuration/user_configurable.md
+++ b/docs/AutoGPT/configuration/user_configurable.md
@@ -63,6 +63,7 @@
 | `browse_spacy_language_model` | `"en_core_web_sm"` |  |
 | `memory_backend` | `"json_file"` |  |
 | `memory_index` | `"auto-gpt-memory"` |  |
+| `memory_embedding_strategy` | `"weighted"` |  |
 | `redis_host` | `"localhost"` |  |
 | `redis_port` | `6379` |  |
 | `redis_password` | `""` |  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@
 | `browse_spacy_language_model` | `"en_core_web_sm"` |  |
 | `memory_backend` | `"json_file"` |  |
 | `memory_index` | `"auto-gpt-memory"` |  |
-| `memory_embedding_strategy` | `"summary"` |  |
+| `memory_embedding_strategy` | `"weighted"` |  |
 | `redis_host` | `"localhost"` |  |
 | `redis_port` | `6379` |  |
 | `redis_password` | `""` |  |


### PR DESCRIPTION
## Summary
- refresh UserConfigurable configuration docs
- ensure docs CI regenerates configuration reference and fails on stale changes

## Testing
- `scripts/build_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c6b1c209f0832f94df7a9b404cff19