### PR TITLE
refactor: introduce shared widgets for chat and tasks

### DIFF
--- a/frontend/lib/views/chat/agent_message_tile.dart
+++ b/frontend/lib/views/chat/agent_message_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../shared/message_tile.dart';
 import 'json_code_snippet_view.dart';
 
 class AgentMessageTile extends StatefulWidget {
@@ -15,22 +16,23 @@ class _AgentMessageTileState extends State<AgentMessageTile> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('Agent'),
-        Text(widget.message),
-        IconButton(
-          icon: Icon(expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down),
-          onPressed: () {
-            setState(() {
-              expanded = !expanded;
-            });
-          },
-        ),
-        if (expanded)
-          const JsonCodeSnippetView(jsonString: '{}'),
-      ],
+    return MessageTile(
+      title: 'Agent',
+      message: widget.message,
+      trailing: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          IconButton(
+            icon: Icon(expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down),
+            onPressed: () {
+              setState(() {
+                expanded = !expanded;
+              });
+            },
+          ),
+          if (expanded) const JsonCodeSnippetView(jsonString: '{}'),
+        ],
+      ),
     );
   }
 }

--- a/frontend/lib/views/chat/user_message_tile.dart
+++ b/frontend/lib/views/chat/user_message_tile.dart
@@ -1,17 +1,13 @@
 import 'package:flutter/material.dart';
 
+import '../shared/message_tile.dart';
+
 class UserMessageTile extends StatelessWidget {
   final String message;
   const UserMessageTile({super.key, required this.message});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('User'),
-        Text(message),
-      ],
-    );
+    return MessageTile(title: 'User', message: message);
   }
 }

--- a/frontend/lib/views/collaboration/collaboration_panel.dart
+++ b/frontend/lib/views/collaboration/collaboration_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../viewmodels/collaboration_viewmodel.dart';
+import '../shared/app_button.dart';
 
 class CollaborationPanel extends StatefulWidget {
   final CollaborationViewModel viewModel;
@@ -28,20 +29,20 @@ class _CollaborationPanelState extends State<CollaborationPanel> {
             TextField(controller: _controller),
             Row(
               children: [
-                ElevatedButton(
+                PrimaryButton(
+                  label: 'Inject',
                   onPressed: () {
                     vm.sendKnowledge(_controller.text);
                     _controller.clear();
                   },
-                  child: const Text('Inject'),
                 ),
                 const SizedBox(width: 8),
-                ElevatedButton(
+                PrimaryButton(
+                  label: 'Correct',
                   onPressed: () {
                     vm.sendCorrection(_controller.text);
                     _controller.clear();
                   },
-                  child: const Text('Correct'),
                 ),
               ],
             )

--- a/frontend/lib/views/shared/app_button.dart
+++ b/frontend/lib/views/shared/app_button.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// A reusable button with consistent styling across the app.
+class PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  const PrimaryButton({super.key, required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/frontend/lib/views/shared/message_tile.dart
+++ b/frontend/lib/views/shared/message_tile.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// A simple tile that shows a message with a title label.
+/// This is used by [UserMessageTile] and [AgentMessageTile]
+/// to ensure consistent styling.
+class MessageTile extends StatelessWidget {
+  final String title;
+  final String message;
+  final Widget? trailing;
+
+  const MessageTile({
+    super.key,
+    required this.title,
+    required this.message,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.labelMedium),
+        Text(
+          message,
+          softWrap: true,
+        ),
+        if (trailing != null) trailing!,
+      ],
+    );
+  }
+}

--- a/frontend/lib/views/task/new_task_button.dart
+++ b/frontend/lib/views/task/new_task_button.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
 
+import '../shared/app_button.dart';
+
 class NewTaskButton extends StatelessWidget {
   final VoidCallback onPressed;
   const NewTaskButton({super.key, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: onPressed,
-      child: const Text('New Task'),
-    );
+    return PrimaryButton(label: 'New Task', onPressed: onPressed);
   }
 }

--- a/frontend/test/agent_message_tile_test.dart
+++ b/frontend/test/agent_message_tile_test.dart
@@ -1,5 +1,6 @@
 import 'package:auto_gpt_flutter_client/views/chat/agent_message_tile.dart';
 import 'package:auto_gpt_flutter_client/views/chat/json_code_snippet_view.dart';
+import 'package:auto_gpt_flutter_client/views/shared/message_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -16,6 +17,8 @@ void main() {
     expect(find.text('Agent'), findsOneWidget);
     // Verify that the message text is displayed
     expect(find.text('Test Message'), findsOneWidget);
+    // Verify shared message tile is used
+    expect(find.byType(MessageTile), findsOneWidget);
   });
 
   // Test to verify that the expand/collapse functionality works

--- a/frontend/test/collaboration_panel_test.dart
+++ b/frontend/test/collaboration_panel_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:auto_gpt_flutter_client/viewmodels/collaboration_viewmodel.dart';
 import 'package:auto_gpt_flutter_client/views/collaboration/collaboration_panel.dart';
+import 'package:auto_gpt_flutter_client/views/shared/app_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -53,6 +54,8 @@ void main() {
     expect(find.text('Plan: P1'), findsOneWidget);
     expect(find.text('World Model: WM'), findsOneWidget);
     expect(find.text('Metrics: M'), findsOneWidget);
+    // Two primary buttons for Inject and Correct
+    expect(find.byType(PrimaryButton), findsNWidgets(2));
 
     await tester.enterText(find.byType(TextField), 'hello');
     await tester.tap(find.text('Inject'));

--- a/frontend/test/new_task_button_test.dart
+++ b/frontend/test/new_task_button_test.dart
@@ -1,3 +1,4 @@
+import 'package:auto_gpt_flutter_client/views/shared/app_button.dart';
 import 'package:auto_gpt_flutter_client/views/task/new_task_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,7 +19,7 @@ void main() {
     expect(find.text('New Task'), findsOneWidget);
 
     // Tap the button and verify if the onPressed callback is triggered.
-    await tester.tap(find.byType(ElevatedButton));
+    await tester.tap(find.byType(PrimaryButton));
     expect(wasPressed, true);
   });
 }

--- a/frontend/test/user_message_tile_test.dart
+++ b/frontend/test/user_message_tile_test.dart
@@ -1,4 +1,5 @@
 import 'package:auto_gpt_flutter_client/views/chat/user_message_tile.dart';
+import 'package:auto_gpt_flutter_client/views/shared/message_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,7 +13,7 @@ void main() {
           body: UserMessageTile(message: 'Hello, User!'),
         ),
       ));
-      expect(find.byType(UserMessageTile), findsOneWidget);
+      expect(find.byType(MessageTile), findsOneWidget);
     });
 
     // Test to check if the widget displays the correct user message


### PR DESCRIPTION
## Summary
- add shared MessageTile for consistent chat styling
- add reusable PrimaryButton and apply to collaboration and tasks
- update widget tests for new shared components

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d189b9fc832f8788bc4758865081