### PR TITLE
feat(security): add sandboxed self-modification with rollback

### DIFF
--- a/modules/security/safe_modification.py
+++ b/modules/security/safe_modification.py
@@ -1,0 +1,130 @@
+"""Utilities for safely testing self-modifying behaviour.
+
+This module provides a sandboxed environment that allows code to modify files in
+isolation before committing them back to the original location. Every change is
+tracked in an audit log and can be rolled back if a failure occurs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class SafeModificationSandbox:
+    """Create an isolated copy of a directory to test self-modification.
+
+    The sandbox works by copying the target directory to a temporary location
+    where modifications can be applied. On :meth:`commit` the changes are copied
+    back to the original directory. If an error happens during commit or if the
+    changes are deemed unsafe, :meth:`rollback` restores the previous state.
+    """
+
+    def __init__(self, target_path: Path | str):
+        self.target_path = Path(target_path)
+        self._tmp_root: Optional[Path] = None
+        self._sandbox_path: Optional[Path] = None
+        self.audit_log: List[str] = []
+        self._backups: Dict[Path, Path] = {}
+
+    # ------------------------------------------------------------------
+    # Context manager interface
+    def __enter__(self) -> "SafeModificationSandbox":
+        self._tmp_root = Path(tempfile.mkdtemp(prefix="autogpt_sandbox_"))
+        self._sandbox_path = self._tmp_root / "snapshot"
+        shutil.copytree(self.target_path, self._sandbox_path)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - part of CM protocol
+        # If an exception occurred and commit wasn't successful, rollback.
+        if exc_type:
+            self.rollback()
+        else:
+            self.cleanup()
+
+    # ------------------------------------------------------------------
+    @property
+    def sandbox_path(self) -> Path:
+        if not self._sandbox_path:
+            raise RuntimeError("Sandbox has not been initialized")
+        return self._sandbox_path
+
+    # ------------------------------------------------------------------
+    def apply_change(self, relative_path: str, content: str) -> None:
+        """Apply a modification inside the sandbox.
+
+        Args:
+            relative_path: Path within the sandbox to modify.
+            content: New file contents.
+
+        Raises:
+            ValueError: If the path attempts to escape the sandbox.
+        """
+
+        sandbox = self.sandbox_path
+        dest = (sandbox / relative_path).resolve()
+        # Prevent path traversal attacks
+        if not str(dest).startswith(str(sandbox.resolve())):
+            raise ValueError("Modification escapes sandbox")
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+        self.audit_log.append(relative_path)
+
+    # ------------------------------------------------------------------
+    def commit(self) -> None:
+        """Commit changes back to the target directory.
+
+        If an error occurs while writing the files, the previous state is
+        restored automatically.
+        """
+
+        sandbox = self.sandbox_path
+        try:
+            for rel_path in self.audit_log:
+                src = sandbox / rel_path
+                dest = self.target_path / rel_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                # Save a backup before overwriting so we can roll back later
+                if dest.exists() and dest not in self._backups:
+                    backup = self._tmp_root / "backup" / rel_path
+                    backup.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(dest, backup)
+                    self._backups[dest] = backup
+                shutil.copy2(src, dest)
+        except Exception:
+            # On any failure, revert to backed up state
+            self.rollback()
+            raise
+        else:
+            self.cleanup()
+
+    # ------------------------------------------------------------------
+    def rollback(self) -> None:
+        """Restore original files and discard sandbox changes."""
+
+        # Restore backups
+        for dest, backup in self._backups.items():
+            shutil.copy2(backup, dest)
+
+        # Remove newly created files
+        for rel_path in self.audit_log:
+            dest = self.target_path / rel_path
+            if dest not in self._backups and dest.exists():
+                os.remove(dest)
+
+        self.cleanup()
+
+    # ------------------------------------------------------------------
+    def cleanup(self) -> None:
+        """Delete temporary files and reset internal state."""
+
+        if self._tmp_root and self._tmp_root.exists():
+            shutil.rmtree(self._tmp_root)
+        self._tmp_root = None
+        self._sandbox_path = None
+        self.audit_log.clear()
+        self._backups.clear()

--- a/modules/tests/test_safe_modification.py
+++ b/modules/tests/test_safe_modification.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+
+from modules.security.safe_modification import SafeModificationSandbox
+
+
+def test_rollback_on_commit_failure(tmp_path, monkeypatch):
+    target = tmp_path / "target"
+    target.mkdir()
+    file = target / "data.txt"
+    file.write_text("original")
+
+    sandbox = SafeModificationSandbox(target)
+    with sandbox:
+        sandbox.apply_change("data.txt", "changed")
+
+        # Simulate failure while copying back to target
+        import modules.security.safe_modification as sm
+        original_copy2 = sm.shutil.copy2
+
+        def broken_copy(src, dst, *args, **kwargs):
+            # fail only when writing back to the target file
+            if Path(dst) == file:
+                raise IOError("disk full")
+            return original_copy2(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr(sm.shutil, "copy2", broken_copy)
+
+        with pytest.raises(IOError):
+            sandbox.commit()
+
+    # The original file should remain untouched after rollback
+    assert file.read_text() == "original"
+
+
+def test_prevent_path_traversal(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+
+    with SafeModificationSandbox(target) as sandbox:
+        with pytest.raises(ValueError):
+            sandbox.apply_change("../evil.txt", "bad")
+
+    assert not (target.parent / "evil.txt").exists()


### PR DESCRIPTION
## Summary
- implement `SafeModificationSandbox` for isolated self-modification testing with audit logging and rollback
- guard against path traversal attacks when applying changes
- add security tests covering rollback on failure and path traversal attempts

## Testing
- `pytest modules/tests/test_safe_modification.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c74e3c50832f8175c0470149e26e