### PR TITLE
Improve plugin reload error handling and tests

### DIFF
--- a/algorithms/plugin_loader.py
+++ b/algorithms/plugin_loader.py
@@ -9,6 +9,11 @@ from typing import Dict
 from watchdog.events import FileModifiedEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 class AlgorithmPluginLoader(FileSystemEventHandler):
     """Discover, load and hot-reload algorithm plugins."""
@@ -42,7 +47,8 @@ class AlgorithmPluginLoader(FileSystemEventHandler):
             new_module = importlib.reload(module)
             self.modules[name] = new_module
             self._backups[name] = new_module
-        except Exception:
+        except (ImportError, ModuleNotFoundError, SyntaxError) as err:
+            logger.exception("Failed to reload plugin %s", name)
             # rollback to last good version
             self.modules[name] = self._backups[name]
 

--- a/tests/backend/algorithms/test_plugin_loader_reload.py
+++ b/tests/backend/algorithms/test_plugin_loader_reload.py
@@ -1,0 +1,43 @@
+import logging
+import textwrap
+from pathlib import Path
+
+from importlib.metadata import EntryPoint, EntryPoints
+from watchdog.events import FileModifiedEvent
+
+from algorithms import plugin_loader
+
+
+def _write_plugin(tmp_path: Path, body: str) -> Path:
+    file = tmp_path / "tmp_plugin_reload.py"
+    file.write_text(textwrap.dedent(body))
+    return file
+
+
+def test_reload_failure_rolls_back_and_logs(tmp_path, monkeypatch, caplog):
+    plugin_file = _write_plugin(
+        tmp_path,
+        """
+        def value():
+            return 1
+        """,
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="tmp_reload", value="tmp_plugin_reload", group="autogpt.algorithms")
+    monkeypatch.setattr(plugin_loader, "entry_points", lambda: EntryPoints([ep]))
+
+    loader = plugin_loader.AlgorithmPluginLoader()
+    loader.load_plugins()
+    assert loader.modules["tmp_reload"].value() == 1
+
+    plugin_file.write_text("def value():\n    return 2\n")
+    loader.on_modified(FileModifiedEvent(str(plugin_file)))
+    assert loader.modules["tmp_reload"].value() == 2
+
+    plugin_file.write_text(
+        "import nonexistent_module\n\n" "def value():\n    return 3\n"
+    )
+    with caplog.at_level(logging.ERROR):
+        loader.on_modified(FileModifiedEvent(str(plugin_file)))
+    assert loader.modules["tmp_reload"].value() == 2
+    assert "Failed to reload plugin tmp_reload" in caplog.text


### PR DESCRIPTION
## Summary
- handle plugin reload failures with specific ImportError, ModuleNotFoundError, and SyntaxError
- log plugin reload failures and roll back to last known good version
- add backend test verifying rollback and logging on reload failure

## Testing
- `PYTHONPATH=. pytest tests/backend/algorithms/test_plugin_loader_reload.py algorithms/tests/test_plugin_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6d187fdb0832f8c55d81789f1bb1b