### PR TITLE
Integrate precision motor neuromorphic loop

### DIFF
--- a/docs/brain_simulation_status.md
+++ b/docs/brain_simulation_status.md
@@ -1,19 +1,18 @@
 # Brain Simulation Status
 
 ## Current Coverage
-- `modules/brain/whole_brain.py:1` describes the integration as a simplified wiring demo rather than a faithful whole brain simulation, signalling missing physiological breadth.
-- `modules/brain/whole_brain.py:150` exposes only cortical sensory, limbic, cognitive, and motor structures; deeper subcortical loops, cerebellar routing, and oscillation control objects exist in the package but are not orchestrated here.
-- `modules/brain/motor_cortex.py:43` keeps cerebellar and spiking backends optional, and the default `WholeBrainSimulation` never primes these hooks, so motor refinement and neuromorphic execution are dormant.
-- `tests/brain/test_whole_brain_neuromorphic.py:1` exercises a basic single-cycle happy path but skips multi-region coordination, plasticity, and oscillatory validation.
+- `modules/brain/whole_brain.py` now wires the cortical loop to the deeper precision motor hierarchy. The default simulation instantiates `PrecisionMotorSystem`, shares its basal ganglia gate with the cortical planner, and feeds neuromorphic modulators (novelty/emotion/oscillation/learning load) through a persistent backend before actions are scheduled.
+- `modules/brain/motor_cortex.py` accepts raw spike sequences or cached neuromorphic run results, converts them into structured `MotorCommand` objects, and layers both cortical and precision cerebellar fine tuning during execution.
+- `modules/brain/neuromorphic/spiking_network.py` exposes a bounded `reset_state` helper and caps event propagation to avoid runaway excitations while keeping energy and synchrony telemetry intact.
+- `modules/tests/test_whole_brain.py` covers the full closed loop—oscillation metrics, basal ganglia gating history, neuromorphic energy/synchrony output, and direct motor cortex handling of pre-computed spike results.
 
 ## Gaps Against "完整的大脑模拟+神经形态"
-- Missing closed-loop integration across cerebellum, basal ganglia, oscillatory dynamics, and neuromorphic motor control.
-- No persistent neuromorphic backend shared between perception and motor planning; perception spikes stop at modality snapshots.
-- Lacks explicit wiring to oscillation generators for synchrony, energy budgeting, or cognitive state gating.
-- Absent durability and evaluation flows to tune neuromorphic parameters against representative activity traces.
+- Neuromorphic runs still rely on capped event queues rather than adaptive convergence criteria; long-running dynamics remain approximated.
+- Precision motor learning is fed with aggregate energy snapshots—richer reward/error channels are still TODO.
+- The oscillation module contributes modulation metrics but is not yet bidirectionally coupled to neuromorphic weights or plasticity persistence.
 
 ## Implementation Starting Point
-1. Embed cerebellar fine-tuning and shared spiking backend into `WholeBrainSimulation` so motor plans run through neuromorphic pathways before dispatch.
-2. Drive oscillation synthesis (alpha/beta/gamma loops) off neuromorphic perception metrics and expose the resulting synchrony to downstream agents.
-3. Extend metrics and state exports to capture oscillation, cerebellar learning, and neuromorphic load, and cover them with regression tests.
-4. Stage follow-up work: multi-region memory consolidation, persistent plasticity checkpoints, and dataset-driven neuromorphic tuning.
+1. Investigate adaptive stopping criteria or lightweight recurrent weight decay so the bounded event loop can be relaxed without risking infinite cascades.
+2. Extend precision cerebellar learning to ingest actuator telemetry and environment feedback, closing the loop for error-driven tuning.
+3. Persist neuromorphic modulation history (energy, synchrony, strategy weights) for cross-cycle adaptation and dashboarding.
+4. Stage follow-up work: multi-region memory consolidation, plasticity checkpoints, and dataset-driven tuning of oscillation/neuromorphic parameters.

--- a/modules/brain/motor_cortex.py
+++ b/modules/brain/motor_cortex.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 """Motor cortex integrating cortical planning with actuators."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Sequence
+
+from .motor.precision import PrecisionMotorSystem
+from .neuromorphic.spiking_network import NeuromorphicRunResult
 
 from .motor.actions import (
     ActionMapping,
@@ -45,6 +48,7 @@ class MotorCortex:
     ethics: Any = None
     actuator: ActuatorInterface | None = None
     action_map: Dict[str, ActionMapping] = field(default_factory=dict)
+    precision_system: PrecisionMotorSystem | None = None
 
     def __post_init__(self) -> None:
         self.primary_motor = PrimaryMotor()
@@ -59,17 +63,43 @@ class MotorCortex:
         """Plan a movement and generate a structured `MotorPlan`."""
 
         parameters = dict(parameters or {})
+        neuromorphic_result = parameters.pop("neuromorphic_result", None)
+        spike_sequence = parameters.pop("spike_sequence", None)
+        modulators = {key: float(value) for key, value in dict(parameters.get("modulators", {})).items()}
+        weights = {key: float(value) for key, value in dict(parameters.get("weights", {})).items()}
+        if modulators:
+            parameters["modulators"] = modulators
+        if weights:
+            parameters["weights"] = weights
+
         first_stage = self.premotor_area.plan(intention)
         second_stage = self.supplementary_motor.organize(first_stage)
         stages = [first_stage, second_stage]
         final_stage = stages[-1]
         if self.basal_ganglia:
-            final_stage = self.basal_ganglia.modulate(final_stage)
+            final_stage = self._apply_basal_ganglia(final_stage)
             stages.append(final_stage)
+
+        if self.precision_system:
+            precision_plan = self.precision_system.plan_movement(intention)
+            stages.append(precision_plan)
+            final_stage = precision_plan
+            parameters.setdefault("precision_plan", precision_plan)
+            parameters.setdefault(
+                "precision_gating",
+                list(getattr(self.precision_system.basal_ganglia, "gating_history", [])),
+            )
 
         plan = MotorPlan(intention=intention, stages=stages, parameters=parameters)
         plan.metadata["plan_summary"] = final_stage
-        plan.command = self._map_plan_to_command(plan)
+        if modulators:
+            plan.metadata["modulators"] = modulators
+        plan.command = self._augment_command_with_neuromorphic(
+            plan,
+            neuromorphic_result=neuromorphic_result,
+            spike_sequence=spike_sequence,
+            weights=weights,
+        )
         return plan
 
     def register_action(self, intention: str, mapping: ActionMapping) -> None:
@@ -83,13 +113,17 @@ class MotorCortex:
     def execute_action(self, motor_instruction: Any):
         """Execute motor instructions via the actuator or primary motor."""
 
-        # Neuromorphic execution path remains untouched for compatibility.
-        if self.spiking_backend and isinstance(motor_instruction, (list, tuple)):
-            outputs = self.spiking_backend.run(motor_instruction)
-            self.spiking_backend.synapses.adapt(
-                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+        if isinstance(motor_instruction, NeuromorphicRunResult):
+            meta_intention = motor_instruction.metadata.get("intention", "neuromorphic")
+            motor_instruction = self.plan_movement(
+                str(meta_intention),
+                parameters={"neuromorphic_result": motor_instruction},
             )
-            return outputs
+        elif self._looks_like_spike_sequence(motor_instruction):
+            motor_instruction = self.plan_movement(
+                "spike_sequence",
+                parameters={"spike_sequence": motor_instruction},
+            )
 
         plan, command = self._ensure_command(motor_instruction)
 
@@ -99,6 +133,12 @@ class MotorCortex:
                 return report
 
         tuned_command, textual_hint = self._apply_cerebellum(command, plan)
+
+        if self.precision_system and plan:
+            precision_trace = plan.metadata.get("plan_summary", plan.describe())
+            precision_feedback = self.precision_system.execute_action(str(precision_trace))
+            tuned_command = self._merge_precision_feedback(tuned_command, precision_feedback)
+            textual_hint = precision_feedback
 
         if self.actuator:
             result = self.actuator.execute(tuned_command)
@@ -114,9 +154,15 @@ class MotorCortex:
     def train(self, feedback: MotorExecutionResult | str | Dict[str, Any]) -> str:
         """Update cerebellar model with rich feedback information."""
 
-        if not self.cerebellum:
+        if not self.cerebellum and not self.precision_system:
             return f"no cerebellum to learn from {feedback}"
-        return self.cerebellum.motor_learning(feedback)
+        if self.cerebellum and hasattr(self.cerebellum, "motor_learning"):
+            result = self.cerebellum.motor_learning(feedback)
+        elif self.precision_system and hasattr(self.precision_system.cerebellum, "learn"):
+            result = self.precision_system.cerebellum.learn(str(feedback))
+        else:
+            result = f"no cerebellum to learn from {feedback}"
+        return result
 
     # ------------------------------------------------------------------
     # Internal helpers -------------------------------------------------
@@ -141,6 +187,16 @@ class MotorCortex:
             return motor_instruction, command
         if isinstance(motor_instruction, MotorCommand):
             return None, motor_instruction
+        if isinstance(motor_instruction, NeuromorphicRunResult):
+            intention = motor_instruction.metadata.get("intention", "neuromorphic")
+            plan = MotorPlan(
+                intention=str(intention),
+                stages=["neuromorphic"],
+                parameters={"neuromorphic_result": motor_instruction},
+                metadata={"plan_summary": "neuromorphic"},
+            )
+            plan.command = self._augment_command_with_neuromorphic(plan, neuromorphic_result=motor_instruction)
+            return plan, plan.command
         if isinstance(motor_instruction, dict) and "operation" in motor_instruction:
             return None, MotorCommand(
                 tool=motor_instruction.get("tool", "motor"),
@@ -156,22 +212,116 @@ class MotorCortex:
     def _apply_cerebellum(
         self, command: MotorCommand, plan: MotorPlan | None
     ) -> Tuple[MotorCommand, Optional[str]]:
-        if not self.cerebellum:
-            return command, plan.describe() if plan else None
-        tuned_command = self.cerebellum.fine_tune(command)
-        textual_hint = None
-        if plan:
-            textual_hint = self.cerebellum.fine_tune(plan.describe())
-            if isinstance(textual_hint, MotorCommand):
-                textual_hint = textual_hint.metadata.get("plan_summary", plan.describe())
-        if isinstance(tuned_command, MotorCommand):
-            return tuned_command, textual_hint
-        return command, str(tuned_command)
+        tuned_command = command
+        textual_hint = plan.describe() if plan else None
+
+        if self.cerebellum and hasattr(self.cerebellum, "fine_tune"):
+            candidate = self.cerebellum.fine_tune(command)
+            if isinstance(candidate, MotorCommand):
+                tuned_command = candidate
+            if plan:
+                textual_hint = self.cerebellum.fine_tune(plan.describe())  # type: ignore[arg-type]
+                if isinstance(textual_hint, MotorCommand):
+                    textual_hint = textual_hint.metadata.get("plan_summary", plan.describe())
+
+        if self.precision_system and hasattr(self.precision_system.cerebellum, "fine_tune"):
+            precision_hint = self.precision_system.cerebellum.fine_tune(
+                textual_hint or tuned_command.metadata.get("plan_summary", tuned_command.operation)
+            )
+            textual_hint = str(precision_hint)
+            if isinstance(tuned_command, MotorCommand):
+                tuned_command = tuned_command.with_updates(
+                    metadata={"precision_hint": textual_hint}
+                )
+
+        return tuned_command, textual_hint
+
+    def _apply_basal_ganglia(self, stage: str) -> str:
+        if hasattr(self.basal_ganglia, "modulate"):
+            return self.basal_ganglia.modulate(stage)
+        if hasattr(self.basal_ganglia, "gate"):
+            return self.basal_ganglia.gate(stage)
+        return stage
+
+    def _augment_command_with_neuromorphic(
+        self,
+        plan: MotorPlan,
+        *,
+        neuromorphic_result: NeuromorphicRunResult | None = None,
+        spike_sequence: Any = None,
+        weights: Dict[str, float] | None = None,
+    ) -> MotorCommand:
+        base_command = self._map_plan_to_command(plan)
+        metadata_updates: Dict[str, Any] = {}
+        argument_updates: Dict[str, Any] = {}
+
+        if weights:
+            argument_updates["weights"] = weights
+        if neuromorphic_result:
+            metadata_updates["neuromorphic"] = neuromorphic_result.to_dict()
+            channels = neuromorphic_result.metadata.get("channels", [])
+            if channels:
+                metadata_updates.setdefault("channels", list(channels))
+            if neuromorphic_result.average_rate:
+                argument_updates["average_rate"] = list(neuromorphic_result.average_rate)
+            if neuromorphic_result.spike_counts:
+                argument_updates["spike_counts"] = list(neuromorphic_result.spike_counts)
+            argument_updates.setdefault("energy_used", neuromorphic_result.energy_used)
+            argument_updates.setdefault("idle_skipped", neuromorphic_result.idle_skipped)
+            if "modulators" in plan.metadata:
+                metadata_updates["modulators"] = plan.metadata["modulators"]
+        elif spike_sequence is not None:
+            metadata_updates["spike_sequence"] = self._summarise_spike_sequence(spike_sequence)
+            if "modulators" in plan.metadata:
+                metadata_updates["modulators"] = plan.metadata["modulators"]
+
+        if not argument_updates and not metadata_updates:
+            return base_command
+        return base_command.with_updates(arguments=argument_updates, metadata=metadata_updates)
+
+    def _summarise_spike_sequence(self, spike_sequence: Any) -> Dict[str, Any]:
+        if isinstance(spike_sequence, NeuromorphicRunResult):
+            return spike_sequence.to_dict()
+        if isinstance(spike_sequence, Sequence):
+            flattened = [float(v) for v in self._flatten_sequence(spike_sequence)]
+            return {
+                "length": len(flattened),
+                "sum": float(sum(flattened)),
+                "max": max(flattened) if flattened else 0.0,
+            }
+        return {"length": 0, "sum": 0.0, "max": 0.0}
+
+    def _flatten_sequence(self, sequence: Sequence[Any]) -> list[float]:
+        flattened: list[float] = []
+        for item in sequence:
+            if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+                flattened.extend(self._flatten_sequence(item))
+            else:
+                try:
+                    flattened.append(float(item))
+                except (TypeError, ValueError):
+                    continue
+        return flattened
 
     def _post_execute_feedback(self, result: MotorExecutionResult) -> None:
         self.feedback_history.append(result)
         if self.cerebellum:
             self.cerebellum.motor_learning(result)
+
+    def _looks_like_spike_sequence(self, value: Any) -> bool:
+        if isinstance(value, NeuromorphicRunResult):
+            return True
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, MotorPlan, MotorCommand)):
+            return any(isinstance(item, (int, float)) or self._looks_like_spike_sequence(item) for item in value)
+        return False
+
+    def _merge_precision_feedback(
+        self, command: MotorCommand, precision_feedback: Any
+    ) -> MotorCommand:
+        if isinstance(command, MotorCommand):
+            metadata = {"precision_feedback": str(precision_feedback)}
+            return command.with_updates(metadata=metadata)
+        return command
 
 
 __all__ = ["MotorCortex", "PrimaryMotor", "PreMotorArea", "SupplementaryMotor"]


### PR DESCRIPTION
## Summary
- wire PrecisionMotorSystem into the WholeBrainSimulation runtime, feed neuromorphic modulators back into motor planning, and expose safe perception encoding fallbacks
- teach MotorCortex to plan and execute using neuromorphic run results or raw spike sequences while blending cortical and precision fine-tuning
- bound spiking network event propagation, expand whole-brain regression coverage, and document the richer neuromorphic loop

## Testing
- pytest modules/tests/test_whole_brain.py

------
https://chatgpt.com/codex/tasks/task_e_68cffce6fa6c832f86562c4ba09e1c22