### PR TITLE
Add CLI and performance monitor tests

### DIFF
--- a/.github/workflows/autogpt-ci.yml
+++ b/.github/workflows/autogpt-ci.yml
@@ -1,18 +1,20 @@
 name: AutoGPT Python CI
 
 on:
-  push:
-    branches: [ master, development, ci-test* ]
-    paths:
-      - '.github/workflows/autogpt-ci.yml'
-      - 'autogpts/autogpt/**'
-      - '!autogpts/autogpt/tests/vcr_cassettes'
-  pull_request:
-    branches: [ master, development, release-* ]
-    paths:
-      - '.github/workflows/autogpt-ci.yml'
-      - 'autogpts/autogpt/**'
-      - '!autogpts/autogpt/tests/vcr_cassettes'
+    push:
+      branches: [ master, development, ci-test* ]
+      paths:
+        - '.github/workflows/autogpt-ci.yml'
+        - 'autogpts/autogpt/**'
+        - '!autogpts/autogpt/tests/vcr_cassettes'
+        - 'tests/**'
+    pull_request:
+      branches: [ master, development, release-* ]
+      paths:
+        - '.github/workflows/autogpt-ci.yml'
+        - 'autogpts/autogpt/**'
+        - '!autogpts/autogpt/tests/vcr_cassettes'
+        - 'tests/**'
 
 concurrency:
   group: ${{ format('autogpt-ci-{0}', github.head_ref && format('{0}-{1}', github.event_name, github.event.pull_request.number) || github.sha) }}

--- a/.github/workflows/autogpt-docker-ci.yml
+++ b/.github/workflows/autogpt-docker-ci.yml
@@ -7,12 +7,14 @@ on:
       - '.github/workflows/autogpt-docker-ci.yml'
       - 'autogpts/autogpt/**'
       - '!autogpts/autogpt/tests/vcr_cassettes'
+      - 'tests/**'
   pull_request:
     branches: [ master, development, release-* ]
     paths:
       - '.github/workflows/autogpt-docker-ci.yml'
       - 'autogpts/autogpt/**'
       - '!autogpts/autogpt/tests/vcr_cassettes'
+      - 'tests/**'
 
 concurrency:
   group: ${{ format('autogpt-docker-ci-{0}', github.head_ref && format('pr-{0}', github.event.pull_request.number) || github.sha) }}

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+"""Backend package."""
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,6 @@ ignore_missing_imports = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 warn_return_any = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests/unit", "tests/integration"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Helper scripts package."""
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Test configuration and shared fixtures."""
+
+import sys
+import types
+
+# Some modules imported by the codebase are optional during tests.
+# Provide lightweight stubs so imports succeed without installing heavy deps.
+sys.modules.setdefault(
+    "auto_gpt_plugin_template", types.ModuleType("auto_gpt_plugin_template")
+)
+sys.modules["auto_gpt_plugin_template"].AutoGPTPluginTemplate = type(
+    "AutoGPTPluginTemplate", (), {}
+)
+
+openai_mod = types.ModuleType("openai")
+exceptions_mod = types.ModuleType("openai._exceptions")
+class APIStatusError(Exception):
+    pass
+class RateLimitError(Exception):
+    pass
+exceptions_mod.APIStatusError = APIStatusError
+exceptions_mod.RateLimitError = RateLimitError
+openai_mod._exceptions = exceptions_mod
+sys.modules.setdefault("openai", openai_mod)
+sys.modules.setdefault("openai._exceptions", exceptions_mod)
+types_mod = types.ModuleType("openai.types")
+openai_mod.types = types_mod
+sys.modules.setdefault("openai.types", types_mod)
+types_mod.CreateEmbeddingResponse = type("CreateEmbeddingResponse", (), {})
+chat_mod = types.ModuleType("openai.types.chat")
+chat_mod.__getattr__ = lambda name: type(name, (), {})
+types_mod.chat = chat_mod
+sys.modules.setdefault("openai.types.chat", chat_mod)
+

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,121 @@
+import io
+import os
+import sys
+import types
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+# Stub external modules required at import time
+sys.modules.setdefault("github", types.ModuleType("github"))
+
+# Stub AutoGPT package used by the CLI
+sys.modules.setdefault("autogpts", types.ModuleType("autogpts"))
+sys.modules.setdefault("autogpts.autogpt", types.ModuleType("autogpts.autogpt"))
+sys.modules.setdefault(
+    "autogpts.autogpt.autogpt", types.ModuleType("autogpts.autogpt.autogpt")
+)
+sys.modules.setdefault(
+    "autogpts.autogpt.autogpt.core",
+    types.ModuleType("autogpts.autogpt.autogpt.core"),
+)
+errors_mod = types.ModuleType("autogpts.autogpt.autogpt.core.errors")
+class AutoGPTError(Exception):
+    pass
+errors_mod.AutoGPTError = AutoGPTError
+logging_mod = types.ModuleType("autogpts.autogpt.autogpt.core.logging")
+logging_mod.handle_exception = lambda e: None
+logging_mod.setup_exception_hooks = lambda: None
+sys.modules["autogpts.autogpt.autogpt.core.errors"] = errors_mod
+sys.modules["autogpts.autogpt.autogpt.core.logging"] = logging_mod
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.cli import cli  # noqa: E402  (import after stubs)
+
+
+def test_setup_command(monkeypatch):
+    runner = CliRunner()
+
+    def fake_exists(path):
+        if path.endswith("setup.sh"):
+            return True
+        # Simulate missing GitHub token so instructions are printed
+        if path == ".github_access_token":
+            return False
+        return False
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+
+    # Avoid creating files
+    monkeypatch.setattr("builtins.open", lambda *a, **k: io.StringIO())
+
+    # Stub subprocess operations
+    monkeypatch.setattr(subprocess, "check_call", lambda *a, **k: 0)
+
+    def fake_check_output(cmd, **kwargs):
+        if cmd[:3] == ["git", "config", "user.name"]:
+            return b"Tester"
+        if cmd[:3] == ["git", "config", "user.email"]:
+            return b"tester@example.com"
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    result = runner.invoke(cli, ["setup"])
+    assert result.exit_code == 0
+    assert "Setup initiated" in result.output
+
+
+def test_agent_start(monkeypatch):
+    runner = CliRunner()
+
+    def fake_exists(path):
+        if "autogpts/test" in path:
+            return True
+        return False
+
+    def fake_isfile(path):
+        if path.endswith("run") or path.endswith("run_benchmark"):
+            return True
+        return False
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+    monkeypatch.setattr(os.path, "isfile", fake_isfile)
+    monkeypatch.setattr(os, "chdir", lambda p: None)
+
+    class DummyProc:
+        def wait(self):
+            pass
+
+    popen_calls = []
+
+    def fake_popen(cmd, cwd=None):
+        popen_calls.append((tuple(cmd), cwd))
+        return DummyProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    from scripts import cli as cli_module
+    monkeypatch.setattr(cli_module, "wait_until_conn_ready", lambda *a, **k: None)
+    monkeypatch.setattr(cli_module, "sys", sys, raising=False)
+
+    result = runner.invoke(cli, ["agent", "start", "test", "--no-setup"])
+    assert result.exit_code == 0
+    assert any("./run" in call[0] for call in popen_calls)
+
+
+def test_agent_stop_no_process(monkeypatch):
+    runner = CliRunner()
+
+    def fake_check_output(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    result = runner.invoke(cli, ["agent", "stop"])
+    assert result.exit_code == 0
+    assert "No process is running on port 8000" in result.output
+    assert "No process is running on port 8080" in result.output

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -1,0 +1,85 @@
+import sys
+import types
+
+# Stub modules required by performance_monitor
+events_mod = types.ModuleType("events")
+class EventBus: ...
+events_mod.EventBus = EventBus
+sys.modules.setdefault("events", events_mod)
+
+common_mod = types.ModuleType("common")
+class AutoGPTException(Exception):
+    pass
+def log_and_format_exception(e):
+    pass
+common_mod.AutoGPTException = AutoGPTException
+common_mod.log_and_format_exception = log_and_format_exception
+sys.modules.setdefault("common", common_mod)
+
+sk_module = types.ModuleType("sklearn")
+ensemble_mod = types.ModuleType("sklearn.ensemble")
+class IsolationForest:
+    def __init__(self, *a, **k):
+        pass
+    def fit(self, data):
+        return self
+    def predict(self, X):
+        return [1 for _ in X]
+sk_module.ensemble = ensemble_mod
+ensemble_mod.IsolationForest = IsolationForest
+sys.modules.setdefault("sklearn", sk_module)
+sys.modules.setdefault("sklearn.ensemble", ensemble_mod)
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+
+from pathlib import Path
+import importlib.util
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+
+monitoring_pkg = types.ModuleType("monitoring")
+sys.modules.setdefault("monitoring", monitoring_pkg)
+
+spec_storage = importlib.util.spec_from_file_location(
+    "monitoring.storage", ROOT / "backend/monitoring/storage.py"
+)
+storage_module = importlib.util.module_from_spec(spec_storage)
+sys.modules["monitoring.storage"] = storage_module
+spec_storage.loader.exec_module(storage_module)
+TimeSeriesStorage = storage_module.TimeSeriesStorage
+
+spec_pm = importlib.util.spec_from_file_location(
+    "monitoring.performance_monitor", ROOT / "backend/monitoring/performance_monitor.py"
+)
+pm_module = importlib.util.module_from_spec(spec_pm)
+sys.modules["monitoring.performance_monitor"] = pm_module
+spec_pm.loader.exec_module(pm_module)
+PerformanceMonitor = pm_module.PerformanceMonitor
+SpikeRateMonitor = pm_module.SpikeRateMonitor
+
+
+def test_spike_rate_monitor_average(tmp_path):
+    storage = TimeSeriesStorage(":memory:")
+    monitor = SpikeRateMonitor(storage)
+    monitor.log("a1", 2.0)
+    monitor.log("a1", 4.0)
+    assert monitor.average("a1") == 3.0
+
+
+def test_performance_monitor_alert_on_degradation(tmp_path):
+    storage = TimeSeriesStorage(":memory:")
+    alerts = []
+
+    def handler(subject, message):
+        alerts.append((subject, message))
+
+    monitor = PerformanceMonitor(
+        storage,
+        training_accuracy=0.9,
+        degradation_threshold=0.1,
+        alert_handlers=[handler],
+    )
+    monitor.log_prediction(1, 1)
+    monitor.log_prediction(1, 0)
+    monitor.check_performance()
+    assert any("Model performance degraded" in s for s, _ in alerts)


### PR DESCRIPTION
## Summary
- add integration tests for `scripts/cli.py` setup/start/stop commands
- cover monitoring utilities with new unit tests
- configure pytest and CI to discover `tests/unit` and `tests/integration`

## Testing
- `pytest tests/integration/test_cli.py tests/unit/test_performance_monitor.py`
- `pytest tests/integration/test_cli.py tests/unit/test_performance_monitor.py tests/unit/test_on_response_updates_state.py` *(fails: No module named 'openai._base_client')*

------
https://chatgpt.com/codex/tasks/task_e_68c6d1719084832f9fd1b58417db3de2