### PR TITLE
docs: keep UserConfigurable reference in sync

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Generate configuration reference
         run: |
           python scripts/generate_user_config_docs.py --output docs/configuration.md
+          git diff --exit-code docs/configuration.md
 
       - name: Build documentation
         run: |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@
 | `browse_spacy_language_model` | `"en_core_web_sm"` |  |
 | `memory_backend` | `"json_file"` |  |
 | `memory_index` | `"auto-gpt-memory"` |  |
-| `memory_embedding_strategy` | `"weighted"` | Memory representation for search: `"summary"` or token-length `"weighted"` average of chunk embeddings. |
+| `memory_embedding_strategy` | `"weighted"` |  |
 | `redis_host` | `"localhost"` |  |
 | `redis_port` | `6379` |  |
 | `redis_password` | `""` |  |
@@ -229,6 +229,12 @@
 | `log_format` | `LogFormatName.SIMPLE` |  |
 | `plain_console_output` | `False` |  |
 | `log_file_format` | `LogFormatName.SIMPLE` |  |
+
+## `models.action_history.ActionHistoryConfiguration`
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `summary_max_tlength` | `1000` | Maximum token length for the action history summary. |
 
 ## `speech.eleven_labs.ElevenLabsConfig`
 


### PR DESCRIPTION
## Summary
- regenerate configuration reference from `UserConfigurable` fields
- fail docs CI if `docs/configuration.md` is out of date

## Testing
- `python scripts/generate_user_config_docs.py --output docs/configuration.md`
- `mkdocs build -f docs/mkdocs.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c6bb946884832f90f87ee53e4fab5f