### PR TITLE
feat: add adaptive fitness generator

### DIFF
--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -11,6 +11,7 @@ from .self_evolving_cognition import SelfEvolvingCognition
 from .self_evolving_ai_architecture import SelfEvolvingAIArchitecture
 from .evolution_engine import EvolutionEngine
 from .adapter import EvolutionModule
+from .fitness_adaptor import AdaptiveFitnessGenerator
 
 try:  # optional dependencies
     from .ppo import PPO, PPOConfig
@@ -63,6 +64,7 @@ __all__ = [
     "SelfEvolvingCognition",
     "SelfEvolvingAIArchitecture",
     "EvolutionEngine",
+    "AdaptiveFitnessGenerator",
     "PPO",
     "PPOConfig",
     "A3C",

--- a/modules/evolution/eval_adaptive_fitness.py
+++ b/modules/evolution/eval_adaptive_fitness.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Simple evaluation comparing manual and adaptive fitness functions."""
+
+import random
+from typing import Dict, Tuple
+
+from modules.evolution.generic_ga import GAConfig, GeneticAlgorithm
+from modules.evolution.fitness_adaptor import AdaptiveFitnessGenerator
+
+
+# Objective functions ---------------------------------------------------------
+def performance(individual: Tuple[float, float]) -> float:
+    """Quadratic bowl with optimum at ``x=1``."""
+
+    x, _ = individual
+    return 1 - (x - 1) ** 2
+
+
+def low_resource(individual: Tuple[float, float]) -> float:
+    """Preference for small absolute ``y`` values."""
+
+    _, y = individual
+    return -abs(y)
+
+
+def ethics(individual: Tuple[float, float]) -> float:
+    """Penalise when ``x + y`` exceeds 1."""
+
+    x, y = individual
+    return -max(0.0, x + y - 1)
+
+
+# Evaluation helpers ---------------------------------------------------------
+def run_manual() -> Tuple[Tuple[float, float], float]:
+    metrics = [
+        (performance, 0.5),
+        (low_resource, 0.3),
+        (ethics, 0.2),
+    ]
+    ga = GeneticAlgorithm(
+        metrics=metrics,
+        bounds=[(-2.0, 2.0), (-2.0, 2.0)],
+        config=GAConfig(population_size=30),
+    )
+    return ga.run(30)
+
+
+def run_adaptive() -> Tuple[Tuple[float, float], float, Dict[str, float]]:
+    objectives = {
+        "performance": performance,
+        "resource": low_resource,
+        "ethics": ethics,
+    }
+    generator = AdaptiveFitnessGenerator(objectives)
+    ga = GeneticAlgorithm(
+        fitness_fn=generator.evaluate,
+        bounds=[(-2.0, 2.0), (-2.0, 2.0)],
+        config=GAConfig(population_size=30),
+    )
+
+    population = [ga._random_individual() for _ in range(ga.config.population_size)]
+    fitnesses = ga._evaluate(population)
+    ga._update_best(population, fitnesses)
+
+    for generation in range(30):
+        if generation > 15:
+            # After half the run, emphasise ethics via environment signal
+            generator.update_environment({"ethics": 1.0})
+        new_population = []
+        while len(new_population) < ga.config.population_size:
+            p1 = ga._tournament_selection(population, fitnesses)
+            p2 = ga._tournament_selection(population, fitnesses)
+            c1, c2 = ga._crossover(p1, p2)
+            ga._mutate(c1)
+            ga._mutate(c2)
+            new_population.extend([c1, c2])
+        population = new_population[: ga.config.population_size]
+        fitnesses = ga._evaluate(population)
+        ga._update_best(population, fitnesses)
+
+    assert ga.best_individual is not None
+    assert ga.best_fitness is not None
+    return ga.best_individual, ga.best_fitness, generator.weights
+
+
+def main() -> None:
+    random.seed(0)
+    manual_best, manual_fit = run_manual()
+    adaptive_best, adaptive_fit, weights = run_adaptive()
+    print("Manual best fitness:", round(manual_fit, 4), "individual:", manual_best)
+    print(
+        "Adaptive best fitness:",
+        round(adaptive_fit, 4),
+        "individual:",
+        adaptive_best,
+        "weights:",
+        {k: round(v, 3) for k, v in weights.items()},
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience script
+    main()

--- a/modules/evolution/fitness_adaptor.py
+++ b/modules/evolution/fitness_adaptor.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Adaptive fitness generator for multi-objective evolutionary runs.
+
+The :class:`AdaptiveFitnessGenerator` dynamically adjusts weights assigned to
+multiple objective functions based on historical performance and optional
+external environment signals.  The generator can be used as a drop-in fitness
+function for the :class:`~modules.evolution.generic_ga.GeneticAlgorithm` by
+passing :meth:`evaluate` as the ``fitness_fn`` argument.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Sequence
+
+
+@dataclass
+class AdaptiveFitnessGenerator:
+    """Compose a fitness function with dynamically learned weights.
+
+    Parameters
+    ----------
+    objectives
+        Mapping from objective name to a callable returning a fitness score for
+        a given individual.  Higher scores are assumed to be better.
+    initial_weights
+        Optional mapping of initial weights for each objective.  When omitted,
+        all objectives are weighted uniformly.
+    history_length
+        Number of recent evaluations considered when estimating performance
+        trends.
+    learning_rate
+        Step size used when adjusting weights.
+    """
+
+    objectives: Dict[str, Callable[[Sequence[float]], float]]
+    initial_weights: Dict[str, float] | None = None
+    history_length: int = 50
+    learning_rate: float = 0.1
+    _history: List[Dict[str, float]] = field(default_factory=list, init=False)
+    _env_signal: Dict[str, float] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        if self.initial_weights is None:
+            weight = 1.0 / len(self.objectives)
+            self.weights: Dict[str, float] = {name: weight for name in self.objectives}
+        else:
+            self.weights = dict(self.initial_weights)
+            self._normalise_weights()
+
+    # ------------------------------------------------------------------
+    # Public API
+    def update_environment(self, signals: Dict[str, float]) -> None:
+        """Update external environment signals.
+
+        Signals are expected to be in the range ``[-1, 1]`` where positive
+        values increase the importance of the corresponding objective and
+        negative values decrease it.
+        """
+
+        self._env_signal.update(signals)
+
+    def evaluate(self, individual: Sequence[float]) -> float:
+        """Evaluate an individual and update objective weights."""
+
+        scores = {name: fn(individual) for name, fn in self.objectives.items()}
+        self._history.append(scores)
+        self._adjust_weights(scores)
+        return sum(self.weights[name] * score for name, score in scores.items())
+
+    # ------------------------------------------------------------------
+    # Weight adaptation utilities
+    def _adjust_weights(self, scores: Dict[str, float]) -> None:
+        """Adjust weights based on score trends and environment signals."""
+
+        window = self._history[-self.history_length :]
+        if len(window) > 1:
+            avgs = {
+                name: sum(h[name] for h in window) / len(window)
+                for name in scores
+            }
+            for name, score in scores.items():
+                trend = score - avgs[name]
+                # When an objective's performance drops below its moving
+                # average, increase its weight to emphasise improvement.  Clamp
+                # to keep weights non-negative.
+                self.weights[name] = max(
+                    0.0, self.weights[name] - self.learning_rate * trend
+                )
+
+        for name, signal in self._env_signal.items():
+            if name in self.weights:
+                self.weights[name] *= 1 + self.learning_rate * signal
+
+        self._normalise_weights()
+
+    def _normalise_weights(self) -> None:
+        total = sum(self.weights.values())
+        if total <= 0:
+            # Avoid division by zero and keep equal weights as fallback
+            weight = 1.0 / len(self.weights)
+            for name in self.weights:
+                self.weights[name] = weight
+            return
+        for name in self.weights:
+            self.weights[name] /= total


### PR DESCRIPTION
## Summary
- implement `AdaptiveFitnessGenerator` for dynamic multi-objective weighting
- expose generator in evolution package API
- add evaluation script comparing manual and adaptive fitness strategies

## Testing
- `python -m modules.evolution.eval_adaptive_fitness`
- `PYTHONPATH=modules pytest modules/tests/test_generic_ga.py modules/tests/test_generic_ga_multi_metric.py modules/tests/evolution/test_evolution_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c72e8034832fb6e96855b46a8a23