### PR TITLE
docs: clarify CLI entry point and run wrapper

### DIFF
--- a/CLI-USAGE.md
+++ b/CLI-USAGE.md
@@ -4,10 +4,12 @@
 
 ### 1. CLI 入口
 
-直接运行 `./run` 不带任何参数会显示帮助信息，其中列出了可用的命令和选项。此外，你可以在任何命令后添加 `--help` 以查看该命令的专属帮助。
+直接运行 `python scripts/cli.py`（或在仓库根目录执行 `./scripts/run`）不带任何参数会显示帮助信息，其中列出了可用的命令和选项。此外，你可以在任何命令后添加 `--help` 以查看该命令的专属帮助。
 
 ```sh
-./run
+python scripts/cli.py
+# 或
+./scripts/run
 ```
 
 **输出**：
@@ -28,7 +30,7 @@ Commands:
 如果你需要任何命令的帮助，只需在命令末尾添加 `--help`，例如：
 
 ```sh
-./run COMMAND --help
+python scripts/cli.py COMMAND --help
 ```
 
 这会显示与该命令相关的详细帮助信息，包括可用的其他选项和参数。
@@ -36,7 +38,9 @@ Commands:
 ### 2. Setup 命令
 
 ```sh
-./run setup
+python scripts/cli.py setup
+# 或
+./scripts/run setup
 ```
 
 **输出**：
@@ -53,7 +57,7 @@ Installation has been completed.
 **a. 列出所有代理**
 
 ```sh
-./run agent list
+python scripts/cli.py agent list
 ```
 
 **输出**：
@@ -69,7 +73,7 @@ Available agents: 🤖
 **b. 创建新代理**
 
 ```sh
-./run agent create my_agent
+python scripts/cli.py agent create my_agent
 ```
 
 **输出**：
@@ -83,7 +87,7 @@ Available agents: 🤖
 **c. 启动代理**
 
 ```sh
-./run agent start my_agent
+python scripts/cli.py agent start my_agent
 ```
 
 **输出**：
@@ -99,7 +103,7 @@ Available agents: 🤖
 **d. 停止代理**
 
 ```sh
-./run agent stop
+python scripts/cli.py agent stop
 ```
 
 **输出**：
@@ -115,7 +119,7 @@ Agent stopped
 **a. 列出 Benchmark 类别**
 
 ```sh
-./run benchmark categories list
+python scripts/cli.py benchmark categories list
 ```
 
 **输出**：
@@ -133,7 +137,7 @@ Available categories: 📚
 **b. 列出 Benchmark 测试**
 
 ```sh
-./run benchmark tests list
+python scripts/cli.py benchmark tests list
 ```
 
 **输出**：
@@ -151,7 +155,7 @@ Available tests: 📚
 **c. 显示 Benchmark 测试详情**
 
 ```sh
-./run benchmark tests details TestWriteFile
+python scripts/cli.py benchmark tests details TestWriteFile
 ```
 
 **输出**：
@@ -170,7 +174,7 @@ TestWriteFile
 **d. 启动代理的 Benchmark**
 
 ```sh
-./run benchmark start my_agent
+python scripts/cli.py benchmark start my_agent
 ```
 
 **输出**：
@@ -187,7 +191,7 @@ TestWriteFile
 **a. 进入 Arena**
 
 ```sh
-./run arena enter my_agent
+python scripts/cli.py arena enter my_agent
 ```
 
 **输出**：
@@ -212,7 +216,7 @@ speech_to_text "audio.mp3"     # 将音频文件转录为文本
 **b. 更新 Arena 提交**
 
 ```sh
-./run arena update my_agent <commit_hash> --branch main
+python scripts/cli.py arena update my_agent <commit_hash> --branch main
 ```
 
 **输出**：

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -39,12 +39,12 @@
    - 在终端中运行 `cd AutoGPT`（或你克隆的仓库名称）以进入项目根目录。
 
 4. **设置项目**
-    接下来我们需要安装所需依赖。我们提供了一个工具帮助你完成仓库中的所有任务。在终端输入 `./run` 即可访问。
+    接下来我们需要安装所需依赖。我们提供了一个工具帮助你完成仓库中的所有任务。在终端输入 `python scripts/cli.py` 或 `./scripts/run` 即可访问。
 
-    首个需要使用的命令是 `./run setup`，它会引导你完成系统设置。
+    首个需要使用的命令是 `python scripts/cli.py setup`（或 `./scripts/run setup`），它会引导你完成系统设置。
     最初你会收到安装 flutter、chrome 以及设置 GitHub 访问令牌的指示，如下图所示：
 
-    > 注意：对于高级用户，GitHub 访问令牌仅在运行 `./run arena enter` 命令时需要，以便系统能自动创建 PR
+    > 注意：对于高级用户，GitHub 访问令牌仅在运行 `python scripts/cli.py arena enter`（或 `./scripts/run arena enter`）命令时需要，以便系统能自动创建 PR
 
     ![Setup the Project](docs/content/imgs/quickstart/005_setup.png)
 
@@ -66,17 +66,17 @@ wsl --install
 更多详细信息和额外步骤请参阅[微软的 WSL 环境设置文档](https://learn.microsoft.com/en-us/windows/wsl/setup/environment)。
 
 #### 解决 FileNotFoundError 或 “No such file or directory” 错误
-运行 `./run setup` 时，如果遇到 `No such file or directory` 或 `FileNotFoundError` 等错误，可能是因为 Windows 风格的行结尾（CRLF）与 Unix/Linux 风格的行结尾（LF）不兼容。
+运行 `python scripts/cli.py setup`（或 `./scripts/run setup`）时，如果遇到 `No such file or directory` 或 `FileNotFoundError` 等错误，可能是因为 Windows 风格的行结尾（CRLF）与 Unix/Linux 风格的行结尾（LF）不兼容。
 
 要解决此问题，可以使用 `dos2unix` 工具将脚本中的行结尾从 CRLF 转换为 LF。安装并运行 `dos2unix` 的方法如下：
 
 ```shell
 sudo apt update
 sudo apt install dos2unix
-dos2unix ./run
+dos2unix scripts/run
 ```
 
-执行上述命令后，运行 `./run setup` 应该就能成功。
+执行上述命令后，运行 `python scripts/cli.py setup` 或 `./scripts/run setup` 应该就能成功。
 
 #### 将项目文件存储在 WSL 文件系统内
 如果问题仍然存在，请考虑将项目文件存储在 WSL 文件系统中，而非 Windows 文件系统。这能避免路径转换和权限相关的问题，并提供更一致的开发环境。
@@ -89,7 +89,7 @@ dos2unix ./run
 ## 创建你的代理
 
 完成设置后，下一步是创建代理模板。
-执行命令 `./run agent create YOUR_AGENT_NAME`，其中 `YOUR_AGENT_NAME` 替换为你选择的名称。
+执行命令 `python scripts/cli.py agent create YOUR_AGENT_NAME`（或 `./scripts/run agent create YOUR_AGENT_NAME`），其中 `YOUR_AGENT_NAME` 替换为你选择的名称。
 
 命名代理的提示：
 * 给它一个独特的名字，或以你的名字命名
@@ -101,7 +101,7 @@ dos2unix ./run
 
 ### 可选：进入 Arena
 
-进入 Arena 是可选步骤，适用于希望参与代理排行榜的用户。如果你决定参与，可运行 `./run arena enter YOUR_AGENT_NAME` 进入 Arena。此步骤对代理的开发或测试并非必需。
+进入 Arena 是可选步骤，适用于希望参与代理排行榜的用户。如果你决定参与，可运行 `python scripts/cli.py arena enter YOUR_AGENT_NAME`（或 `./scripts/run arena enter YOUR_AGENT_NAME`）进入 Arena。此步骤对代理的开发或测试并非必需。
 
 名称如 `agent`、`ExampleAgent`、`test_agent` 或 `MyExampleGPT` 的条目不会被合并。我们也不接受使用其他项目名称的模仿条目，如 `AutoGPT` 或 `evo.ninja`。
 
@@ -124,7 +124,7 @@ dos2unix ./run
 
 ## 运行你的代理
 
-使用 `./run agent start YOUR_AGENT_NAME` 可以启动代理。
+使用 `python scripts/cli.py agent start YOUR_AGENT_NAME`（或 `./scripts/run agent start YOUR_AGENT_NAME`）可以启动代理。
 
 它会在 `http://localhost:8000/` 上启动代理。
 
@@ -140,14 +140,14 @@ dos2unix ./run
 
 使用完代理或需要重启时，按 Ctrl-C 结束会话，然后重新运行启动命令。
 
-如果遇到问题并想确保代理已停止，可以使用 `./run agent stop`，该命令会终止占用 8000 端口的进程，即该代理。
+如果遇到问题并想确保代理已停止，可以使用 `python scripts/cli.py agent stop`（或 `./scripts/run agent stop`），该命令会终止占用 8000 端口的进程，即该代理。
 
 ## 为代理运行基准测试
 
 基准测试系统同样可通过 CLI 访问：
 
 ```bash
-agpt % ./run benchmark
+agpt % python scripts/cli.py benchmark
 Usage: cli.py benchmark [OPTIONS] COMMAND [ARGS]...
 
   Commands to start the benchmark and list tests and categories
@@ -159,7 +159,7 @@ Commands:
   categories  Benchmark categories group command
   start       Starts the benchmark command
   tests       Benchmark tests group command
-agpt % ./run benchmark categories
+agpt % python scripts/cli.py benchmark categories
 Usage: cli.py benchmark categories [OPTIONS] COMMAND [ARGS]...
 
   Benchmark categories group command
@@ -169,7 +169,7 @@ Options:
 
 Commands:
   list  List benchmark categories command
-agpt % ./run benchmark tests
+agpt % python scripts/cli.py benchmark tests
 Usage: cli.py benchmark tests [OPTIONS] COMMAND [ARGS]...
 
   Benchmark tests group command
@@ -184,9 +184,9 @@ Commands:
 
 基准测试被划分为不同技能类别，可用于测试你的代理。使用以下命令查看可用类别：
 ```bash
-./run benchmark categories list
+python scripts/cli.py benchmark categories list
 # 查看可用测试
-./run benchmark tests list
+python scripts/cli.py benchmark tests list
 ```
 
 ![Login](docs/content/imgs/quickstart/012_tests.png)
@@ -194,7 +194,7 @@ Commands:
 最后，可以通过以下命令运行基准测试：
 
 ```bash
-./run benchmark start YOUR_AGENT_NAME
+python scripts/cli.py benchmark start YOUR_AGENT_NAME
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ autogpt-v0.5.1/
 ### 安装步骤
 1. 克隆项目并进入目录
 2. 复制 `.env.example` 为 `.env` 并配置API密钥
-3. 运行 `./run setup` 安装依赖
-4. 使用 `./run agent start <agent-name>` 启动代理
+3. 运行 `python scripts/cli.py setup` 或 `./scripts/run setup` 安装依赖
+4. 使用 `python scripts/cli.py agent start <agent-name>` 或 `./scripts/run agent start <agent-name>` 启动代理
 
 ### 模块级依赖
 
@@ -67,9 +67,14 @@ pip install -r modules/requirements.txt
 统一的CLI工具，支持代理管理、基准测试等功能：
 
 ```bash
-./run agent start <agent-name>    # 启动代理
-./run benchmark start             # 运行基准测试  
-./run setup                       # 安装依赖
+python scripts/cli.py agent start <agent-name>    # 启动代理
+python scripts/cli.py benchmark start             # 运行基准测试
+python scripts/cli.py setup                       # 安装依赖
+
+# 或使用封装脚本
+./scripts/run agent start <agent-name>
+./scripts/run benchmark start
+./scripts/run setup
 ```
 
 ### 🎤 音频能力

--- a/scripts/run
+++ b/scripts/run
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-python3 cli.py "$@"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/cli.py" "$@"


### PR DESCRIPTION
## Summary
- document `python scripts/cli.py` and `./scripts/run` as the correct CLI entry point in README, CLI-USAGE, and QUICKSTART
- update `scripts/run` to resolve `cli.py` relative to its own directory

## Testing
- `./scripts/run --help` *(fails: ModuleNotFoundError: No module named 'autogpts')*
- `./scripts/lint.sh` *(fails: Found 535 errors)*
- `./scripts/typecheck.sh` *(fails: algorithms/data_structures/advanced/binary_tree.py:54: error: Invalid syntax)*
- `./scripts/run_tests.sh`
- `python scripts/benchmark_sorting.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca0a33c0832fa319bc812172a497