### PR TITLE
Add dynamic architecture expander with self-evolving integration

### DIFF
--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -11,6 +11,7 @@ from .self_evolving_cognition import SelfEvolvingCognition
 from .self_evolving_ai_architecture import SelfEvolvingAIArchitecture
 from .evolution_engine import EvolutionEngine
 from .adapter import EvolutionModule
+from .dynamic_architecture import DynamicArchitectureExpander
 
 try:  # optional dependencies
     from .ppo import PPO, PPOConfig
@@ -63,6 +64,7 @@ __all__ = [
     "SelfEvolvingCognition",
     "SelfEvolvingAIArchitecture",
     "EvolutionEngine",
+    "DynamicArchitectureExpander",
     "PPO",
     "PPOConfig",
     "A3C",

--- a/modules/evolution/dynamic_architecture.py
+++ b/modules/evolution/dynamic_architecture.py
@@ -1,0 +1,129 @@
+"""Runtime architecture expansion utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from .self_evolving_ai_architecture import SelfEvolvingAIArchitecture
+
+
+class DynamicArchitectureExpander:
+    """Dynamically add or remove modules and connections.
+
+    The expander maintains a lightweight directed graph of callable modules. It
+    can restructure the graph at runtime and optionally synchronise changes with
+    :class:`SelfEvolvingAIArchitecture`. When performance metrics or
+    environmental feedback indicate that the current setup is sub-optimal the
+    expander can invoke the self-evolution machinery to mutate the architecture
+    further.
+    """
+
+    def __init__(
+        self,
+        modules: Dict[str, Callable[[float], float]],
+        connections: Optional[Dict[str, List[str]]] = None,
+        evolver: Optional[SelfEvolvingAIArchitecture] = None,
+    ) -> None:
+        self.modules = modules
+        self.connections = connections or {name: [] for name in modules}
+        self.evolver = evolver
+
+    # ------------------------------------------------------------------
+    def add_module(self, name: str, module: Callable[[float], float]) -> None:
+        """Add a new module to the architecture."""
+
+        self.modules[name] = module
+        self.connections.setdefault(name, [])
+
+    # ------------------------------------------------------------------
+    def remove_module(self, name: str) -> None:
+        """Remove ``name`` and any links pointing to it."""
+
+        self.modules.pop(name, None)
+        self.connections.pop(name, None)
+        for dsts in self.connections.values():
+            if name in dsts:
+                dsts.remove(name)
+
+    # ------------------------------------------------------------------
+    def connect(self, src: str, dst: str) -> None:
+        """Create a connection from ``src`` to ``dst``."""
+
+        self.connections.setdefault(src, [])
+        if dst not in self.connections[src]:
+            self.connections[src].append(dst)
+
+    # ------------------------------------------------------------------
+    def disconnect(self, src: str, dst: str) -> None:
+        """Remove the connection from ``src`` to ``dst`` if present."""
+
+        if src in self.connections and dst in self.connections[src]:
+            self.connections[src].remove(dst)
+
+    # ------------------------------------------------------------------
+    def run(self, start: str, value: float) -> float:
+        """Execute the architecture starting from ``start`` on ``value``."""
+
+        visited: Set[str] = set()
+
+        def _run(name: str, val: float) -> float:
+            visited.add(name)
+            out = self.modules[name](val)
+            for nxt in self.connections.get(name, []):
+                if nxt not in visited:
+                    out = _run(nxt, out)
+            return out
+
+        return _run(start, value)
+
+    # ------------------------------------------------------------------
+    def auto_expand(
+        self,
+        performance: float,
+        env_feedback: Optional[
+            Dict[str, Tuple[str, Callable[[float], float], str] | str]
+        ] = None,
+        threshold: float = 0.5,
+    ) -> None:
+        """Restructure the architecture based on feedback.
+
+        Parameters
+        ----------
+        performance:
+            Current performance metric. If below ``threshold`` the underlying
+            self-evolution algorithm is triggered.
+        env_feedback:
+            Optional directives from the environment. Supported keys are::
+
+                "add_module" -> (name, callable, parent)
+                    Adds ``name`` and connects it after ``parent``.
+                "remove_module" -> name
+                    Removes the specified module.
+        threshold:
+            Performance threshold to trigger self-evolution.
+        """
+
+        if env_feedback:
+            if "add_module" in env_feedback:
+                name, module, parent = env_feedback["add_module"]
+                self.add_module(name, module)
+                self.connect(parent, name)
+            if "remove_module" in env_feedback:
+                target = env_feedback["remove_module"]
+                self.remove_module(target)
+
+        if performance < threshold and self.evolver is not None:
+            candidates = self.evolver.generate_architecture_mutations()
+            self.evolver.evolutionary_selection(candidates)
+
+        if self.evolver is not None:
+            self._sync_with_evolver()
+
+    # ------------------------------------------------------------------
+    def _sync_with_evolver(self) -> None:
+        """Update the attached :class:`SelfEvolvingAIArchitecture` with modules."""
+
+        if self.evolver is None:
+            return
+        arch = {name: 1.0 for name in self.modules}
+        self.evolver.update_architecture(arch)

--- a/tests/evolution/test_dynamic_architecture_expander.py
+++ b/tests/evolution/test_dynamic_architecture_expander.py
@@ -1,0 +1,47 @@
+"""Tests for DynamicArchitectureExpander."""
+
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.evolution import (
+    DynamicArchitectureExpander,
+    EvolvingCognitiveArchitecture,
+    EvolutionGeneticAlgorithm,
+    SelfEvolvingAIArchitecture,
+)
+from modules.evolution.evolving_cognitive_architecture import GAConfig
+
+
+def fitness_fn(arch):
+    return float(len(arch))
+
+
+def test_expander_adds_module_and_produces_new_behavior():
+    random.seed(0)
+    ga = EvolutionGeneticAlgorithm(fitness_fn, GAConfig(population_size=5, generations=2))
+    evolver = EvolvingCognitiveArchitecture(fitness_fn, ga)
+    self_arch = SelfEvolvingAIArchitecture({"inc": 1.0}, evolver)
+
+    expander = DynamicArchitectureExpander(
+        modules={"inc": lambda x: x + 1},
+        connections={"inc": []},
+        evolver=self_arch,
+    )
+
+    # Original behaviour: only increment.
+    assert expander.run("inc", 3) == 4
+
+    # Add doubling module via environment feedback and trigger auto expansion.
+    expander.auto_expand(
+        performance=0.1,
+        env_feedback={"add_module": ("dbl", lambda x: x * 2, "inc")},
+    )
+
+    # The architecture is updated in the evolver.
+    assert "dbl" in self_arch.architecture
+
+    # New behaviour should increment then double.
+    assert expander.run("inc", 3) == 8


### PR DESCRIPTION
## Summary
- implement `DynamicArchitectureExpander` to add/remove modules and connections at runtime
- integrate expander with `SelfEvolvingAIArchitecture` for performance and environment driven restructuring
- add tests covering dynamic expansion producing new behavior

## Testing
- `ruff check modules/evolution/dynamic_architecture.py tests/evolution/test_dynamic_architecture_expander.py`
- `pytest tests/evolution -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7229a3c832fb00ca5ee1a92c3d6