### PR TITLE
feat: add exploration strategies and experiment for evolution

### DIFF
--- a/modules/evolution/__init__.py
+++ b/modules/evolution/__init__.py
@@ -12,6 +12,11 @@ from .self_evolving_ai_architecture import SelfEvolvingAIArchitecture
 from .evolution_engine import EvolutionEngine
 from .adapter import EvolutionModule
 from .dynamic_architecture import DynamicArchitectureExpander
+from .strategy import (
+    ExplorationStrategy,
+    SimulatedAnnealingStrategy,
+    InnovationProtectionStrategy,
+)
 
 try:  # optional dependencies
     from .ppo import PPO, PPOConfig
@@ -65,6 +70,9 @@ __all__ = [
     "SelfEvolvingAIArchitecture",
     "EvolutionEngine",
     "DynamicArchitectureExpander",
+    "ExplorationStrategy",
+    "SimulatedAnnealingStrategy",
+    "InnovationProtectionStrategy",
     "PPO",
     "PPOConfig",
     "A3C",

--- a/modules/evolution/strategy.py
+++ b/modules/evolution/strategy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Exploration strategies for evolutionary algorithms.
+
+This module provides simple operators that can be plugged into the
+:class:`~modules.evolution.generic_ga.GeneticAlgorithm` to encourage search
+beyond local optima.  Two strategies are implemented:
+
+* :class:`SimulatedAnnealingStrategy` - occasionally accepts worse individuals
+  with a probability governed by an annealing temperature.
+* :class:`InnovationProtectionStrategy` - adds random noise to individuals that
+  have been seen before to maintain population diversity.
+"""
+
+from dataclasses import dataclass, field
+import math
+import random
+from typing import List, Tuple
+
+
+class ExplorationStrategy:
+    """Interface for exploration strategies."""
+
+    def apply(self, population: List[List[float]], fitnesses: List[float], generation: int) -> None:
+        """Modify ``population`` or ``fitnesses`` in-place.
+
+        Parameters
+        ----------
+        population: List[List[float]]
+            Current population of individuals.
+        fitnesses: List[float]
+            Fitness for each individual.  The list is mutated when fitnesses are
+            adjusted.
+        generation: int
+            Index of the current generation.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class SimulatedAnnealingStrategy(ExplorationStrategy):
+    """Accept worse individuals with a probability that decreases over time."""
+
+    initial_temp: float = 1.0
+    cooling_rate: float = 0.95
+
+    def apply(self, population: List[List[float]], fitnesses: List[float], generation: int) -> None:
+        temp = self.initial_temp * (self.cooling_rate ** generation)
+        if temp <= 0:
+            return
+        best_idx = max(range(len(population)), key=lambda i: fitnesses[i])
+        best_fit = fitnesses[best_idx]
+        for i in range(len(population)):
+            if fitnesses[i] < best_fit:
+                prob = math.exp((fitnesses[i] - best_fit) / max(temp, 1e-12))
+                if random.random() < prob:
+                    population[best_idx], population[i] = population[i], population[best_idx]
+                    fitnesses[best_idx], fitnesses[i] = fitnesses[i], fitnesses[best_idx]
+                    best_idx = i
+                    best_fit = fitnesses[i]
+
+
+@dataclass
+class InnovationProtectionStrategy(ExplorationStrategy):
+    """Perturb duplicate individuals to protect novel solutions."""
+
+    noise_scale: float = 0.1
+    archive: set[Tuple[float, ...]] = field(default_factory=set)
+
+    def apply(self, population: List[List[float]], fitnesses: List[float], generation: int) -> None:
+        for ind in population:
+            key = tuple(ind)
+            if key in self.archive:
+                for j in range(len(ind)):
+                    ind[j] += random.uniform(-self.noise_scale, self.noise_scale)
+            self.archive.add(tuple(ind))

--- a/scripts/evolution_experiment.py
+++ b/scripts/evolution_experiment.py
@@ -1,0 +1,56 @@
+"""Simple experiment to measure the benefit of exploration strategies.
+
+The script runs the :class:`modules.evolution.generic_ga.GeneticAlgorithm` on a
+one-dimensional multimodal function.  It compares success rates and average
+performance with and without the :class:`~modules.evolution.strategy.SimulatedAnnealingStrategy`.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from statistics import mean
+from typing import Tuple
+
+# Ensure repository root on path for direct execution
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modules.evolution.generic_ga import GeneticAlgorithm
+from modules.evolution.strategy import SimulatedAnnealingStrategy
+
+
+# Target function with many local optima
+
+def objective(ind: Tuple[float, ...]) -> float:
+    x = ind[0]
+    return math.sin(5 * x) * (1 - math.tanh(x * x))
+
+
+BOUNDS = [(-2.0, 2.0)]
+GENERATIONS = 40
+TRIALS = 20
+SUCCESS_THRESHOLD = 0.9
+
+
+def run_trial(use_strategy: bool) -> float:
+    strategy = SimulatedAnnealingStrategy() if use_strategy else None
+    ga = GeneticAlgorithm(objective, bounds=BOUNDS, strategy=strategy)
+    _, best = ga.run(GENERATIONS)
+    return best
+
+
+def run_experiment() -> None:
+    for use_strategy in (False, True):
+        results = [run_trial(use_strategy) for _ in range(TRIALS)]
+        success_rate = sum(r > SUCCESS_THRESHOLD for r in results) / TRIALS
+        avg_score = mean(results)
+        label = "with" if use_strategy else "without"
+        print(
+            f"Simulated annealing {label} strategy: "
+            f"success rate={success_rate:.2f}, avg best={avg_score:.3f}"
+        )
+
+
+if __name__ == "__main__":
+    run_experiment()


### PR DESCRIPTION
## Summary
- add simulated annealing and innovation protection strategies
- enhance generic GA with diversity metrics and optional exploration operators
- include experiment script recording success rate vs simulated annealing

## Testing
- `PYTHONPATH=modules pytest modules/tests/test_generic_ga.py -q`
- `PYTHONPATH=modules pytest modules/tests/test_generic_ga_multi_metric.py -q`
- `python scripts/evolution_experiment.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6c9f74c2c832fad12c1af95fc712b